### PR TITLE
dyninst: ebpf and decoder support for interfaces

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -33,10 +33,11 @@ type Throttler struct {
 
 // Program represents stack machine program.
 type Program struct {
-	ID         uint32
-	Functions  []Function
-	Types      []ir.Type
-	Throttlers []Throttler
+	ID               uint32
+	Functions        []Function
+	Types            []ir.Type
+	Throttlers       []Throttler
+	GoModuledataInfo ir.GoModuledataInfo
 }
 
 type generator struct {
@@ -118,10 +119,11 @@ func GenerateProgram(program *ir.Program) (Program, error) {
 		types = append(types, t)
 	}
 	return Program{
-		ID:         uint32(program.ID),
-		Functions:  g.functions,
-		Types:      types,
-		Throttlers: throttlers,
+		ID:               uint32(program.ID),
+		Functions:        g.functions,
+		Types:            types,
+		Throttlers:       throttlers,
+		GoModuledataInfo: program.GoModuledataInfo,
 	}, nil
 }
 
@@ -348,8 +350,20 @@ func (g *generator) addTypeHandler(t ir.Type) (FunctionID, bool, error) {
 		}
 
 	case *ir.GoEmptyInterfaceType:
+		needed = true
+		offsetShift = 0
+		ops = []Op{
+			ProcessGoEmptyInterfaceOp{},
+			ReturnOp{},
+		}
+
 	case *ir.GoInterfaceType:
-		// TODO: support Go interfaces
+		needed = true
+		offsetShift = 0
+		ops = []Op{
+			ProcessGoInterfaceOp{},
+			ReturnOp{},
+		}
 
 	case *ir.GoMapType:
 		g.typeQueue = append(g.typeQueue, t.HeaderType)

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -13,7 +13,7 @@
 	Call 03 00 00 00 // ProcessType[*****int]
 	Return 
 // 0x24: ProcessEvent[Probe[main.PointerChainArg]@4a6006]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6006.expr[0]]
 	Return 
 // 0x33: ProcessType[**int]
@@ -26,7 +26,7 @@
 	Call 33 00 00 00 // ProcessType[**int]
 	Return 
 // 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6050]
-	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
 	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6050.expr[0]]
 	Return 
 // 0x63: ProcessType[map[string]main.bigStruct]
@@ -39,7 +39,7 @@
 	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x84: ProcessEvent[Probe[main.bigMapArg]@4a64f3]
-	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	PrepareEventRoot 53 00 00 00 09 00 00 00 
 	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a64f3.expr[0]]
 	Return 
 // 0x93: ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xa9: ProcessEvent[Probe[main.inlined]@4a63ca]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 54 00 00 00 09 00 00 00 
 	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a63ca.expr[0]]
 	Return 
 // 0xb8: ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc8: ProcessEvent[Probe[main.inlined]@4a5dce]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 54 00 00 00 09 00 00 00 
 	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5dce.expr[0]]
 	Return 
 // 0xd7: ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
@@ -66,7 +66,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xed: ProcessEvent[Probe[main.intArg]@4a60aa]
-	PrepareEventRoot 34 00 00 00 09 00 00 00 
+	PrepareEventRoot 4b 00 00 00 09 00 00 00 
 	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a60aa.expr[0]]
 	Return 
 // 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
@@ -75,11 +75,11 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x118: ProcessEvent[Probe[main.intArrayArg]@4a622a]
-	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	PrepareEventRoot 4e 00 00 00 19 00 00 00 
 	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a622a.expr[0]]
 	Return 
 // 0x127: ProcessType[string]
-	ProcessString 2a 00 00 00 
+	ProcessString 41 00 00 00 
 	Return 
 // 0x12d: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -93,11 +93,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a63a0]
-	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	PrepareEventRoot 51 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a63a0.expr[0]]
 	Return 
 // 0x16d: ProcessType[[]int]
-	ProcessSlice 2c 00 00 00 08 00 00 00 
+	ProcessSlice 43 00 00 00 08 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
 	ExprPrepare 
@@ -108,7 +108,7 @@
 	Call 6d 01 00 00 // ProcessType[[]int]
 	Return 
 // 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4a61aa]
-	PrepareEventRoot 36 00 00 00 19 00 00 00 
+	PrepareEventRoot 4d 00 00 00 19 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a61aa.expr[0]]
 	Return 
 // 0x1af: ProcessType[map[string]int]
@@ -121,7 +121,7 @@
 	Call af 01 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1d0: ProcessEvent[Probe[main.mapArg]@4a648a]
-	PrepareEventRoot 3b 00 00 00 09 00 00 00 
+	PrepareEventRoot 52 00 00 00 09 00 00 00 
 	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a648a.expr[0]]
 	Return 
 // 0x1df: ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
@@ -132,7 +132,7 @@
 	Call 27 01 00 00 // ProcessType[string]
 	Return 
 // 0x201: ProcessEvent[Probe[main.stringArg]@4a612a]
-	PrepareEventRoot 35 00 00 00 11 00 00 00 
+	PrepareEventRoot 4c 00 00 00 11 00 00 00 
 	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a612a.expr[0]]
 	Return 
 // 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
@@ -142,11 +142,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringArrayArg]@4a632a]
-	PrepareEventRoot 39 00 00 00 31 00 00 00 
+	PrepareEventRoot 50 00 00 00 31 00 00 00 
 	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a632a.expr[0]]
 	Return 
 // 0x240: ProcessType[[]string]
-	ProcessSlice 2e 00 00 00 10 00 00 00 
+	ProcessSlice 45 00 00 00 10 00 00 00 
 	Return 
 // 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	ExprPrepare 
@@ -157,68 +157,131 @@
 	Call 40 02 00 00 // ProcessType[[]string]
 	Return 
 // 0x273: ProcessEvent[Probe[main.stringSliceArg]@4a62aa]
-	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	PrepareEventRoot 4f 00 00 00 19 00 00 00 
 	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a62aa.expr[0]]
 	Return 
 // 0x282: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[*int]
+// 0x288: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x28e: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 33 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x294: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29c: ProcessType[hash<string,int>]
-	ProcessGoHmap 30 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x29a: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2aa: ProcessType[[]string.array]
+// 0x2a0: ProcessType[hash<string,int>]
+	ProcessGoHmap 47 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2ae: ProcessType[*runtime.mapextra]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x2b4: ProcessType[*[]*runtime.bmap]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x2ba: ProcessType[*runtime.bmap]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x2c0: ProcessType[runtime.mapextra]
+	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 02 00 00 // ProcessType[*runtime.bmap]
+	Return 
+// 0x2da: ProcessType[[]*runtime.bmap]
+	ProcessSlice 48 00 00 00 08 00 00 00 
+	Return 
+// 0x2e4: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 4a 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2f2: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x2f8: ProcessType[*bool]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x2fe: ProcessType[*uintptr]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x304: ProcessType[*int32]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x30a: ProcessType[*uint32]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x310: ProcessType[*float64]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x316: ProcessType[*int64]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x31c: ProcessType[*uint64]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x322: ProcessType[*error]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x328: ProcessType[*float32]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x32e: ProcessType[*uint]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x334: ProcessType[*uint16]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x33a: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2b6: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
-	Return 
-// 0x2bc: ProcessType[[]key<string>]
+// 0x346: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2cc: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x2d2: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call cc 02 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2e2: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 25 00 00 00 
-	Return 
-// 0x2e8: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call bc 02 00 00 // ProcessType[[]key<string>]
-	Call d2 02 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call e2 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
-	Return 
-// 0x2fd: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call e8 02 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x309: ProcessType[*bucket<string,int>]
+// 0x356: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x30f: ProcessType[bucket<string,int>]
+// 0x35c: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call bc 02 00 00 // ProcessType[[]key<string>]
+	Call 46 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 09 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 56 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x324: ProcessType[[]bucket<string,int>.array]
+// 0x371: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 0f 03 00 00 // ProcessType[bucket<string,int>]
+	Call 5c 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x37d: ProcessType[[]*runtime.bmap.array]
+	ProcessSliceDataPrep 
+	Call ba 02 00 00 // ProcessType[*runtime.bmap]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x389: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call f2 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x399: ProcessType[*bucket<string,main.bigStruct>]
+	ProcessPointer 25 00 00 00 
+	Return 
+// 0x39f: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 46 03 00 00 // ProcessType[[]key<string>]
+	Call 89 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 99 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x3b4: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 9f 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -239,63 +302,86 @@
 ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 8 Enqueue: 3
 ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 694
+ID: 4 Len: 8 Enqueue: 648
 ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 648
+ID: 6 Len: 8 Enqueue: 654
 ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 660
 ID: 9 Len: 1 Enqueue: 0
 ID: 10 Len: 24 Enqueue: 365
 ID: 11 Len: 24 Enqueue: 0
 ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 666
 ID: 14 Len: 48 Enqueue: 301
 ID: 15 Len: 8 Enqueue: 431
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 668
+ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 777
-ID: 21 Len: 208 Enqueue: 783
+ID: 20 Len: 8 Enqueue: 854
+ID: 21 Len: 208 Enqueue: 860
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 700
+ID: 23 Len: 128 Enqueue: 838
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 24 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 24 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 686
+ID: 27 Len: 24 Enqueue: 704
+ID: 28 Len: 8 Enqueue: 692
+ID: 29 Len: 24 Enqueue: 730
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 0
+ID: 31 Len: 8 Enqueue: 698
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 8 Enqueue: 99
 ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 654
-ID: 36 Len: 8 Enqueue: 738
-ID: 37 Len: 208 Enqueue: 744
-ID: 38 Len: 64 Enqueue: 722
-ID: 39 Len: 8 Enqueue: 716
+ID: 35 Len: 48 Enqueue: 740
+ID: 36 Len: 8 Enqueue: 921
+ID: 37 Len: 208 Enqueue: 927
+ID: 38 Len: 64 Enqueue: 905
+ID: 39 Len: 8 Enqueue: 754
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
-ID: 42 Len: 2048 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 2048 Enqueue: 0
+ID: 42 Len: 1 Enqueue: 0
+ID: 43 Len: 8 Enqueue: 760
+ID: 44 Len: 8 Enqueue: 766
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 2048 Enqueue: 682
+ID: 46 Len: 4 Enqueue: 0
 ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 2048 Enqueue: 804
-ID: 49 Len: 2048 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 2048 Enqueue: 765
-ID: 52 Len: 9 Enqueue: 0
-ID: 53 Len: 17 Enqueue: 0
-ID: 54 Len: 25 Enqueue: 0
-ID: 55 Len: 25 Enqueue: 0
-ID: 56 Len: 25 Enqueue: 0
-ID: 57 Len: 49 Enqueue: 0
-ID: 58 Len: 49 Enqueue: 0
-ID: 59 Len: 9 Enqueue: 0
-ID: 60 Len: 9 Enqueue: 0
-ID: 61 Len: 9 Enqueue: 0
-ID: 62 Len: 9 Enqueue: 0
-ID: 63 Len: 9 Enqueue: 0
+ID: 48 Len: 1 Enqueue: 0
+ID: 49 Len: 8 Enqueue: 0
+ID: 50 Len: 4 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 16 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 772
+ID: 55 Len: 8 Enqueue: 778
+ID: 56 Len: 8 Enqueue: 0
+ID: 57 Len: 16 Enqueue: 0
+ID: 58 Len: 8 Enqueue: 784
+ID: 59 Len: 8 Enqueue: 790
+ID: 60 Len: 8 Enqueue: 796
+ID: 61 Len: 8 Enqueue: 802
+ID: 62 Len: 8 Enqueue: 808
+ID: 63 Len: 8 Enqueue: 814
+ID: 64 Len: 8 Enqueue: 820
+ID: 65 Len: 2048 Enqueue: 0
+ID: 66 Len: 8 Enqueue: 0
+ID: 67 Len: 2048 Enqueue: 0
+ID: 68 Len: 8 Enqueue: 0
+ID: 69 Len: 2048 Enqueue: 826
+ID: 70 Len: 8 Enqueue: 0
+ID: 71 Len: 2048 Enqueue: 881
+ID: 72 Len: 2048 Enqueue: 893
+ID: 73 Len: 8 Enqueue: 0
+ID: 74 Len: 2048 Enqueue: 948
+ID: 75 Len: 9 Enqueue: 0
+ID: 76 Len: 17 Enqueue: 0
+ID: 77 Len: 25 Enqueue: 0
+ID: 78 Len: 25 Enqueue: 0
+ID: 79 Len: 25 Enqueue: 0
+ID: 80 Len: 49 Enqueue: 0
+ID: 81 Len: 49 Enqueue: 0
+ID: 82 Len: 9 Enqueue: 0
+ID: 83 Len: 9 Enqueue: 0
+ID: 84 Len: 9 Enqueue: 0
+ID: 85 Len: 9 Enqueue: 0
+ID: 86 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -209,79 +209,82 @@
 // 0x2fe: ProcessType[*uintptr]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x304: ProcessType[*int32]
+// 0x304: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x306: ProcessType[*int32]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x30a: ProcessType[*uint32]
+// 0x30c: ProcessType[*uint32]
 	ProcessPointer 13 00 00 00 
 	Return 
-// 0x310: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x316: ProcessType[*int64]
+// 0x318: ProcessType[*int64]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x31c: ProcessType[*uint64]
+// 0x31e: ProcessType[*uint64]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x322: ProcessType[*error]
+// 0x324: ProcessType[*error]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x328: ProcessType[*float32]
+// 0x32a: ProcessType[*float32]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x32e: ProcessType[*uint]
+// 0x330: ProcessType[*uint]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x334: ProcessType[*uint16]
+// 0x336: ProcessType[*uint16]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x33a: ProcessType[[]string.array]
+// 0x33c: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x346: ProcessType[[]key<string>]
+// 0x348: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x356: ProcessType[*bucket<string,int>]
+// 0x358: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x35c: ProcessType[bucket<string,int>]
+// 0x35e: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 03 00 00 // ProcessType[[]key<string>]
+	Call 48 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 56 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 58 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x371: ProcessType[[]bucket<string,int>.array]
+// 0x373: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 5c 03 00 00 // ProcessType[bucket<string,int>]
+	Call 5e 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37d: ProcessType[[]*runtime.bmap.array]
+// 0x37f: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
 	Call ba 02 00 00 // ProcessType[*runtime.bmap]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x389: ProcessType[[]val<main.bigStruct>]
+// 0x38b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
 	Call f2 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x399: ProcessType[*bucket<string,main.bigStruct>]
+// 0x39b: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 25 00 00 00 
 	Return 
-// 0x39f: ProcessType[bucket<string,main.bigStruct>]
+// 0x3a1: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 03 00 00 // ProcessType[[]key<string>]
-	Call 89 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 99 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 48 03 00 00 // ProcessType[[]key<string>]
+	Call 8b 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 9b 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3b4: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3b6: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 9f 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call a1 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -318,10 +321,10 @@ ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 854
-ID: 21 Len: 208 Enqueue: 860
+ID: 20 Len: 8 Enqueue: 856
+ID: 21 Len: 208 Enqueue: 862
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 838
+ID: 23 Len: 128 Enqueue: 840
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 686
@@ -334,9 +337,9 @@ ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 8 Enqueue: 99
 ID: 34 Len: 8 Enqueue: 0
 ID: 35 Len: 48 Enqueue: 740
-ID: 36 Len: 8 Enqueue: 921
-ID: 37 Len: 208 Enqueue: 927
-ID: 38 Len: 64 Enqueue: 905
+ID: 36 Len: 8 Enqueue: 923
+ID: 37 Len: 208 Enqueue: 929
+ID: 38 Len: 64 Enqueue: 907
 ID: 39 Len: 8 Enqueue: 754
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
@@ -350,29 +353,29 @@ ID: 48 Len: 1 Enqueue: 0
 ID: 49 Len: 8 Enqueue: 0
 ID: 50 Len: 4 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 0
+ID: 52 Len: 16 Enqueue: 772
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 772
-ID: 55 Len: 8 Enqueue: 778
+ID: 54 Len: 8 Enqueue: 774
+ID: 55 Len: 8 Enqueue: 780
 ID: 56 Len: 8 Enqueue: 0
 ID: 57 Len: 16 Enqueue: 0
-ID: 58 Len: 8 Enqueue: 784
-ID: 59 Len: 8 Enqueue: 790
-ID: 60 Len: 8 Enqueue: 796
-ID: 61 Len: 8 Enqueue: 802
-ID: 62 Len: 8 Enqueue: 808
-ID: 63 Len: 8 Enqueue: 814
-ID: 64 Len: 8 Enqueue: 820
+ID: 58 Len: 8 Enqueue: 786
+ID: 59 Len: 8 Enqueue: 792
+ID: 60 Len: 8 Enqueue: 798
+ID: 61 Len: 8 Enqueue: 804
+ID: 62 Len: 8 Enqueue: 810
+ID: 63 Len: 8 Enqueue: 816
+ID: 64 Len: 8 Enqueue: 822
 ID: 65 Len: 2048 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
-ID: 69 Len: 2048 Enqueue: 826
+ID: 69 Len: 2048 Enqueue: 828
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 881
-ID: 72 Len: 2048 Enqueue: 893
+ID: 71 Len: 2048 Enqueue: 883
+ID: 72 Len: 2048 Enqueue: 895
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 2048 Enqueue: 948
+ID: 74 Len: 2048 Enqueue: 950
 ID: 75 Len: 9 Enqueue: 0
 ID: 76 Len: 17 Enqueue: 0
 ID: 77 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -13,7 +13,7 @@
 	Call 03 00 00 00 // ProcessType[*****int]
 	Return 
 // 0x24: ProcessEvent[Probe[main.PointerChainArg]@4a8006]
-	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
 	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8006.expr[0]]
 	Return 
 // 0x33: ProcessType[**int]
@@ -26,7 +26,7 @@
 	Call 33 00 00 00 // ProcessType[**int]
 	Return 
 // 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8050]
-	PrepareEventRoot 40 00 00 00 09 00 00 00 
+	PrepareEventRoot 57 00 00 00 09 00 00 00 
 	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8050.expr[0]]
 	Return 
 // 0x63: ProcessType[map[string]main.bigStruct]
@@ -39,7 +39,7 @@
 	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x84: ProcessEvent[Probe[main.bigMapArg]@4a84f3]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 54 00 00 00 09 00 00 00 
 	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a84f3.expr[0]]
 	Return 
 // 0x93: ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xa9: ProcessEvent[Probe[main.inlined]@4a83ca]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a83ca.expr[0]]
 	Return 
 // 0xb8: ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc8: ProcessEvent[Probe[main.inlined]@4a7dce]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7dce.expr[0]]
 	Return 
 // 0xd7: ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
@@ -66,7 +66,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xed: ProcessEvent[Probe[main.intArg]@4a80aa]
-	PrepareEventRoot 35 00 00 00 09 00 00 00 
+	PrepareEventRoot 4c 00 00 00 09 00 00 00 
 	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0x4a80aa.expr[0]]
 	Return 
 // 0xfc: ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
@@ -75,11 +75,11 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x118: ProcessEvent[Probe[main.intArrayArg]@4a822a]
-	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	PrepareEventRoot 4f 00 00 00 19 00 00 00 
 	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a822a.expr[0]]
 	Return 
 // 0x127: ProcessType[string]
-	ProcessString 2b 00 00 00 
+	ProcessString 42 00 00 00 
 	Return 
 // 0x12d: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -93,11 +93,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a83a0]
-	PrepareEventRoot 3b 00 00 00 31 00 00 00 
+	PrepareEventRoot 52 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a83a0.expr[0]]
 	Return 
 // 0x16d: ProcessType[[]int]
-	ProcessSlice 2d 00 00 00 08 00 00 00 
+	ProcessSlice 44 00 00 00 08 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
 	ExprPrepare 
@@ -108,7 +108,7 @@
 	Call 6d 01 00 00 // ProcessType[[]int]
 	Return 
 // 0x1a0: ProcessEvent[Probe[main.intSliceArg]@4a81aa]
-	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	PrepareEventRoot 4e 00 00 00 19 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a81aa.expr[0]]
 	Return 
 // 0x1af: ProcessType[map[string]int]
@@ -121,7 +121,7 @@
 	Call af 01 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1d0: ProcessEvent[Probe[main.mapArg]@4a848a]
-	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	PrepareEventRoot 53 00 00 00 09 00 00 00 
 	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a848a.expr[0]]
 	Return 
 // 0x1df: ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
@@ -132,7 +132,7 @@
 	Call 27 01 00 00 // ProcessType[string]
 	Return 
 // 0x201: ProcessEvent[Probe[main.stringArg]@4a812a]
-	PrepareEventRoot 36 00 00 00 11 00 00 00 
+	PrepareEventRoot 4d 00 00 00 11 00 00 00 
 	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a812a.expr[0]]
 	Return 
 // 0x210: ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
@@ -142,11 +142,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringArrayArg]@4a832a]
-	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	PrepareEventRoot 51 00 00 00 31 00 00 00 
 	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a832a.expr[0]]
 	Return 
 // 0x240: ProcessType[[]string]
-	ProcessSlice 2f 00 00 00 10 00 00 00 
+	ProcessSlice 46 00 00 00 10 00 00 00 
 	Return 
 // 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	ExprPrepare 
@@ -157,96 +157,135 @@
 	Call 40 02 00 00 // ProcessType[[]string]
 	Return 
 // 0x273: ProcessEvent[Probe[main.stringSliceArg]@4a82aa]
-	PrepareEventRoot 39 00 00 00 19 00 00 00 
+	PrepareEventRoot 50 00 00 00 19 00 00 00 
 	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a82aa.expr[0]]
 	Return 
 // 0x282: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[*int]
+// 0x288: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x28e: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 33 00 00 00 25 00 00 00 10 18 
+// 0x294: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29a: ProcessType[map<string,int>]
-	ProcessGoSwissMap 31 00 00 00 1a 00 00 00 10 18 
+// 0x29a: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2a6: ProcessType[[]string.array]
+// 0x2a0: ProcessType[map<string,int>]
+	ProcessGoSwissMap 48 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
+	Call 27 01 00 00 // ProcessType[string]
+	Return 
+// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x2c2: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x2cd: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4a 00 00 00 25 00 00 00 10 18 
+	Return 
+// 0x2d9: ProcessType[*main.bigStruct]
+	ProcessPointer 29 00 00 00 
+	Return 
+// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 27 01 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call d9 02 00 00 // ProcessType[*main.bigStruct]
+	Return 
+// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x30a: ProcessType[*bool]
+	ProcessPointer 2c 00 00 00 
+	Return 
+// 0x310: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x316: ProcessType[*int32]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x31c: ProcessType[*uint32]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x322: ProcessType[*float64]
+	ProcessPointer 35 00 00 00 
+	Return 
+// 0x328: ProcessType[*int64]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x32e: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x334: ProcessType[*error]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x33a: ProcessType[*float32]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x340: ProcessType[*uint]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x346: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2b2: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
-	Return 
-// 0x2b8: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 22 00 00 00 
-	Return 
-// 0x2be: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call b8 02 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ca: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x2d0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call ca 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call d0 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call e0 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x2fb: ProcessType[*table<string,int>]
+// 0x358: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x301: ProcessType[[]*table<string,int>.array]
+// 0x35e: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call fb 02 00 00 // ProcessType[*table<string,int>]
+	Call 58 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x30d: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
+// 0x36a: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 22 00 00 00 
 	Return 
-// 0x313: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call 0d 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x323: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call 13 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x32e: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 34 00 00 00 c8 00 00 00 00 08 
-	Return 
-// 0x33a: ProcessType[table<string,main.bigStruct>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 2e 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
-	Return 
-// 0x345: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 32 00 00 00 c8 00 00 00 00 08 
-	Return 
-// 0x351: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 45 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x35c: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x370: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f0 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 6a 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x37c: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
+	Return 
+// 0x388: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7c 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x393: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
+	Return 
+// 0x39f: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 93 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x3aa: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x368: ProcessType[[]noalg.map.group[string]int.array]
+// 0x3b6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 23 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -267,64 +306,87 @@
 ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 8 Enqueue: 3
 ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 690
+ID: 4 Len: 8 Enqueue: 648
 ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 648
+ID: 6 Len: 8 Enqueue: 654
 ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 660
 ID: 9 Len: 1 Enqueue: 0
 ID: 10 Len: 24 Enqueue: 365
 ID: 11 Len: 24 Enqueue: 0
 ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 666
 ID: 14 Len: 48 Enqueue: 301
 ID: 15 Len: 8 Enqueue: 431
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 666
+ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 763
-ID: 22 Len: 32 Enqueue: 849
+ID: 21 Len: 8 Enqueue: 856
+ID: 22 Len: 32 Enqueue: 904
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 837
+ID: 24 Len: 16 Enqueue: 892
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 803
-ID: 27 Len: 192 Enqueue: 787
-ID: 28 Len: 24 Enqueue: 781
+ID: 26 Len: 200 Enqueue: 706
+ID: 27 Len: 192 Enqueue: 690
+ID: 28 Len: 24 Enqueue: 684
 ID: 29 Len: 8 Enqueue: 99
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 654
+ID: 31 Len: 48 Enqueue: 717
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 696
-ID: 34 Len: 32 Enqueue: 826
-ID: 35 Len: 16 Enqueue: 814
+ID: 33 Len: 8 Enqueue: 874
+ID: 34 Len: 32 Enqueue: 927
+ID: 35 Len: 16 Enqueue: 915
 ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 752
-ID: 38 Len: 192 Enqueue: 736
-ID: 39 Len: 24 Enqueue: 720
-ID: 40 Len: 8 Enqueue: 714
+ID: 37 Len: 200 Enqueue: 767
+ID: 38 Len: 192 Enqueue: 751
+ID: 39 Len: 24 Enqueue: 735
+ID: 40 Len: 8 Enqueue: 729
 ID: 41 Len: 184 Enqueue: 0
 ID: 42 Len: 128 Enqueue: 0
-ID: 43 Len: 2048 Enqueue: 0
-ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 2048 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 2048 Enqueue: 678
-ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8192 Enqueue: 769
-ID: 50 Len: 2048 Enqueue: 872
-ID: 51 Len: 8192 Enqueue: 702
-ID: 52 Len: 2048 Enqueue: 860
-ID: 53 Len: 9 Enqueue: 0
-ID: 54 Len: 17 Enqueue: 0
-ID: 55 Len: 25 Enqueue: 0
-ID: 56 Len: 25 Enqueue: 0
-ID: 57 Len: 25 Enqueue: 0
-ID: 58 Len: 49 Enqueue: 0
-ID: 59 Len: 49 Enqueue: 0
-ID: 60 Len: 9 Enqueue: 0
-ID: 61 Len: 9 Enqueue: 0
-ID: 62 Len: 9 Enqueue: 0
-ID: 63 Len: 9 Enqueue: 0
-ID: 64 Len: 9 Enqueue: 0
+ID: 43 Len: 4 Enqueue: 0
+ID: 44 Len: 1 Enqueue: 0
+ID: 45 Len: 4 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 778
+ID: 47 Len: 8 Enqueue: 0
+ID: 48 Len: 16 Enqueue: 0
+ID: 49 Len: 8 Enqueue: 0
+ID: 50 Len: 1 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 4 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 784
+ID: 55 Len: 8 Enqueue: 790
+ID: 56 Len: 8 Enqueue: 796
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 16 Enqueue: 0
+ID: 59 Len: 8 Enqueue: 802
+ID: 60 Len: 8 Enqueue: 808
+ID: 61 Len: 8 Enqueue: 814
+ID: 62 Len: 8 Enqueue: 820
+ID: 63 Len: 8 Enqueue: 826
+ID: 64 Len: 8 Enqueue: 832
+ID: 65 Len: 8 Enqueue: 838
+ID: 66 Len: 2048 Enqueue: 0
+ID: 67 Len: 8 Enqueue: 0
+ID: 68 Len: 2048 Enqueue: 0
+ID: 69 Len: 8 Enqueue: 0
+ID: 70 Len: 2048 Enqueue: 844
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 8192 Enqueue: 862
+ID: 73 Len: 2048 Enqueue: 938
+ID: 74 Len: 8192 Enqueue: 880
+ID: 75 Len: 2048 Enqueue: 950
+ID: 76 Len: 9 Enqueue: 0
+ID: 77 Len: 17 Enqueue: 0
+ID: 78 Len: 25 Enqueue: 0
+ID: 79 Len: 25 Enqueue: 0
+ID: 80 Len: 25 Enqueue: 0
+ID: 81 Len: 49 Enqueue: 0
+ID: 82 Len: 49 Enqueue: 0
+ID: 83 Len: 9 Enqueue: 0
+ID: 84 Len: 9 Enqueue: 0
+ID: 85 Len: 9 Enqueue: 0
+ID: 86 Len: 9 Enqueue: 0
+ID: 87 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -213,77 +213,80 @@
 // 0x30a: ProcessType[*bool]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x310: ProcessType[*uintptr]
+// 0x310: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x312: ProcessType[*uintptr]
 	ProcessPointer 13 00 00 00 
 	Return 
-// 0x316: ProcessType[*int32]
+// 0x318: ProcessType[*int32]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x31c: ProcessType[*uint32]
+// 0x31e: ProcessType[*uint32]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x322: ProcessType[*float64]
+// 0x324: ProcessType[*float64]
 	ProcessPointer 35 00 00 00 
 	Return 
-// 0x328: ProcessType[*int64]
+// 0x32a: ProcessType[*int64]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x32e: ProcessType[*uint64]
+// 0x330: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x334: ProcessType[*error]
+// 0x336: ProcessType[*error]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x33a: ProcessType[*float32]
+// 0x33c: ProcessType[*float32]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x340: ProcessType[*uint]
+// 0x342: ProcessType[*uint]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x346: ProcessType[*uint16]
+// 0x348: ProcessType[*uint16]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]string.array]
+// 0x34e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x358: ProcessType[*table<string,int>]
+// 0x35a: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x35e: ProcessType[[]*table<string,int>.array]
+// 0x360: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 58 03 00 00 // ProcessType[*table<string,int>]
+	Call 5a 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36a: ProcessType[*table<string,main.bigStruct>]
+// 0x36c: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 22 00 00 00 
 	Return 
-// 0x370: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 6a 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37c: ProcessType[groupReference<string,int>]
+// 0x37e: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 49 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x388: ProcessType[table<string,int>]
+// 0x38a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7c 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x393: ProcessType[groupReference<string,main.bigStruct>]
+// 0x395: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x39f: ProcessType[table<string,main.bigStruct>]
+// 0x3a1: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 93 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x3aa: ProcessType[[]noalg.map.group[string]int.array]
+// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
 	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3b6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
 	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
@@ -323,10 +326,10 @@ ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 856
-ID: 22 Len: 32 Enqueue: 904
+ID: 21 Len: 8 Enqueue: 858
+ID: 22 Len: 32 Enqueue: 906
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 892
+ID: 24 Len: 16 Enqueue: 894
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 200 Enqueue: 706
 ID: 27 Len: 192 Enqueue: 690
@@ -335,9 +338,9 @@ ID: 29 Len: 8 Enqueue: 99
 ID: 30 Len: 8 Enqueue: 0
 ID: 31 Len: 48 Enqueue: 717
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 874
-ID: 34 Len: 32 Enqueue: 927
-ID: 35 Len: 16 Enqueue: 915
+ID: 33 Len: 8 Enqueue: 876
+ID: 34 Len: 32 Enqueue: 929
+ID: 35 Len: 16 Enqueue: 917
 ID: 36 Len: 8 Enqueue: 0
 ID: 37 Len: 200 Enqueue: 767
 ID: 38 Len: 192 Enqueue: 751
@@ -350,34 +353,34 @@ ID: 44 Len: 1 Enqueue: 0
 ID: 45 Len: 4 Enqueue: 0
 ID: 46 Len: 8 Enqueue: 778
 ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 16 Enqueue: 0
+ID: 48 Len: 16 Enqueue: 784
 ID: 49 Len: 8 Enqueue: 0
 ID: 50 Len: 1 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
 ID: 52 Len: 4 Enqueue: 0
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 784
-ID: 55 Len: 8 Enqueue: 790
-ID: 56 Len: 8 Enqueue: 796
+ID: 54 Len: 8 Enqueue: 786
+ID: 55 Len: 8 Enqueue: 792
+ID: 56 Len: 8 Enqueue: 798
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 802
-ID: 60 Len: 8 Enqueue: 808
-ID: 61 Len: 8 Enqueue: 814
-ID: 62 Len: 8 Enqueue: 820
-ID: 63 Len: 8 Enqueue: 826
-ID: 64 Len: 8 Enqueue: 832
-ID: 65 Len: 8 Enqueue: 838
+ID: 59 Len: 8 Enqueue: 804
+ID: 60 Len: 8 Enqueue: 810
+ID: 61 Len: 8 Enqueue: 816
+ID: 62 Len: 8 Enqueue: 822
+ID: 63 Len: 8 Enqueue: 828
+ID: 64 Len: 8 Enqueue: 834
+ID: 65 Len: 8 Enqueue: 840
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 844
+ID: 70 Len: 2048 Enqueue: 846
 ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 8192 Enqueue: 862
-ID: 73 Len: 2048 Enqueue: 938
-ID: 74 Len: 8192 Enqueue: 880
-ID: 75 Len: 2048 Enqueue: 950
+ID: 72 Len: 8192 Enqueue: 864
+ID: 73 Len: 2048 Enqueue: 940
+ID: 74 Len: 8192 Enqueue: 882
+ID: 75 Len: 2048 Enqueue: 952
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -13,7 +13,7 @@
 	Call 03 00 00 00 // ProcessType[*****int]
 	Return 
 // 0x24: ProcessEvent[Probe[main.PointerChainArg]@b5338]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
 	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5338.expr[0]]
 	Return 
 // 0x33: ProcessType[**int]
@@ -26,7 +26,7 @@
 	Call 33 00 00 00 // ProcessType[**int]
 	Return 
 // 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b5370]
-	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	PrepareEventRoot 57 00 00 00 09 00 00 00 
 	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5370.expr[0]]
 	Return 
 // 0x63: ProcessType[map[string]main.bigStruct]
@@ -39,7 +39,7 @@
 	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x84: ProcessEvent[Probe[main.bigMapArg]@b5820]
-	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	PrepareEventRoot 54 00 00 00 09 00 00 00 
 	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5820.expr[0]]
 	Return 
 // 0x93: ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xa9: ProcessEvent[Probe[main.inlined]@b56ec]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb56ec.expr[0]]
 	Return 
 // 0xb8: ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc8: ProcessEvent[Probe[main.inlined]@b514c]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb514c.expr[0]]
 	Return 
 // 0xd7: ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
@@ -66,7 +66,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xed: ProcessEvent[Probe[main.intArg]@b53cc]
-	PrepareEventRoot 34 00 00 00 09 00 00 00 
+	PrepareEventRoot 4c 00 00 00 09 00 00 00 
 	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb53cc.expr[0]]
 	Return 
 // 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
@@ -75,11 +75,11 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x118: ProcessEvent[Probe[main.intArrayArg]@b554c]
-	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	PrepareEventRoot 4f 00 00 00 19 00 00 00 
 	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb554c.expr[0]]
 	Return 
 // 0x127: ProcessType[string]
-	ProcessString 2a 00 00 00 
+	ProcessString 42 00 00 00 
 	Return 
 // 0x12d: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -93,11 +93,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b56d0]
-	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	PrepareEventRoot 52 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb56d0.expr[0]]
 	Return 
 // 0x16d: ProcessType[[]int]
-	ProcessSlice 2c 00 00 00 08 00 00 00 
+	ProcessSlice 44 00 00 00 08 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
 	ExprPrepare 
@@ -108,7 +108,7 @@
 	Call 6d 01 00 00 // ProcessType[[]int]
 	Return 
 // 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b54bc]
-	PrepareEventRoot 36 00 00 00 19 00 00 00 
+	PrepareEventRoot 4e 00 00 00 19 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb54bc.expr[0]]
 	Return 
 // 0x1af: ProcessType[map[string]int]
@@ -121,7 +121,7 @@
 	Call af 01 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1d0: ProcessEvent[Probe[main.mapArg]@b57ac]
-	PrepareEventRoot 3b 00 00 00 09 00 00 00 
+	PrepareEventRoot 53 00 00 00 09 00 00 00 
 	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb57ac.expr[0]]
 	Return 
 // 0x1df: ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
@@ -132,7 +132,7 @@
 	Call 27 01 00 00 // ProcessType[string]
 	Return 
 // 0x201: ProcessEvent[Probe[main.stringArg]@b543c]
-	PrepareEventRoot 35 00 00 00 11 00 00 00 
+	PrepareEventRoot 4d 00 00 00 11 00 00 00 
 	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb543c.expr[0]]
 	Return 
 // 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
@@ -142,11 +142,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringArrayArg]@b565c]
-	PrepareEventRoot 39 00 00 00 31 00 00 00 
+	PrepareEventRoot 51 00 00 00 31 00 00 00 
 	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb565c.expr[0]]
 	Return 
 // 0x240: ProcessType[[]string]
-	ProcessSlice 2e 00 00 00 10 00 00 00 
+	ProcessSlice 46 00 00 00 10 00 00 00 
 	Return 
 // 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	ExprPrepare 
@@ -157,68 +157,131 @@
 	Call 40 02 00 00 // ProcessType[[]string]
 	Return 
 // 0x273: ProcessEvent[Probe[main.stringSliceArg]@b55cc]
-	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	PrepareEventRoot 50 00 00 00 19 00 00 00 
 	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb55cc.expr[0]]
 	Return 
 // 0x282: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[*int]
+// 0x288: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x28e: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 33 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x294: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29c: ProcessType[hash<string,int>]
-	ProcessGoHmap 30 00 00 00 d0 00 00 00 08 09 10 18 
+// 0x29a: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2aa: ProcessType[[]string.array]
+// 0x2a0: ProcessType[hash<string,int>]
+	ProcessGoHmap 48 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2ae: ProcessType[*runtime.mapextra]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x2b4: ProcessType[*[]*runtime.bmap]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x2ba: ProcessType[*runtime.bmap]
+	ProcessPointer 20 00 00 00 
+	Return 
+// 0x2c0: ProcessType[runtime.mapextra]
+	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call b4 02 00 00 // ProcessType[*[]*runtime.bmap]
+	IncrementOutputOffset 08 00 00 00 
+	Call ba 02 00 00 // ProcessType[*runtime.bmap]
+	Return 
+// 0x2da: ProcessType[[]*runtime.bmap]
+	ProcessSlice 49 00 00 00 08 00 00 00 
+	Return 
+// 0x2e4: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 4b 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x2f2: ProcessType[*main.bigStruct]
+	ProcessPointer 28 00 00 00 
+	Return 
+// 0x2f8: ProcessType[*bool]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x2fe: ProcessType[*uintptr]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x304: ProcessType[*int32]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x30a: ProcessType[*uint32]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x310: ProcessType[*float64]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x316: ProcessType[*int64]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x31c: ProcessType[*uint64]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x322: ProcessType[*error]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x328: ProcessType[*float32]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x32e: ProcessType[*uint]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x334: ProcessType[*uint16]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x33a: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2b6: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
-	Return 
-// 0x2bc: ProcessType[[]key<string>]
+// 0x346: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2cc: ProcessType[*main.bigStruct]
-	ProcessPointer 28 00 00 00 
-	Return 
-// 0x2d2: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call cc 02 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2e2: ProcessType[*bucket<string,main.bigStruct>]
-	ProcessPointer 25 00 00 00 
-	Return 
-// 0x2e8: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call bc 02 00 00 // ProcessType[[]key<string>]
-	Call d2 02 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call e2 02 00 00 // ProcessType[*bucket<string,main.bigStruct>]
-	Return 
-// 0x2fd: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call e8 02 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x309: ProcessType[*bucket<string,int>]
+// 0x356: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x30f: ProcessType[bucket<string,int>]
+// 0x35c: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call bc 02 00 00 // ProcessType[[]key<string>]
+	Call 46 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 09 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 56 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x324: ProcessType[[]bucket<string,int>.array]
+// 0x371: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 0f 03 00 00 // ProcessType[bucket<string,int>]
+	Call 5c 03 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x37d: ProcessType[[]*runtime.bmap.array]
+	ProcessSliceDataPrep 
+	Call ba 02 00 00 // ProcessType[*runtime.bmap]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x389: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call f2 02 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x399: ProcessType[*bucket<string,main.bigStruct>]
+	ProcessPointer 25 00 00 00 
+	Return 
+// 0x39f: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 46 03 00 00 // ProcessType[[]key<string>]
+	Call 89 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 99 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x3b4: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 9f 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -239,63 +302,87 @@
 ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 8 Enqueue: 3
 ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 694
+ID: 4 Len: 8 Enqueue: 648
 ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 648
+ID: 6 Len: 8 Enqueue: 654
 ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 660
 ID: 9 Len: 1 Enqueue: 0
 ID: 10 Len: 24 Enqueue: 365
 ID: 11 Len: 24 Enqueue: 0
 ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 666
 ID: 14 Len: 48 Enqueue: 301
 ID: 15 Len: 8 Enqueue: 431
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 668
+ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 777
-ID: 21 Len: 208 Enqueue: 783
+ID: 20 Len: 8 Enqueue: 854
+ID: 21 Len: 208 Enqueue: 860
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 700
+ID: 23 Len: 128 Enqueue: 838
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 24 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 24 Enqueue: 0
+ID: 26 Len: 8 Enqueue: 686
+ID: 27 Len: 24 Enqueue: 704
+ID: 28 Len: 8 Enqueue: 692
+ID: 29 Len: 24 Enqueue: 730
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 8 Enqueue: 0
+ID: 31 Len: 8 Enqueue: 698
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 8 Enqueue: 99
 ID: 34 Len: 8 Enqueue: 0
-ID: 35 Len: 48 Enqueue: 654
-ID: 36 Len: 8 Enqueue: 738
-ID: 37 Len: 208 Enqueue: 744
-ID: 38 Len: 64 Enqueue: 722
-ID: 39 Len: 8 Enqueue: 716
+ID: 35 Len: 48 Enqueue: 740
+ID: 36 Len: 8 Enqueue: 921
+ID: 37 Len: 208 Enqueue: 927
+ID: 38 Len: 64 Enqueue: 905
+ID: 39 Len: 8 Enqueue: 754
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
-ID: 42 Len: 2048 Enqueue: 0
-ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 2048 Enqueue: 0
+ID: 42 Len: 1 Enqueue: 0
+ID: 43 Len: 8 Enqueue: 760
+ID: 44 Len: 8 Enqueue: 766
 ID: 45 Len: 8 Enqueue: 0
-ID: 46 Len: 2048 Enqueue: 682
-ID: 47 Len: 8 Enqueue: 0
-ID: 48 Len: 2048 Enqueue: 804
-ID: 49 Len: 2048 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 0
-ID: 51 Len: 2048 Enqueue: 765
-ID: 52 Len: 9 Enqueue: 0
-ID: 53 Len: 17 Enqueue: 0
-ID: 54 Len: 25 Enqueue: 0
-ID: 55 Len: 25 Enqueue: 0
-ID: 56 Len: 25 Enqueue: 0
-ID: 57 Len: 49 Enqueue: 0
-ID: 58 Len: 49 Enqueue: 0
-ID: 59 Len: 9 Enqueue: 0
-ID: 60 Len: 9 Enqueue: 0
-ID: 61 Len: 9 Enqueue: 0
-ID: 62 Len: 9 Enqueue: 0
-ID: 63 Len: 9 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 0
+ID: 47 Len: 4 Enqueue: 0
+ID: 48 Len: 8 Enqueue: 0
+ID: 49 Len: 1 Enqueue: 0
+ID: 50 Len: 4 Enqueue: 0
+ID: 51 Len: 8 Enqueue: 0
+ID: 52 Len: 16 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 772
+ID: 55 Len: 8 Enqueue: 778
+ID: 56 Len: 2 Enqueue: 0
+ID: 57 Len: 8 Enqueue: 0
+ID: 58 Len: 16 Enqueue: 0
+ID: 59 Len: 8 Enqueue: 784
+ID: 60 Len: 8 Enqueue: 790
+ID: 61 Len: 8 Enqueue: 796
+ID: 62 Len: 8 Enqueue: 802
+ID: 63 Len: 8 Enqueue: 808
+ID: 64 Len: 8 Enqueue: 814
+ID: 65 Len: 8 Enqueue: 820
+ID: 66 Len: 2048 Enqueue: 0
+ID: 67 Len: 8 Enqueue: 0
+ID: 68 Len: 2048 Enqueue: 0
+ID: 69 Len: 8 Enqueue: 0
+ID: 70 Len: 2048 Enqueue: 826
+ID: 71 Len: 8 Enqueue: 0
+ID: 72 Len: 2048 Enqueue: 881
+ID: 73 Len: 2048 Enqueue: 893
+ID: 74 Len: 8 Enqueue: 0
+ID: 75 Len: 2048 Enqueue: 948
+ID: 76 Len: 9 Enqueue: 0
+ID: 77 Len: 17 Enqueue: 0
+ID: 78 Len: 25 Enqueue: 0
+ID: 79 Len: 25 Enqueue: 0
+ID: 80 Len: 25 Enqueue: 0
+ID: 81 Len: 49 Enqueue: 0
+ID: 82 Len: 49 Enqueue: 0
+ID: 83 Len: 9 Enqueue: 0
+ID: 84 Len: 9 Enqueue: 0
+ID: 85 Len: 9 Enqueue: 0
+ID: 86 Len: 9 Enqueue: 0
+ID: 87 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -209,79 +209,82 @@
 // 0x2fe: ProcessType[*uintptr]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x304: ProcessType[*int32]
+// 0x304: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x306: ProcessType[*int32]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x30a: ProcessType[*uint32]
+// 0x30c: ProcessType[*uint32]
 	ProcessPointer 13 00 00 00 
 	Return 
-// 0x310: ProcessType[*float64]
+// 0x312: ProcessType[*float64]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x316: ProcessType[*int64]
+// 0x318: ProcessType[*int64]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x31c: ProcessType[*uint64]
+// 0x31e: ProcessType[*uint64]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x322: ProcessType[*error]
+// 0x324: ProcessType[*error]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x328: ProcessType[*float32]
+// 0x32a: ProcessType[*float32]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x32e: ProcessType[*uint]
+// 0x330: ProcessType[*uint]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x334: ProcessType[*uint16]
+// 0x336: ProcessType[*uint16]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x33a: ProcessType[[]string.array]
+// 0x33c: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x346: ProcessType[[]key<string>]
+// 0x348: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x356: ProcessType[*bucket<string,int>]
+// 0x358: ProcessType[*bucket<string,int>]
 	ProcessPointer 15 00 00 00 
 	Return 
-// 0x35c: ProcessType[bucket<string,int>]
+// 0x35e: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 03 00 00 // ProcessType[[]key<string>]
+	Call 48 03 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 56 03 00 00 // ProcessType[*bucket<string,int>]
+	Call 58 03 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x371: ProcessType[[]bucket<string,int>.array]
+// 0x373: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 5c 03 00 00 // ProcessType[bucket<string,int>]
+	Call 5e 03 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37d: ProcessType[[]*runtime.bmap.array]
+// 0x37f: ProcessType[[]*runtime.bmap.array]
 	ProcessSliceDataPrep 
 	Call ba 02 00 00 // ProcessType[*runtime.bmap]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x389: ProcessType[[]val<main.bigStruct>]
+// 0x38b: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
 	Call f2 02 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x399: ProcessType[*bucket<string,main.bigStruct>]
+// 0x39b: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 25 00 00 00 
 	Return 
-// 0x39f: ProcessType[bucket<string,main.bigStruct>]
+// 0x3a1: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 03 00 00 // ProcessType[[]key<string>]
-	Call 89 03 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 99 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 48 03 00 00 // ProcessType[[]key<string>]
+	Call 8b 03 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 9b 03 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x3b4: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x3b6: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 9f 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call a1 03 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -318,10 +321,10 @@ ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 2 Enqueue: 0
 ID: 19 Len: 4 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 854
-ID: 21 Len: 208 Enqueue: 860
+ID: 20 Len: 8 Enqueue: 856
+ID: 21 Len: 208 Enqueue: 862
 ID: 22 Len: 8 Enqueue: 0
-ID: 23 Len: 128 Enqueue: 838
+ID: 23 Len: 128 Enqueue: 840
 ID: 24 Len: 64 Enqueue: 0
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 8 Enqueue: 686
@@ -334,9 +337,9 @@ ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 8 Enqueue: 99
 ID: 34 Len: 8 Enqueue: 0
 ID: 35 Len: 48 Enqueue: 740
-ID: 36 Len: 8 Enqueue: 921
-ID: 37 Len: 208 Enqueue: 927
-ID: 38 Len: 64 Enqueue: 905
+ID: 36 Len: 8 Enqueue: 923
+ID: 37 Len: 208 Enqueue: 929
+ID: 38 Len: 64 Enqueue: 907
 ID: 39 Len: 8 Enqueue: 754
 ID: 40 Len: 184 Enqueue: 0
 ID: 41 Len: 128 Enqueue: 0
@@ -350,30 +353,30 @@ ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 1 Enqueue: 0
 ID: 50 Len: 4 Enqueue: 0
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 16 Enqueue: 0
+ID: 52 Len: 16 Enqueue: 772
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 772
-ID: 55 Len: 8 Enqueue: 778
+ID: 54 Len: 8 Enqueue: 774
+ID: 55 Len: 8 Enqueue: 780
 ID: 56 Len: 2 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 784
-ID: 60 Len: 8 Enqueue: 790
-ID: 61 Len: 8 Enqueue: 796
-ID: 62 Len: 8 Enqueue: 802
-ID: 63 Len: 8 Enqueue: 808
-ID: 64 Len: 8 Enqueue: 814
-ID: 65 Len: 8 Enqueue: 820
+ID: 59 Len: 8 Enqueue: 786
+ID: 60 Len: 8 Enqueue: 792
+ID: 61 Len: 8 Enqueue: 798
+ID: 62 Len: 8 Enqueue: 804
+ID: 63 Len: 8 Enqueue: 810
+ID: 64 Len: 8 Enqueue: 816
+ID: 65 Len: 8 Enqueue: 822
 ID: 66 Len: 2048 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 2048 Enqueue: 0
 ID: 69 Len: 8 Enqueue: 0
-ID: 70 Len: 2048 Enqueue: 826
+ID: 70 Len: 2048 Enqueue: 828
 ID: 71 Len: 8 Enqueue: 0
-ID: 72 Len: 2048 Enqueue: 881
-ID: 73 Len: 2048 Enqueue: 893
+ID: 72 Len: 2048 Enqueue: 883
+ID: 73 Len: 2048 Enqueue: 895
 ID: 74 Len: 8 Enqueue: 0
-ID: 75 Len: 2048 Enqueue: 948
+ID: 75 Len: 2048 Enqueue: 950
 ID: 76 Len: 9 Enqueue: 0
 ID: 77 Len: 17 Enqueue: 0
 ID: 78 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -213,77 +213,80 @@
 // 0x30a: ProcessType[*bool]
 	ProcessPointer 2c 00 00 00 
 	Return 
-// 0x310: ProcessType[*uintptr]
+// 0x310: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x312: ProcessType[*uintptr]
 	ProcessPointer 13 00 00 00 
 	Return 
-// 0x316: ProcessType[*int32]
+// 0x318: ProcessType[*int32]
 	ProcessPointer 2f 00 00 00 
 	Return 
-// 0x31c: ProcessType[*uint32]
+// 0x31e: ProcessType[*uint32]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x322: ProcessType[*float64]
+// 0x324: ProcessType[*float64]
 	ProcessPointer 35 00 00 00 
 	Return 
-// 0x328: ProcessType[*int64]
+// 0x32a: ProcessType[*int64]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x32e: ProcessType[*uint64]
+// 0x330: ProcessType[*uint64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x334: ProcessType[*error]
+// 0x336: ProcessType[*error]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x33a: ProcessType[*float32]
+// 0x33c: ProcessType[*float32]
 	ProcessPointer 34 00 00 00 
 	Return 
-// 0x340: ProcessType[*uint]
+// 0x342: ProcessType[*uint]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x346: ProcessType[*uint16]
+// 0x348: ProcessType[*uint16]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x34c: ProcessType[[]string.array]
+// 0x34e: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x358: ProcessType[*table<string,int>]
+// 0x35a: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x35e: ProcessType[[]*table<string,int>.array]
+// 0x360: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 58 03 00 00 // ProcessType[*table<string,int>]
+	Call 5a 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x36a: ProcessType[*table<string,main.bigStruct>]
+// 0x36c: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 22 00 00 00 
 	Return 
-// 0x370: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x372: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 6a 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 6c 03 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x37c: ProcessType[groupReference<string,int>]
+// 0x37e: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x388: ProcessType[table<string,int>]
+// 0x38a: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7c 03 00 00 // ProcessType[groupReference<string,int>]
+	Call 7e 03 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x393: ProcessType[groupReference<string,main.bigStruct>]
+// 0x395: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x39f: ProcessType[table<string,main.bigStruct>]
+// 0x3a1: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 93 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 95 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x3aa: ProcessType[[]noalg.map.group[string]int.array]
+// 0x3ac: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
 	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x3b6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x3b8: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
 	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
@@ -323,10 +326,10 @@ ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 856
-ID: 22 Len: 32 Enqueue: 904
+ID: 21 Len: 8 Enqueue: 858
+ID: 22 Len: 32 Enqueue: 906
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 892
+ID: 24 Len: 16 Enqueue: 894
 ID: 25 Len: 8 Enqueue: 0
 ID: 26 Len: 200 Enqueue: 706
 ID: 27 Len: 192 Enqueue: 690
@@ -335,9 +338,9 @@ ID: 29 Len: 8 Enqueue: 99
 ID: 30 Len: 8 Enqueue: 0
 ID: 31 Len: 48 Enqueue: 717
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 874
-ID: 34 Len: 32 Enqueue: 927
-ID: 35 Len: 16 Enqueue: 915
+ID: 33 Len: 8 Enqueue: 876
+ID: 34 Len: 32 Enqueue: 929
+ID: 35 Len: 16 Enqueue: 917
 ID: 36 Len: 8 Enqueue: 0
 ID: 37 Len: 200 Enqueue: 767
 ID: 38 Len: 192 Enqueue: 751
@@ -351,34 +354,34 @@ ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 8 Enqueue: 778
 ID: 47 Len: 4 Enqueue: 0
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 16 Enqueue: 0
+ID: 49 Len: 16 Enqueue: 784
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 1 Enqueue: 0
 ID: 52 Len: 4 Enqueue: 0
 ID: 53 Len: 8 Enqueue: 0
-ID: 54 Len: 8 Enqueue: 784
-ID: 55 Len: 8 Enqueue: 790
-ID: 56 Len: 8 Enqueue: 796
+ID: 54 Len: 8 Enqueue: 786
+ID: 55 Len: 8 Enqueue: 792
+ID: 56 Len: 8 Enqueue: 798
 ID: 57 Len: 2 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 16 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 802
-ID: 61 Len: 8 Enqueue: 808
-ID: 62 Len: 8 Enqueue: 814
-ID: 63 Len: 8 Enqueue: 820
-ID: 64 Len: 8 Enqueue: 826
-ID: 65 Len: 8 Enqueue: 832
-ID: 66 Len: 8 Enqueue: 838
+ID: 60 Len: 8 Enqueue: 804
+ID: 61 Len: 8 Enqueue: 810
+ID: 62 Len: 8 Enqueue: 816
+ID: 63 Len: 8 Enqueue: 822
+ID: 64 Len: 8 Enqueue: 828
+ID: 65 Len: 8 Enqueue: 834
+ID: 66 Len: 8 Enqueue: 840
 ID: 67 Len: 2048 Enqueue: 0
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 2048 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 2048 Enqueue: 844
+ID: 71 Len: 2048 Enqueue: 846
 ID: 72 Len: 8 Enqueue: 0
-ID: 73 Len: 8192 Enqueue: 862
-ID: 74 Len: 2048 Enqueue: 938
-ID: 75 Len: 8192 Enqueue: 880
-ID: 76 Len: 2048 Enqueue: 950
+ID: 73 Len: 8192 Enqueue: 864
+ID: 74 Len: 2048 Enqueue: 940
+ID: 75 Len: 8192 Enqueue: 882
+ID: 76 Len: 2048 Enqueue: 952
 ID: 77 Len: 9 Enqueue: 0
 ID: 78 Len: 17 Enqueue: 0
 ID: 79 Len: 25 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -13,7 +13,7 @@
 	Call 03 00 00 00 // ProcessType[*****int]
 	Return 
 // 0x24: ProcessEvent[Probe[main.PointerChainArg]@b51cc]
-	PrepareEventRoot 3f 00 00 00 09 00 00 00 
+	PrepareEventRoot 57 00 00 00 09 00 00 00 
 	Call 09 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb51cc.expr[0]]
 	Return 
 // 0x33: ProcessType[**int]
@@ -26,7 +26,7 @@
 	Call 33 00 00 00 // ProcessType[**int]
 	Return 
 // 0x54: ProcessEvent[Probe[main.PointerSmallChainArg]@b5204]
-	PrepareEventRoot 40 00 00 00 09 00 00 00 
+	PrepareEventRoot 58 00 00 00 09 00 00 00 
 	Call 39 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5204.expr[0]]
 	Return 
 // 0x63: ProcessType[map[string]main.bigStruct]
@@ -39,7 +39,7 @@
 	Call 63 00 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x84: ProcessEvent[Probe[main.bigMapArg]@b5690]
-	PrepareEventRoot 3d 00 00 00 09 00 00 00 
+	PrepareEventRoot 55 00 00 00 09 00 00 00 
 	Call 69 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5690.expr[0]]
 	Return 
 // 0x93: ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
@@ -48,7 +48,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xa9: ProcessEvent[Probe[main.inlined]@b555c]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
 	Call 93 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb555c.expr[0]]
 	Return 
 // 0xb8: ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
@@ -57,7 +57,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xc8: ProcessEvent[Probe[main.inlined]@b4fec]
-	PrepareEventRoot 3e 00 00 00 09 00 00 00 
+	PrepareEventRoot 56 00 00 00 09 00 00 00 
 	Call b8 00 00 00 // ProcessExpression[Probe[main.inlined]@0xb4fec.expr[0]]
 	Return 
 // 0xd7: ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
@@ -66,7 +66,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0xed: ProcessEvent[Probe[main.intArg]@b525c]
-	PrepareEventRoot 35 00 00 00 09 00 00 00 
+	PrepareEventRoot 4d 00 00 00 09 00 00 00 
 	Call d7 00 00 00 // ProcessExpression[Probe[main.intArg]@0xb525c.expr[0]]
 	Return 
 // 0xfc: ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
@@ -75,11 +75,11 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x118: ProcessEvent[Probe[main.intArrayArg]@b53cc]
-	PrepareEventRoot 38 00 00 00 19 00 00 00 
+	PrepareEventRoot 50 00 00 00 19 00 00 00 
 	Call fc 00 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb53cc.expr[0]]
 	Return 
 // 0x127: ProcessType[string]
-	ProcessString 2b 00 00 00 
+	ProcessString 43 00 00 00 
 	Return 
 // 0x12d: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
@@ -93,11 +93,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x15e: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5540]
-	PrepareEventRoot 3b 00 00 00 31 00 00 00 
+	PrepareEventRoot 53 00 00 00 31 00 00 00 
 	Call 3d 01 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5540.expr[0]]
 	Return 
 // 0x16d: ProcessType[[]int]
-	ProcessSlice 2d 00 00 00 08 00 00 00 
+	ProcessSlice 45 00 00 00 08 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
 	ExprPrepare 
@@ -108,7 +108,7 @@
 	Call 6d 01 00 00 // ProcessType[[]int]
 	Return 
 // 0x1a0: ProcessEvent[Probe[main.intSliceArg]@b534c]
-	PrepareEventRoot 37 00 00 00 19 00 00 00 
+	PrepareEventRoot 4f 00 00 00 19 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb534c.expr[0]]
 	Return 
 // 0x1af: ProcessType[map[string]int]
@@ -121,7 +121,7 @@
 	Call af 01 00 00 // ProcessType[map[string]int]
 	Return 
 // 0x1d0: ProcessEvent[Probe[main.mapArg]@b561c]
-	PrepareEventRoot 3c 00 00 00 09 00 00 00 
+	PrepareEventRoot 54 00 00 00 09 00 00 00 
 	Call b5 01 00 00 // ProcessExpression[Probe[main.mapArg]@0xb561c.expr[0]]
 	Return 
 // 0x1df: ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
@@ -132,7 +132,7 @@
 	Call 27 01 00 00 // ProcessType[string]
 	Return 
 // 0x201: ProcessEvent[Probe[main.stringArg]@b52cc]
-	PrepareEventRoot 36 00 00 00 11 00 00 00 
+	PrepareEventRoot 4e 00 00 00 11 00 00 00 
 	Call df 01 00 00 // ProcessExpression[Probe[main.stringArg]@0xb52cc.expr[0]]
 	Return 
 // 0x210: ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
@@ -142,11 +142,11 @@
 	Call 2d 01 00 00 // ProcessType[[3]string]
 	Return 
 // 0x231: ProcessEvent[Probe[main.stringArrayArg]@b54cc]
-	PrepareEventRoot 3a 00 00 00 31 00 00 00 
+	PrepareEventRoot 52 00 00 00 31 00 00 00 
 	Call 10 02 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb54cc.expr[0]]
 	Return 
 // 0x240: ProcessType[[]string]
-	ProcessSlice 2f 00 00 00 10 00 00 00 
+	ProcessSlice 47 00 00 00 10 00 00 00 
 	Return 
 // 0x24a: ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	ExprPrepare 
@@ -157,96 +157,135 @@
 	Call 40 02 00 00 // ProcessType[[]string]
 	Return 
 // 0x273: ProcessEvent[Probe[main.stringSliceArg]@b544c]
-	PrepareEventRoot 39 00 00 00 19 00 00 00 
+	PrepareEventRoot 51 00 00 00 19 00 00 00 
 	Call 4a 02 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb544c.expr[0]]
 	Return 
 // 0x282: ProcessType[****int]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x288: ProcessType[*int]
+// 0x288: ProcessType[***int]
+	ProcessPointer 05 00 00 00 
+	Return 
+// 0x28e: ProcessType[*int]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x28e: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 33 00 00 00 25 00 00 00 10 18 
+// 0x294: ProcessType[*uint8]
+	ProcessPointer 09 00 00 00 
 	Return 
-// 0x29a: ProcessType[map<string,int>]
-	ProcessGoSwissMap 31 00 00 00 1a 00 00 00 10 18 
+// 0x29a: ProcessType[*string]
+	ProcessPointer 07 00 00 00 
 	Return 
-// 0x2a6: ProcessType[[]string.array]
+// 0x2a0: ProcessType[map<string,int>]
+	ProcessGoSwissMap 49 00 00 00 1a 00 00 00 10 18 
+	Return 
+// 0x2ac: ProcessType[noalg.struct { key string; elem int }]
+	Call 27 01 00 00 // ProcessType[string]
+	Return 
+// 0x2b2: ProcessType[noalg.[8]struct { key string; elem int }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call ac 02 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	ProcessSliceDataRepeat 18 00 00 00 
+	Return 
+// 0x2c2: ProcessType[noalg.map.group[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call b2 02 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Return 
+// 0x2cd: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 4b 00 00 00 25 00 00 00 10 18 
+	Return 
+// 0x2d9: ProcessType[*main.bigStruct]
+	ProcessPointer 29 00 00 00 
+	Return 
+// 0x2df: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 27 01 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call d9 02 00 00 // ProcessType[*main.bigStruct]
+	Return 
+// 0x2ef: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	ProcessArrayDataPrep c0 00 00 00 
+	Call df 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x2ff: ProcessType[noalg.map.group[string]main.bigStruct]
+	IncrementOutputOffset 08 00 00 00 
+	Call ef 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Return 
+// 0x30a: ProcessType[*bool]
+	ProcessPointer 2c 00 00 00 
+	Return 
+// 0x310: ProcessType[*uintptr]
+	ProcessPointer 13 00 00 00 
+	Return 
+// 0x316: ProcessType[*int32]
+	ProcessPointer 2f 00 00 00 
+	Return 
+// 0x31c: ProcessType[*uint32]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x322: ProcessType[*float64]
+	ProcessPointer 35 00 00 00 
+	Return 
+// 0x328: ProcessType[*int64]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x32e: ProcessType[*uint64]
+	ProcessPointer 12 00 00 00 
+	Return 
+// 0x334: ProcessType[*error]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x33a: ProcessType[*float32]
+	ProcessPointer 34 00 00 00 
+	Return 
+// 0x340: ProcessType[*uint]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x346: ProcessType[*uint16]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x34c: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
 	Call 27 01 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x2b2: ProcessType[***int]
-	ProcessPointer 05 00 00 00 
-	Return 
-// 0x2b8: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 22 00 00 00 
-	Return 
-// 0x2be: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call b8 02 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2ca: ProcessType[*main.bigStruct]
-	ProcessPointer 29 00 00 00 
-	Return 
-// 0x2d0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 27 01 00 00 // ProcessType[string]
-	IncrementOutputOffset 10 00 00 00 
-	Call ca 02 00 00 // ProcessType[*main.bigStruct]
-	Return 
-// 0x2e0: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call d0 02 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x2f0: ProcessType[noalg.map.group[string]main.bigStruct]
-	IncrementOutputOffset 08 00 00 00 
-	Call e0 02 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
-	Return 
-// 0x2fb: ProcessType[*table<string,int>]
+// 0x358: ProcessType[*table<string,int>]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x301: ProcessType[[]*table<string,int>.array]
+// 0x35e: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call fb 02 00 00 // ProcessType[*table<string,int>]
+	Call 58 03 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x30d: ProcessType[noalg.struct { key string; elem int }]
-	Call 27 01 00 00 // ProcessType[string]
+// 0x36a: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 22 00 00 00 
 	Return 
-// 0x313: ProcessType[noalg.[8]struct { key string; elem int }]
-	ProcessArrayDataPrep c0 00 00 00 
-	Call 0d 03 00 00 // ProcessType[noalg.struct { key string; elem int }]
-	ProcessSliceDataRepeat 18 00 00 00 
-	Return 
-// 0x323: ProcessType[noalg.map.group[string]int]
-	IncrementOutputOffset 08 00 00 00 
-	Call 13 03 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
-	Return 
-// 0x32e: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 34 00 00 00 c8 00 00 00 00 08 
-	Return 
-// 0x33a: ProcessType[table<string,main.bigStruct>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 2e 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
-	Return 
-// 0x345: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 32 00 00 00 c8 00 00 00 00 08 
-	Return 
-// 0x351: ProcessType[table<string,int>]
-	IncrementOutputOffset 10 00 00 00 
-	Call 45 03 00 00 // ProcessType[groupReference<string,int>]
-	Return 
-// 0x35c: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x370: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f0 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 6a 03 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x37c: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 4a 00 00 00 c8 00 00 00 00 08 
+	Return 
+// 0x388: ProcessType[table<string,int>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 7c 03 00 00 // ProcessType[groupReference<string,int>]
+	Return 
+// 0x393: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups 4c 00 00 00 c8 00 00 00 00 08 
+	Return 
+// 0x39f: ProcessType[table<string,main.bigStruct>]
+	IncrementOutputOffset 10 00 00 00 
+	Call 93 03 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Return 
+// 0x3aa: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call c2 02 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x368: ProcessType[[]noalg.map.group[string]int.array]
+// 0x3b6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 23 03 00 00 // ProcessType[noalg.map.group[string]int]
+	Call ff 02 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -267,64 +306,88 @@
 ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 8 Enqueue: 3
 ID: 3 Len: 8 Enqueue: 642
-ID: 4 Len: 8 Enqueue: 690
+ID: 4 Len: 8 Enqueue: 648
 ID: 5 Len: 8 Enqueue: 51
-ID: 6 Len: 8 Enqueue: 648
+ID: 6 Len: 8 Enqueue: 654
 ID: 7 Len: 16 Enqueue: 295
-ID: 8 Len: 8 Enqueue: 0
+ID: 8 Len: 8 Enqueue: 660
 ID: 9 Len: 1 Enqueue: 0
 ID: 10 Len: 24 Enqueue: 365
 ID: 11 Len: 24 Enqueue: 0
 ID: 12 Len: 24 Enqueue: 576
-ID: 13 Len: 8 Enqueue: 0
+ID: 13 Len: 8 Enqueue: 666
 ID: 14 Len: 48 Enqueue: 301
 ID: 15 Len: 8 Enqueue: 431
 ID: 16 Len: 8 Enqueue: 0
-ID: 17 Len: 48 Enqueue: 666
+ID: 17 Len: 48 Enqueue: 672
 ID: 18 Len: 8 Enqueue: 0
 ID: 19 Len: 8 Enqueue: 0
 ID: 20 Len: 8 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 763
-ID: 22 Len: 32 Enqueue: 849
+ID: 21 Len: 8 Enqueue: 856
+ID: 22 Len: 32 Enqueue: 904
 ID: 23 Len: 2 Enqueue: 0
-ID: 24 Len: 16 Enqueue: 837
+ID: 24 Len: 16 Enqueue: 892
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 200 Enqueue: 803
-ID: 27 Len: 192 Enqueue: 787
-ID: 28 Len: 24 Enqueue: 781
+ID: 26 Len: 200 Enqueue: 706
+ID: 27 Len: 192 Enqueue: 690
+ID: 28 Len: 24 Enqueue: 684
 ID: 29 Len: 8 Enqueue: 99
 ID: 30 Len: 8 Enqueue: 0
-ID: 31 Len: 48 Enqueue: 654
+ID: 31 Len: 48 Enqueue: 717
 ID: 32 Len: 8 Enqueue: 0
-ID: 33 Len: 8 Enqueue: 696
-ID: 34 Len: 32 Enqueue: 826
-ID: 35 Len: 16 Enqueue: 814
+ID: 33 Len: 8 Enqueue: 874
+ID: 34 Len: 32 Enqueue: 927
+ID: 35 Len: 16 Enqueue: 915
 ID: 36 Len: 8 Enqueue: 0
-ID: 37 Len: 200 Enqueue: 752
-ID: 38 Len: 192 Enqueue: 736
-ID: 39 Len: 24 Enqueue: 720
-ID: 40 Len: 8 Enqueue: 714
+ID: 37 Len: 200 Enqueue: 767
+ID: 38 Len: 192 Enqueue: 751
+ID: 39 Len: 24 Enqueue: 735
+ID: 40 Len: 8 Enqueue: 729
 ID: 41 Len: 184 Enqueue: 0
 ID: 42 Len: 128 Enqueue: 0
-ID: 43 Len: 2048 Enqueue: 0
-ID: 44 Len: 8 Enqueue: 0
-ID: 45 Len: 2048 Enqueue: 0
-ID: 46 Len: 8 Enqueue: 0
-ID: 47 Len: 2048 Enqueue: 678
+ID: 43 Len: 4 Enqueue: 0
+ID: 44 Len: 1 Enqueue: 0
+ID: 45 Len: 8 Enqueue: 0
+ID: 46 Len: 8 Enqueue: 778
+ID: 47 Len: 4 Enqueue: 0
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8192 Enqueue: 769
-ID: 50 Len: 2048 Enqueue: 872
-ID: 51 Len: 8192 Enqueue: 702
-ID: 52 Len: 2048 Enqueue: 860
-ID: 53 Len: 9 Enqueue: 0
-ID: 54 Len: 17 Enqueue: 0
-ID: 55 Len: 25 Enqueue: 0
-ID: 56 Len: 25 Enqueue: 0
-ID: 57 Len: 25 Enqueue: 0
-ID: 58 Len: 49 Enqueue: 0
-ID: 59 Len: 49 Enqueue: 0
-ID: 60 Len: 9 Enqueue: 0
-ID: 61 Len: 9 Enqueue: 0
-ID: 62 Len: 9 Enqueue: 0
-ID: 63 Len: 9 Enqueue: 0
-ID: 64 Len: 9 Enqueue: 0
+ID: 49 Len: 16 Enqueue: 0
+ID: 50 Len: 8 Enqueue: 0
+ID: 51 Len: 1 Enqueue: 0
+ID: 52 Len: 4 Enqueue: 0
+ID: 53 Len: 8 Enqueue: 0
+ID: 54 Len: 8 Enqueue: 784
+ID: 55 Len: 8 Enqueue: 790
+ID: 56 Len: 8 Enqueue: 796
+ID: 57 Len: 2 Enqueue: 0
+ID: 58 Len: 8 Enqueue: 0
+ID: 59 Len: 16 Enqueue: 0
+ID: 60 Len: 8 Enqueue: 802
+ID: 61 Len: 8 Enqueue: 808
+ID: 62 Len: 8 Enqueue: 814
+ID: 63 Len: 8 Enqueue: 820
+ID: 64 Len: 8 Enqueue: 826
+ID: 65 Len: 8 Enqueue: 832
+ID: 66 Len: 8 Enqueue: 838
+ID: 67 Len: 2048 Enqueue: 0
+ID: 68 Len: 8 Enqueue: 0
+ID: 69 Len: 2048 Enqueue: 0
+ID: 70 Len: 8 Enqueue: 0
+ID: 71 Len: 2048 Enqueue: 844
+ID: 72 Len: 8 Enqueue: 0
+ID: 73 Len: 8192 Enqueue: 862
+ID: 74 Len: 2048 Enqueue: 938
+ID: 75 Len: 8192 Enqueue: 880
+ID: 76 Len: 2048 Enqueue: 950
+ID: 77 Len: 9 Enqueue: 0
+ID: 78 Len: 17 Enqueue: 0
+ID: 79 Len: 25 Enqueue: 0
+ID: 80 Len: 25 Enqueue: 0
+ID: 81 Len: 25 Enqueue: 0
+ID: 82 Len: 49 Enqueue: 0
+ID: 83 Len: 49 Enqueue: 0
+ID: 84 Len: 9 Enqueue: 0
+ID: 85 Len: 9 Enqueue: 0
+ID: 86 Len: 9 Enqueue: 0
+ID: 87 Len: 9 Enqueue: 0
+ID: 88 Len: 9 Enqueue: 0

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -184,16 +184,19 @@ func (d *Decoder) encodeValue(
 	data []byte,
 	valueType string,
 ) error {
-	if err := writeTokens(enc,
-		jsontext.BeginObject,
-		jsontext.String("type"),
-		jsontext.String(valueType),
-	); err != nil {
-		return err
-	}
 	decoderType, ok := d.decoderTypes[typeID]
 	if !ok {
 		return fmt.Errorf("no decoder type found for type %s", decoderType.irType().GetName())
+	}
+	if err := writeTokens(enc, jsontext.BeginObject); err != nil {
+		return err
+	}
+	if !decoderType.hasDynamicType() {
+		if err := writeTokens(
+			enc, jsontext.String("type"), jsontext.String(valueType),
+		); err != nil {
+			return err
+		}
 	}
 	if err := decoderType.encodeValueFields(d, enc, data); err != nil {
 		return err

--- a/pkg/dyninst/decode/not_captured_reason.go
+++ b/pkg/dyninst/decode/not_captured_reason.go
@@ -19,6 +19,9 @@ var (
 	tokenNotCapturedReasonUnavailable    = jsontext.String("unavailable")
 	tokenNotCapturedReasonUnimplemented  = jsontext.String("unimplemented")
 	tokenNotCapturedReasonCycle          = jsontext.String("circular reference")
+	// This is used when we're missing the type information for a value
+	// underneath an interface.
+	tokenNotCapturedReasonMissingTypeInfo = jsontext.String("missing type information")
 	// tokenNotCapturedReasonFieldCount      = jsontext.String("fieldCount")
 
 	tokenTruncated = jsontext.String("truncated")

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -29,6 +29,7 @@ import (
 // value types.
 type decoderType interface {
 	irType() ir.Type
+	hasDynamicType() bool
 	encodeValueFields(
 		d *Decoder,
 		enc *jsontext.Encoder,
@@ -463,6 +464,7 @@ func (b *baseType) encodeValueFields(
 		return fmt.Errorf("%s is not a base type", kind)
 	}
 }
+func (*baseType) hasDynamicType() bool { return false }
 
 func (e *eventRootType) irType() ir.Type { return (*ir.EventRootType)(e) }
 func (e *eventRootType) encodeValueFields(
@@ -475,6 +477,7 @@ func (e *eventRootType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*eventRootType) hasDynamicType() bool { return false }
 
 func (m *goMapType) irType() ir.Type { return (*ir.GoMapType)(m) }
 func (m *goMapType) encodeValueFields(
@@ -483,8 +486,9 @@ func (m *goMapType) encodeValueFields(
 	data []byte,
 ) error {
 	const encodeAddress = false
-	return encodePointer(data, encodeAddress, m.HeaderType, enc, d)
+	return encodePointer(data, encodeAddress, m.HeaderType.GetID(), enc, d)
 }
+func (*goMapType) hasDynamicType() bool { return false }
 
 func (h *goHMapHeaderType) irType() ir.Type { return h.GoHMapHeaderType }
 func (h *goHMapHeaderType) encodeValueFields(
@@ -554,6 +558,7 @@ func (h *goHMapHeaderType) encodeValueFields(
 	}
 	return nil
 }
+func (*goHMapHeaderType) hasDynamicType() bool { return false }
 
 func encodeHMapBucket(
 	d *Decoder,
@@ -617,6 +622,7 @@ func (*goHMapBucketType) encodeValueFields(
 ) error {
 	return fmt.Errorf("hmap bucket type is never directly encoded")
 }
+func (*goHMapBucketType) hasDynamicType() bool { return false }
 
 func (s *goSwissMapHeaderType) irType() ir.Type { return s.GoSwissMapHeaderType }
 func (s *goSwissMapHeaderType) encodeValueFields(
@@ -703,6 +709,7 @@ func (s *goSwissMapHeaderType) encodeValueFields(
 	}
 	return writeTokens(enc, jsontext.EndArray)
 }
+func (*goSwissMapHeaderType) hasDynamicType() bool { return false }
 
 func (s *goSwissMapGroupsType) irType() ir.Type { return (*ir.GoSwissMapGroupsType)(s) }
 func (s *goSwissMapGroupsType) encodeValueFields(
@@ -715,6 +722,7 @@ func (s *goSwissMapGroupsType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*goSwissMapGroupsType) hasDynamicType() bool { return false }
 
 func (v *voidPointerType) irType() ir.Type { return (*ir.VoidPointerType)(v) }
 func (v *voidPointerType) encodeValueFields(
@@ -730,6 +738,7 @@ func (v *voidPointerType) encodeValueFields(
 		jsontext.String("0x"+strconv.FormatUint(binary.NativeEndian.Uint64(data), 16)),
 	)
 }
+func (*voidPointerType) hasDynamicType() bool { return false }
 
 func (p *pointerType) irType() ir.Type { return (*ir.PointerType)(p) }
 func (p *pointerType) encodeValueFields(
@@ -745,23 +754,23 @@ func (p *pointerType) encodeValueFields(
 	// find a go kind.
 	goKind, ok := p.Pointee.GetGoKind()
 	writeAddress := ok && goKind != reflect.Pointer
-	return encodePointer(data, writeAddress, p.Pointee, enc, d)
+	return encodePointer(data, writeAddress, p.Pointee.GetID(), enc, d)
 }
+func (*pointerType) hasDynamicType() bool { return false }
 
 func encodePointer(
 	data []byte,
 	writeAddress bool,
-	pointee ir.Type,
+	pointee ir.TypeID,
 	enc *jsontext.Encoder,
 	d *Decoder,
 ) error {
 	if len(data) < 8 {
 		return errors.New("passed data not long enough for pointer: need 8 bytes")
 	}
-	pointeeID := pointee.GetID()
 	addr := binary.NativeEndian.Uint64(data)
 	pointeeKey := typeAndAddr{
-		irType: uint32(pointeeID),
+		irType: uint32(pointee),
 		addr:   addr,
 	}
 	if pointeeKey.addr == 0 {
@@ -793,9 +802,9 @@ func encodePointer(
 	if _, alreadyEncoding := d.currentlyEncoding[pointeeKey]; !alreadyEncoding && dataItemExists {
 		d.currentlyEncoding[pointeeKey] = struct{}{}
 		defer delete(d.currentlyEncoding, pointeeKey)
-		pointeeDecoderType, ok := d.decoderTypes[pointeeID]
+		pointeeDecoderType, ok := d.decoderTypes[pointee]
 		if !ok {
-			return fmt.Errorf("no decoder type found for pointee type (ID: %d)", pointeeID)
+			return fmt.Errorf("no decoder type found for pointee type (ID: %d)", pointee)
 		}
 		if err := pointeeDecoderType.encodeValueFields(
 			d,
@@ -845,6 +854,7 @@ func (s *structureType) encodeValueFields(
 	}
 	return writeTokens(enc, jsontext.EndObject)
 }
+func (*structureType) hasDynamicType() bool { return false }
 
 func (a *arrayType) irType() ir.Type { return (*ir.ArrayType)(a) }
 func (a *arrayType) encodeValueFields(
@@ -891,6 +901,7 @@ func (a *arrayType) encodeValueFields(
 	}
 	return nil
 }
+func (*arrayType) hasDynamicType() bool { return false }
 
 func (s *goSliceHeaderType) irType() ir.Type { return (*ir.GoSliceHeaderType)(s) }
 func (s *goSliceHeaderType) encodeValueFields(
@@ -978,6 +989,7 @@ func (s *goSliceHeaderType) encodeValueFields(
 	}
 	return nil
 }
+func (*goSliceHeaderType) hasDynamicType() bool { return false }
 
 func (s *goSliceDataType) irType() ir.Type { return (*ir.GoSliceDataType)(s) }
 func (s *goSliceDataType) encodeValueFields(
@@ -990,6 +1002,7 @@ func (s *goSliceDataType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*goSliceDataType) hasDynamicType() bool { return false }
 
 func (s *goStringHeaderType) irType() ir.Type { return s.GoStringHeaderType }
 func (s *goStringHeaderType) encodeValueFields(
@@ -1043,6 +1056,7 @@ func (s *goStringHeaderType) encodeValueFields(
 	str := unsafe.String(unsafe.SliceData(stringData), int(length))
 	return writeTokens(enc, jsontext.String(str))
 }
+func (*goStringHeaderType) hasDynamicType() bool { return false }
 
 func (s *goStringDataType) irType() ir.Type { return (*ir.GoStringDataType)(s) }
 func (s *goStringDataType) encodeValueFields(
@@ -1055,6 +1069,7 @@ func (s *goStringDataType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*goStringDataType) hasDynamicType() bool { return false }
 
 func (c *goChannelType) irType() ir.Type { return (*ir.GoChannelType)(c) }
 func (c *goChannelType) encodeValueFields(
@@ -1067,29 +1082,74 @@ func (c *goChannelType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*goChannelType) hasDynamicType() bool { return false }
+
+const goRuntimeTypeOffset = 0x00
+const goInterfaceDataOffset = 0x08
 
 func (e *goEmptyInterfaceType) irType() ir.Type { return (*ir.GoEmptyInterfaceType)(e) }
 func (e *goEmptyInterfaceType) encodeValueFields(
-	_ *Decoder,
+	d *Decoder,
 	enc *jsontext.Encoder,
-	_ []byte,
+	data []byte,
 ) error {
-	return writeTokens(enc,
-		tokenNotCapturedReason,
-		tokenNotCapturedReasonUnimplemented,
-	)
+	return encodeInterface(d, enc, data)
 }
+func (*goEmptyInterfaceType) hasDynamicType() bool { return true }
 
 func (i *goInterfaceType) irType() ir.Type { return (*ir.GoInterfaceType)(i) }
 func (i *goInterfaceType) encodeValueFields(
-	_ *Decoder,
+	d *Decoder,
 	enc *jsontext.Encoder,
-	_ []byte,
+	data []byte,
 ) error {
-	return writeTokens(enc,
-		tokenNotCapturedReason,
-		tokenNotCapturedReasonUnimplemented,
-	)
+	return encodeInterface(d, enc, data)
+}
+func (*goInterfaceType) hasDynamicType() bool { return true }
+
+func encodeInterface(
+	d *Decoder,
+	enc *jsontext.Encoder,
+	data []byte,
+) error {
+	if len(data) != 16 {
+		return fmt.Errorf("go interface data must be 16 bytes, got %d", len(data))
+	}
+	runtimeType := binary.NativeEndian.Uint64(data[goRuntimeTypeOffset : goRuntimeTypeOffset+8])
+	typeID, ok := d.typesByGoRuntimeType[uint32(runtimeType)]
+	if !ok {
+		if err := writeTokens(enc,
+			jsontext.String("type"),
+			jsontext.String(fmt.Sprintf("UnknownType(0x%x)", runtimeType)),
+			tokenNotCapturedReason,
+			tokenNotCapturedReasonMissingTypeInfo,
+		); err != nil {
+			return err
+		}
+		return nil
+	}
+	// We know the concrete type; include it even for dynamic interfaces.
+	t, ok := d.program.Types[typeID]
+	if !ok {
+		return fmt.Errorf("no type found for type ID: %d", typeID)
+	}
+	if err := writeTokens(enc,
+		jsontext.String("type"),
+		jsontext.String(t.GetName()),
+	); err != nil {
+		return err
+	}
+	ptrData := data[goInterfaceDataOffset : goInterfaceDataOffset+8]
+	switch t := t.(type) {
+	case *ir.PointerType:
+		// Delegate to the pointer type for its handling of the decision
+		// when to write out the address.
+		return (*pointerType)(t).encodeValueFields(d, enc, ptrData)
+	case *ir.GoMapType /* *ir.GoChannelType, *ir.GoSubroutineType */ :
+		typeID = t.HeaderType.GetID()
+	default:
+	}
+	return encodePointer(ptrData, false, typeID, enc, d)
 }
 
 func (s *goSubroutineType) irType() ir.Type { return (*ir.GoSubroutineType)(s) }
@@ -1103,6 +1163,7 @@ func (s *goSubroutineType) encodeValueFields(
 		tokenNotCapturedReasonUnimplemented,
 	)
 }
+func (*goSubroutineType) hasDynamicType() bool { return false }
 
 func getFieldByName(fields []ir.Field, name string) (*ir.Field, error) {
 	for _, f := range fields {

--- a/pkg/dyninst/ebpf/program.h
+++ b/pkg/dyninst/ebpf/program.h
@@ -49,4 +49,20 @@ struct {
 } probe_params SEC(".maps");
 volatile const uint32_t num_probe_params = 0;
 
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 0);
+  __type(key, uint32_t);
+  __type(value, uint32_t);
+} go_runtime_types SEC(".maps");
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 0);
+  __type(key, uint32_t);
+  __type(value, uint32_t);
+} go_runtime_type_ids SEC(".maps");
+
+volatile const uint32_t num_go_runtime_types = 0;
+
 #endif // __PROGRAM_H__

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -29,6 +29,29 @@ static bool get_type_info(type_t t, const type_info_t** info_out) {
   return true;
 }
 
+DEFINE_BINARY_SEARCH(
+  lookup_type_id,
+  uint32_t,
+  go_runtime_type,
+  go_runtime_types,
+  num_go_runtime_types
+);
+
+static type_t lookup_go_interface(uint32_t go_runtime_type) {
+  if (go_runtime_type == 0) {
+    return 0;
+  }
+  uint32_t idx = lookup_type_id_by_go_runtime_type(go_runtime_type);
+  uint32_t *got = bpf_map_lookup_elem(&go_runtime_types, &idx);
+  if (!got || *got != go_runtime_type) {
+    return 0;
+  }
+  uint32_t *type_id = bpf_map_lookup_elem(&go_runtime_type_ids, &idx);
+  if (!type_id) {
+    return 0;
+  }
+  return *type_id;
+}
 
 static bool chased_pointers_trie_push(chased_pointers_trie_t* chased, target_ptr_t ptr,
                                  type_t type) {
@@ -299,25 +322,26 @@ sm_record_pointer(global_ctx_t* ctx, type_t type, target_ptr_t addr,
   return true;
 }
 
-// inline __attribute__((always_inline)) bool
-// sm_record_go_interface_impl(global_ctx_t* global_ctx, uint64_t go_runtime_type,
-//                          target_ptr_t addr) {
-//   // Resolve implementation type.
-//   if (go_runtime_type == (uint64_t)(-1)) {
-//     // TODO: Maybe this should not short-circuit the rest of execution.
-//     // Note that this happens only when there's an issue reading the
-//     // runtime.firstmoduledata or if the type does not reside inside of
-//     // it.
-//     LOG(3, "chase: interface unknown go runtime type");
-//     return true;
-//   }
-//   type_t t = lookup_go_interface(go_runtime_type);
-//   if (t == TYPE_NONE) {
-//     LOG(4, "chase: interface type not found %lld", go_runtime_type);
-//     return true;
-//   }
-//   return sm_record_pointer(global_ctx, t, addr, ENQUEUE_LEN_SENTINEL);
-// }
+static inline __attribute__((always_inline)) bool
+sm_record_go_interface_impl(global_ctx_t* global_ctx, uint64_t go_runtime_type,
+                         target_ptr_t addr) {
+  // Resolve implementation type.
+  if (go_runtime_type == (uint64_t)(-1)) {
+    // TODO: Maybe this should not short-circuit the rest of execution.
+    // Note that this happens only when there's an issue reading the
+    // runtime.firstmoduledata or if the type does not reside inside of
+    // it.
+    LOG(3, "chase: interface unknown go runtime type");
+    return true;
+  }
+  type_t t = lookup_go_interface(go_runtime_type);
+  if (t == 0) {
+    LOG(4, "chase: interface type not found %llx", go_runtime_type);
+    return true;
+  }
+  const bool decrease_ttl = false;
+  return sm_record_pointer(global_ctx, t, addr, decrease_ttl, ENQUEUE_LEN_SENTINEL);
+}
 
 typedef struct typebounds {
   uint64_t types;
@@ -336,123 +360,145 @@ struct {
   __type(value, moduledata_t);
 } moduledata_buf SEC(".maps");
 
-// // Translate a pointer to a type (i.e. a pointer pointing to type information
-// // inside moduledata) like that found inside an empty interface to an offset
-// // into moduledata. We commonly represent runtime type information as such an
-// // offset.
-// inline __attribute__((always_inline)) uint64_t
-// go_runtime_type_from_ptr(target_ptr_t type_ptr) {
-//   const unsigned long zero = 0;
-//   moduledata_t* moduledata =
-//       (moduledata_t*)bpf_map_lookup_elem(&moduledata_buf, &zero);
-//   if (!moduledata) {
-//     return -1;
-//   }
-//   // Detect if the moduledata is up-to-date by checking if the address is
-//   // correct. If it is not, then we need to update the typebounds.
-//   if (moduledata->addr != VARIABLE_runtime_dot_firstmoduledata) {
-//     moduledata->addr = VARIABLE_runtime_dot_firstmoduledata;
-//     if (bpf_probe_read_user(&moduledata->types, sizeof(typebounds_t),
-//                             (void*)(VARIABLE_runtime_dot_firstmoduledata +
-//                                     OFFSET_runtime_dot_moduledata__types))) {
-//       return -1;
-//     }
-//   }
+// These constants are filled in by the loader.
+volatile const uint64_t VARIABLE_runtime_dot_firstmoduledata = 0;
+volatile const uint32_t OFFSET_runtime_dot_moduledata__types = 0;
 
-//   typebounds_t* typebounds = &moduledata->types;
-//   if (type_ptr >= typebounds->types && type_ptr < typebounds->etypes) {
-//     return type_ptr - typebounds->types;
-//   }
-//   return -1;
-// }
+// Translate a pointer to a type (i.e. a pointer pointing to type information
+// inside moduledata) like that found inside an empty interface to an offset
+// into moduledata. We commonly represent runtime type information as such an
+// offset.
+static inline __attribute__((always_inline)) uint64_t
+go_runtime_type_from_ptr(target_ptr_t type_ptr) {
+  const unsigned long zero = 0;
+  moduledata_t* moduledata =
+      (moduledata_t*)bpf_map_lookup_elem(&moduledata_buf, &zero);
+  if (!moduledata) {
+    LOG(1, "go_runtime_type_from_ptr: moduledata not found");
+    return -1;
+  }
+  // Detect if the moduledata is up-to-date by checking if the address is
+  // correct. If it is not, then we need to update the typebounds.
+  if (moduledata->addr != VARIABLE_runtime_dot_firstmoduledata) {
+    moduledata->addr = VARIABLE_runtime_dot_firstmoduledata;
+    if (bpf_probe_read_user(&moduledata->types, sizeof(typebounds_t),
+                            (void*)(VARIABLE_runtime_dot_firstmoduledata +
+                                    OFFSET_runtime_dot_moduledata__types))) {
+      LOG(1, "go_runtime_type_from_ptr: failed to read moduledata types %llx + %d",
+          VARIABLE_runtime_dot_firstmoduledata,
+          OFFSET_runtime_dot_moduledata__types);
+      return -1;
+    }
+  }
 
-// inline __attribute__((always_inline)) bool
-// sm_resolve_go_empty_interface(global_ctx_t* ctx, resolved_go_interface_t* res) {
-//   scratch_buf_t* buf = ctx->buf;
-//   stack_machine_t* sm = ctx->stack_machine;
-//   buf_offset_t offset = sm->offset;
-//   res->addr = 0;
-//   res->go_runtime_type = 0;
-//   if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) * 2)) {
-//     return false;
-//   }
-//   if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) +
-//                                              OFFSET_runtime_dot_eface__data)) {
-//     return false;
-//   }
-//   target_ptr_t type_addr =
-//       *(target_ptr_t*)(&(*buf)[offset + OFFSET_runtime_dot_eface___type]);
-//   res->addr =
-//       *(target_ptr_t*)&((*buf)[offset + OFFSET_runtime_dot_eface__data]);
-//   if (type_addr == 0) {
-//     // Not an error, just literally a nil interface.
-//     return true;
-//   }
-//   // TODO: check the return value for error
-//   res->go_runtime_type = go_runtime_type_from_ptr(type_addr);
-//   return true;
-// }
+  typebounds_t* typebounds = &moduledata->types;
+  if (type_ptr >= typebounds->types && type_ptr < typebounds->etypes) {
+    return type_ptr - typebounds->types;
+  }
+  LOG(1, "go_runtime_type_from_ptr: type_ptr %llx not in typebounds %llx-%llx",
+    type_ptr, typebounds->types, typebounds->etypes);
+  return -1;
+}
 
-// // Resolves address and implementation type of a non-empty interface.
-// inline __attribute__((always_inline)) bool
-// sm_resolve_go_interface(global_ctx_t* ctx, resolved_go_interface_t* res) {
-//   scratch_buf_t* buf = ctx->buf;
-//   stack_machine_t* sm = ctx->stack_machine;
-//   buf_offset_t offset = sm->offset;
-//   res->addr = 0;
-//   res->go_runtime_type = 0;
-//   if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) * 2)) {
-//     return false;
-//   }
-//   if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) +
-//                                              OFFSET_runtime_dot_iface__data)) {
-//     return false;
-//   }
-//   res->addr =
-//       *(target_ptr_t*)&((*buf)[offset + OFFSET_runtime_dot_iface__data]);
-//   target_ptr_t itab =
-//       *(target_ptr_t*)(&(*buf)[offset + OFFSET_runtime_dot_iface__tab]);
-//   if (itab == 0) {
-//     return true;
-//   }
-//   target_ptr_t type_addr;
-//   if (bpf_probe_read_user(&type_addr, sizeof(target_ptr_t),
-//                           (void*)(itab) +
-//                               (uint64_t)(OFFSET_runtime_dot_itab___type))) {
-//     LOG(3, "enqueue: failed interface type read %llx",
-//         (void*)(itab) + (uint64_t)(OFFSET_runtime_dot_itab___type));
-//     return true;
-//   }
-//   // TODO: check the return value for error
-//   res->go_runtime_type = go_runtime_type_from_ptr(type_addr);
-//   return true;
-// }
+// TODO: These could be extracted from the debug info, but for now we'll
+// simplify and hardcode them. They have never changed.
+#define OFFSET_runtime_dot_iface__tab 0x00
+#define OFFSET_runtime_dot_iface__data 0x08
+#define OFFSET_runtime_dot_itab___type 0x08
+#define OFFSET_runtime_dot_eface___type 0x00
+#define OFFSET_runtime_dot_eface__data 0x08
 
-// inline __attribute__((always_inline)) bool
-// sm_resolve_go_any_type(global_ctx_t* global_ctx, resolved_go_any_type_t* r) {
-//   r->i.addr = 0;
-//   r->i.go_runtime_type = 0;
-//   r->type = (type_t)0;
-//   r->has_info = false;
-//   if (!sm_resolve_go_empty_interface(global_ctx, &r->i)) {
-//     return false;
-//   }
-//   if (r->i.go_runtime_type == (uint64_t)(-1)) {
-//     return true;
-//   }
-//   r->type = lookup_go_interface(r->i.go_runtime_type);
-//   if (r->type == TYPE_NONE) {
-//     return true;
-//   }
-//   const type_info_t* info;
-//   if (!get_type_info(r->type, &info)) {
-//     LOG(3, "any type info not found %d", r->type);
-//     return true;
-//   }
-//   r->has_info = true;
-//   r->info = *info;
-//   return true;
-// }
+static inline __attribute__((always_inline)) bool
+sm_resolve_go_empty_interface(global_ctx_t* ctx, resolved_go_interface_t* res) {
+  scratch_buf_t* buf = ctx->buf;
+  stack_machine_t* sm = ctx->stack_machine;
+  buf_offset_t offset = sm->offset;
+  res->addr = 0;
+  res->go_runtime_type = 0;
+  if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) * 2)) {
+    return false;
+  }
+  if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) +
+                                             OFFSET_runtime_dot_eface__data)) {
+    return false;
+  }
+  target_ptr_t type_addr =
+      *(target_ptr_t*)(&(*buf)[offset + OFFSET_runtime_dot_eface___type]);
+  res->addr =
+      *(target_ptr_t*)&((*buf)[offset + OFFSET_runtime_dot_eface__data]);
+  if (type_addr == 0) {
+    // Not an error, just literally a nil interface.
+    return true;
+  }
+  // TODO: check the return value for error
+  res->go_runtime_type = go_runtime_type_from_ptr(type_addr);
+  return true;
+}
+
+
+// Resolves address and implementation type of a non-empty interface.
+static inline __attribute__((always_inline)) bool
+sm_resolve_go_interface(global_ctx_t* ctx, resolved_go_interface_t* res) {
+  scratch_buf_t* buf = ctx->buf;
+  stack_machine_t* sm = ctx->stack_machine;
+  buf_offset_t offset = sm->offset;
+  res->addr = 0;
+  res->go_runtime_type = 0;
+  if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) * 2)) {
+    return false;
+  }
+  if (!scratch_buf_bounds_check(&offset, sizeof(target_ptr_t) +
+                                             OFFSET_runtime_dot_iface__data)) {
+    return false;
+  }
+  res->addr =
+      *(target_ptr_t*)&((*buf)[offset + OFFSET_runtime_dot_iface__data]);
+  target_ptr_t itab =
+      *(target_ptr_t*)(&(*buf)[offset + OFFSET_runtime_dot_iface__tab]);
+  if (itab == 0) {
+    return true;
+  }
+  target_ptr_t type_addr;
+  if (bpf_probe_read_user(&type_addr, sizeof(target_ptr_t),
+                          (void*)(itab) +
+                              (uint64_t)(OFFSET_runtime_dot_itab___type))) {
+    LOG(3, "enqueue: failed interface type read %llx",
+        (void*)(itab) + (uint64_t)(OFFSET_runtime_dot_itab___type));
+    return true;
+  }
+  // TODO: check the return value for error
+  res->go_runtime_type = go_runtime_type_from_ptr(type_addr);
+  return true;
+}
+
+// Resolve the type of a Go any type.
+//
+// Note that it will only return false in the case of a bounds check failure.
+static inline __attribute__((always_inline)) bool
+sm_resolve_go_any_type(global_ctx_t* global_ctx, resolved_go_any_type_t* r) {
+  r->i.addr = 0;
+  r->i.go_runtime_type = 0;
+  r->type = (type_t)0;
+  r->has_info = false;
+  if (!sm_resolve_go_empty_interface(global_ctx, &r->i)) {
+    return false;
+  }
+  if (r->i.go_runtime_type == (uint64_t)(-1)) {
+    return true;
+  }
+  r->type = lookup_go_interface(r->i.go_runtime_type);
+  if (r->type == 0) {
+    return true;
+  }
+  const type_info_t* info;
+  if (!get_type_info(r->type, &info)) {
+    LOG(3, "any type info not found %d", r->type);
+    return true;
+  }
+  r->has_info = true;
+  r->info = *info;
+  return true;
+}
 
 // inline __attribute__((always_inline)) bool sm_record_go_context_value(
 //     global_ctx_t* ctx, const go_context_value_type_t* spec,
@@ -868,40 +914,41 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     zero_data(buf, sm->offset, data_len);
   } break;
 
-  // case SM_OP_ENQUEUE_GO_EMPTY_INTERFACE: {
-  //   resolved_go_interface_t r;
-  //   if (!sm_resolve_go_empty_interface(ctx, &r)) {
-  //     return 1;
-  //   }
-  //   // Overwrite the type_addr with the go_runtime_type.
-  //   if (!scratch_buf_bounds_check(&sm->offset, sizeof(target_ptr_t))) {
-  //     return 1;
-  //   }
-  //   *(uint64_t*)(&(*buf)[sm->offset + OFFSET_runtime_dot_eface___type]) =
-  //       r.go_runtime_type;
-  //   if (!sm_record_go_interface_impl(ctx, r.go_runtime_type, r.addr)) {
-  //     LOG(3, "enqueue: failed empty interface chase");
-  //   }
-  // } break;
+  case SM_OP_PROCESS_GO_EMPTY_INTERFACE: {
+    resolved_go_interface_t r;
+    if (!sm_resolve_go_empty_interface(ctx, &r)) {
+      return 1;
+    }
+    LOG(4, "resolved_go_interface_t: %llx %llx", r.addr, r.go_runtime_type)
+    // Overwrite the type_addr with the go_runtime_type.
+    if (!scratch_buf_bounds_check(&sm->offset, sizeof(target_ptr_t))) {
+      return 1;
+    }
+    *(uint64_t*)(&(*buf)[sm->offset + OFFSET_runtime_dot_eface___type]) =
+        r.go_runtime_type;
+    if (!sm_record_go_interface_impl(ctx, r.go_runtime_type, r.addr)) {
+      LOG(3, "enqueue: failed empty interface chase");
+    }
+  } break;
 
-  // case SM_OP_ENQUEUE_GO_INTERFACE: {
-  //   resolved_go_interface_t r;
-  //   if (!sm_resolve_go_interface(ctx, &r)) {
-  //     return 1;
-  //   }
-  //   if (r.go_runtime_type == 0) {
-  //     break;
-  //   }
-  //   // Overwrite the type_addr with the go_runtime_type.
-  //   if (!scratch_buf_bounds_check(&sm->offset, sizeof(target_ptr_t))) {
-  //     return 1;
-  //   }
-  //   *(uint64_t*)(&(*buf)[sm->offset + OFFSET_runtime_dot_iface__tab]) =
-  //       r.go_runtime_type;
-  //   if (!sm_record_go_interface_impl(ctx, r.go_runtime_type, r.addr)) {
-  //     LOG(3, "enqueue: failed interface chase");
-  //   }
-  // } break;
+  case SM_OP_PROCESS_GO_INTERFACE: {
+    resolved_go_interface_t r;
+    if (!sm_resolve_go_interface(ctx, &r)) {
+      return 1;
+    }
+    if (r.go_runtime_type == 0) {
+      break;
+    }
+    // Overwrite the type_addr with the go_runtime_type.
+    if (!scratch_buf_bounds_check(&sm->offset, sizeof(target_ptr_t))) {
+      return 1;
+    }
+    *(uint64_t*)(&(*buf)[sm->offset + OFFSET_runtime_dot_iface__tab]) =
+        r.go_runtime_type;
+    if (!sm_record_go_interface_impl(ctx, r.go_runtime_type, r.addr)) {
+      LOG(3, "enqueue: failed interface chase");
+    }
+  } break;
 
   case SM_OP_PROCESS_GO_HMAP: {
     // https://github.com/golang/go/blob/8d04110c/src/runtime/map.go#L105

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -88,9 +88,6 @@ var expectations embed.FS
 
 func TestEndToEnd(t *testing.T) {
 	t.Parallel()
-	if testing.Short() {
-		t.Skip("skipping end-to-end test in short mode")
-	}
 	dyninsttest.SkipIfKernelNotSupported(t)
 	cfgs := testprogs.MustGetCommonConfigs(t)
 	idx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
@@ -113,6 +110,9 @@ func TestEndToEnd(t *testing.T) {
 				}
 				if !useDocker {
 					t.Skip("docker is not enabled")
+				}
+				if testing.Short() {
+					t.Skip("skipping docker test in short mode")
 				}
 				t.Parallel()
 				runE2ETest(t, e2eTestConfig{

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -40,6 +40,25 @@ type Program struct {
 	MaxTypeID TypeID
 	// Issues is a list of probes that could not be created.
 	Issues []ProbeIssue
+	// GoModuledataInfo is used to resolve types from interfaces.
+	GoModuledataInfo GoModuledataInfo
+}
+
+// GoModuledataInfo is information about the runtime-internal structure used to
+// translate type pointer addresses to Go runtime type IDs. This information is
+// used in the generated program to resolve type information for interface
+// values.
+type GoModuledataInfo struct {
+	// FirstModuledataAddr is the virtual memory address of the firstmoduledata
+	// variable.
+	//
+	// See https://github.com/golang/go/blob/5a56d884/src/runtime/symtab.go#L483
+	FirstModuledataAddr uint64
+	// TypesOffset is the offset in the runtime.moduledata type of
+	// the types field.
+	//
+	// See https://github.com/golang/go/blob/5a56d884/src/runtime/symtab.go#L414
+	TypesOffset uint32
 }
 
 // InlinePCRanges represent the pc ranges for a single instance of an inlined subprogram.

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -190,7 +190,7 @@ type GoEmptyInterfaceType struct {
 
 	// UnderlyingStructure is the structure that is the underlying type of the
 	// runtime.eface.
-	UnderlyingStructure *StructureType
+	RawFields []Field
 }
 
 func (t *GoEmptyInterfaceType) irType() {}
@@ -202,7 +202,7 @@ type GoInterfaceType struct {
 
 	// UnderlyingStructure is the structure that is the underlying type of the
 	// runtime.iface.
-	UnderlyingStructure *StructureType
+	RawFields []Field
 }
 
 func (t *GoInterfaceType) irType() {}

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -146,7 +146,7 @@ func generateIR(
 		cfg.maxDynamicTypeSize,
 		cfg.maxHashBucketsSize,
 	)
-	pendingSubprograms, err := processDwarf(interests, d, typeCatalog, objFile)
+	pendingSubprograms, goModuledataInfo, err := processDwarf(interests, d, typeCatalog, objFile)
 	if err != nil {
 		return nil, err
 	}
@@ -207,12 +207,13 @@ func generateIR(
 	slices.SortFunc(issues, ir.CompareProbeIDs)
 
 	return &ir.Program{
-		ID:          programID,
-		Subprograms: subprograms,
-		Probes:      probes,
-		Types:       typeCatalog.typesByID,
-		MaxTypeID:   typeCatalog.idAlloc.alloc,
-		Issues:      issues,
+		ID:               programID,
+		Subprograms:      subprograms,
+		Probes:           probes,
+		Types:            typeCatalog.typesByID,
+		MaxTypeID:        typeCatalog.idAlloc.alloc,
+		Issues:           issues,
+		GoModuledataInfo: goModuledataInfo,
 	}, nil
 }
 
@@ -354,7 +355,7 @@ func processDwarf(
 	d *dwarf.Data,
 	typeCatalog *typeCatalog,
 	objFile object.FileWithDwarf,
-) ([]*pendingSubprogram, error) {
+) ([]*pendingSubprogram, ir.GoModuledataInfo, error) {
 	v := &rootVisitor{
 		interests:           interests,
 		dwarf:               d,
@@ -368,7 +369,7 @@ func processDwarf(
 
 	// Visit the entire DWARF tree.
 	if err := visitDwarf(d.Reader(), v); err != nil {
-		return nil, err
+		return nil, ir.GoModuledataInfo{}, err
 	}
 
 	// Concrete subprograms are already in v.pendingSubprograms.
@@ -407,7 +408,10 @@ func processDwarf(
 		})
 	}
 
-	return pending, nil
+	if v.goRuntimeInformation == (ir.GoModuledataInfo{}) {
+		return nil, ir.GoModuledataInfo{}, fmt.Errorf("runtime.firstmoduledata not found")
+	}
+	return pending, v.goRuntimeInformation, nil
 }
 
 func findUnusedConfigs(
@@ -935,6 +939,8 @@ type rootVisitor struct {
 	typeCatalog        *typeCatalog
 	loclistReader      *loclist.Reader
 
+	goRuntimeInformation ir.GoModuledataInfo
+
 	// This is used to avoid allocations of unitChildVisitor for each
 	// compile unit.
 	freeUnitChildVisitor *unitChildVisitor
@@ -1099,8 +1105,45 @@ func (v *unitChildVisitor) push(
 		return nil, nil
 
 	case dwarf.TagVariable:
-		// TODO: Handle variables.
+		name, ok, err := maybeGetAttr[string](entry, dwarf.AttrName)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || name != "runtime.firstmoduledata" {
+			return nil, nil
+		}
+
+		typeOffset, err := getAttr[dwarf.Offset](entry, dwarf.AttrType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get type for runtime.firstmoduledata: %w", err)
+		}
+
+		// See https://github.com/golang/go/blob/5a56d884/src/runtime/symtab.go#L414
+		byteSize, memberOffset, err := findStructSizeAndMemberOffset(v.root.dwarf, typeOffset, "types")
+		if err != nil {
+			return nil, fmt.Errorf("failed to find struct size and member offset: %w", err)
+		}
+		location, err := getAttr[[]byte](entry, dwarf.AttrLocation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get location for runtime.firstmoduledata: %w", err)
+		}
+		instructions, err := loclist.ParseInstructions(location, v.root.pointerSize, byteSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse location for runtime.firstmoduledata: %w", err)
+		}
+		if len(instructions) != 1 {
+			return nil, fmt.Errorf("runtime.firstmoduledata has %d instructions, expected 1", len(instructions))
+		}
+		addr, ok := instructions[0].Op.(ir.Addr)
+		if !ok {
+			return nil, fmt.Errorf("runtime.firstmoduledata is not an address, got %T", instructions[0].Op)
+		}
+		v.root.goRuntimeInformation = ir.GoModuledataInfo{
+			FirstModuledataAddr: addr.Addr,
+			TypesOffset:         memberOffset,
+		}
 		return nil, nil
+
 	case dwarf.TagConstant:
 		// TODO: Handle constants.
 		return nil, nil
@@ -1113,6 +1156,79 @@ func (v *unitChildVisitor) push(
 // It doesn't match anything with a package or any of the odd internal types
 // used by the runtime like sudog<T>.
 var primitiveTypeNameRegexp = regexp.MustCompile(`^[a-z]+[0-9]*$`)
+
+// findStructMemberOffset finds the offset of a member in a struct type.
+func findStructSizeAndMemberOffset(
+	dwarfData *dwarf.Data,
+	typeOffset dwarf.Offset,
+	memberName string,
+) (size uint32, memberOffset uint32, retErr error) {
+	reader := dwarfData.Reader()
+	reader.Seek(typeOffset)
+	entry, err := reader.Next()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get entry: %w", err)
+	}
+	if entry.Tag != dwarf.TagTypedef {
+		return 0, 0, fmt.Errorf("expected typedef type, got %s", entry.Tag)
+	}
+	underlyingOffset, err := getAttr[dwarf.Offset](entry, dwarf.AttrType)
+	if err != nil {
+		return 0, 0, fmt.Errorf("missing type for typedef: %w", err)
+	}
+	reader.Seek(underlyingOffset)
+	entry, err = reader.Next()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get entry: %w", err)
+	}
+	if entry.Tag != dwarf.TagStructType {
+		return 0, 0, fmt.Errorf("expected struct type, got %s", entry.Tag)
+	}
+	if !entry.Children {
+		return 0, 0, fmt.Errorf("struct type has no children")
+	}
+	structSize, err := getAttr[int64](entry, dwarf.AttrByteSize)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get size for struct type: %w", err)
+	}
+	if structSize < 0 || structSize > math.MaxUint32 {
+		return 0, 0, fmt.Errorf("invalid struct size %d", structSize)
+	}
+	size = uint32(structSize)
+	for {
+		child, err := reader.Next()
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to get next child: %w", err)
+		}
+		if child == nil {
+			return 0, 0, fmt.Errorf("unexpected EOF while reading struct type")
+		}
+		if child.Tag == 0 {
+			break
+		}
+		if child.Tag == dwarf.TagMember {
+			name, err := getAttr[string](child, dwarf.AttrName)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to get name for member: %w", err)
+			}
+			if name != memberName {
+				continue
+			}
+			offset, err := getAttr[int64](child, dwarf.AttrDataMemberLoc)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to get offset for member: %w", err)
+			}
+			if offset > math.MaxUint32 {
+				return 0, 0, fmt.Errorf("member offset is too large: %d", offset)
+			}
+			return size, uint32(offset), nil
+		}
+		if child.Children {
+			reader.SkipChildren()
+		}
+	}
+	return 0, 0, fmt.Errorf("member %q not found", memberName)
+}
 
 func (v *unitChildVisitor) pop(_ *dwarf.Entry, childVisitor visitor) error {
 	switch t := childVisitor.(type) {

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1 EventRootType Probe[main.noop]
+          Type: 35 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a5f60", Frameless: true}]
           Condition: null
 Subprograms:
@@ -20,8 +20,238 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: EventRootType
+    - __kind: BaseType
       ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 37504
+      GoKind: 12
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37184
+      GoKind: 10
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 36928
+      GoKind: 8
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 37824
+      GoKind: 1
+    - __kind: PointerType
+      ID: 5
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26752
+      GoKind: 22
+      Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 25856
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37056
+      GoKind: 9
+    - __kind: PointerType
+      ID: 8
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26432
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: BaseType
+      ID: 9
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 37376
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 10
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 36800
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 34 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 33 GoStringDataType string.str
+    - __kind: BaseType
+      ID: 11
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 37312
+      GoKind: 11
+    - __kind: BaseType
+      ID: 12
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37120
+      GoKind: 5
+    - __kind: BaseType
+      ID: 13
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 37248
+      GoKind: 6
+    - __kind: BaseType
+      ID: 14
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 36864
+      GoKind: 3
+    - __kind: BaseType
+      ID: 15
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 37440
+      GoKind: 7
+    - __kind: BaseType
+      ID: 16
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 37696
+      GoKind: 13
+    - __kind: BaseType
+      ID: 17
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 37760
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 18
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 57984
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 19
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 37888
+      GoKind: 26
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26048
+      GoKind: 22
+      Pointee: 12 BaseType int32
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26112
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25728
+      GoKind: 22
+      Pointee: 10 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 23
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 37568
+      GoKind: 15
+    - __kind: BaseType
+      ID: 24
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 37632
+      GoKind: 16
+    - __kind: PointerType
+      ID: 25
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26688
+      GoKind: 22
+      Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 26
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26176
+      GoKind: 22
+      Pointee: 13 BaseType int64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26304
+      GoKind: 22
+      Pointee: 9 BaseType int
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26240
+      GoKind: 22
+      Pointee: 11 BaseType uint64
+    - __kind: PointerType
+      ID: 29
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25664
+      GoKind: 22
+      Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 30
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26624
+      GoKind: 22
+      Pointee: 16 BaseType float32
+    - __kind: PointerType
+      ID: 31
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26368
+      GoKind: 22
+      Pointee: 15 BaseType uint
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 25984
+      GoKind: 22
+      Pointee: 7 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 33
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 34
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 33 GoStringDataType string.str
+    - __kind: EventRootType
+      ID: 35
       Name: Probe[main.noop]
-MaxTypeID: 1
+MaxTypeID: 35
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.23.11.yaml
@@ -255,3 +255,4 @@ Types:
       Name: Probe[main.noop]
 MaxTypeID: 35
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x572260", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -255,3 +255,4 @@ Types:
       Name: Probe[main.noop]
 MaxTypeID: 35
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x57d340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1 EventRootType Probe[main.noop]
+          Type: 35 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: "0x4a7fe0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -20,8 +20,238 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: EventRootType
+    - __kind: BaseType
       ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 41312
+      GoKind: 12
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 40992
+      GoKind: 10
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 40736
+      GoKind: 8
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 41632
+      GoKind: 1
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 28352
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 40864
+      GoKind: 9
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41184
+      GoKind: 2
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41120
+      GoKind: 11
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 40608
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 34 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 33 GoStringDataType string.str
+    - __kind: BaseType
+      ID: 10
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 40928
+      GoKind: 5
+    - __kind: PointerType
+      ID: 11
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 29248
+      GoKind: 22
+      Pointee: 4 BaseType bool
+    - __kind: BaseType
+      ID: 12
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41056
+      GoKind: 6
+    - __kind: GoInterfaceType
+      ID: 13
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 62112
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 14 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 14 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 14
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 41696
+      GoKind: 26
+    - __kind: BaseType
+      ID: 15
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 40672
+      GoKind: 3
+    - __kind: BaseType
+      ID: 16
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 41248
+      GoKind: 7
+    - __kind: BaseType
+      ID: 17
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 41504
+      GoKind: 13
+    - __kind: BaseType
+      ID: 18
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 41568
+      GoKind: 14
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 28928
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28544
+      GoKind: 22
+      Pointee: 10 BaseType int32
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28608
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28224
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 23
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 41376
+      GoKind: 15
+    - __kind: BaseType
+      ID: 24
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 41440
+      GoKind: 16
+    - __kind: PointerType
+      ID: 25
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29184
+      GoKind: 22
+      Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 26
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28672
+      GoKind: 22
+      Pointee: 12 BaseType int64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 28800
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 28
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 28736
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 29
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 28160
+      GoKind: 22
+      Pointee: 13 GoInterfaceType error
+    - __kind: PointerType
+      ID: 30
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 29120
+      GoKind: 22
+      Pointee: 17 BaseType float32
+    - __kind: PointerType
+      ID: 31
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 28864
+      GoKind: 22
+      Pointee: 16 BaseType uint
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 28480
+      GoKind: 22
+      Pointee: 6 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 33
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 34
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 33 GoStringDataType string.str
+    - __kind: EventRootType
+      ID: 35
       Name: Probe[main.noop]
-MaxTypeID: 1
+MaxTypeID: 35
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -261,3 +261,4 @@ Types:
       Name: Probe[main.noop]
 MaxTypeID: 36
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1 EventRootType Probe[main.noop]
+          Type: 36 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: 742032, Frameless: true}]
           Condition: null
 Subprograms:
@@ -20,8 +20,244 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: EventRootType
+    - __kind: BaseType
       ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 37472
+      GoKind: 12
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 37152
+      GoKind: 10
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 36896
+      GoKind: 8
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 37792
+      GoKind: 1
+    - __kind: PointerType
+      ID: 5
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26720
+      GoKind: 22
+      Pointee: 4 BaseType bool
+    - __kind: PointerType
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 25824
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 37024
+      GoKind: 9
+    - __kind: PointerType
+      ID: 8
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26400
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: BaseType
+      ID: 9
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 37344
+      GoKind: 2
+    - __kind: GoStringHeaderType
+      ID: 10
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 36768
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 35 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 9 BaseType int
+      Data: 34 GoStringDataType string.str
+    - __kind: BaseType
+      ID: 11
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 37280
+      GoKind: 11
+    - __kind: BaseType
+      ID: 12
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 37408
+      GoKind: 7
+    - __kind: BaseType
+      ID: 13
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37088
+      GoKind: 5
+    - __kind: BaseType
+      ID: 14
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 37216
+      GoKind: 6
+    - __kind: BaseType
+      ID: 15
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 36832
+      GoKind: 3
+    - __kind: BaseType
+      ID: 16
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 37664
+      GoKind: 13
+    - __kind: BaseType
+      ID: 17
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 37728
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 18
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 57856
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 19 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 19 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 19
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 37856
+      GoKind: 26
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26016
+      GoKind: 22
+      Pointee: 13 BaseType int32
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26080
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 25696
+      GoKind: 22
+      Pointee: 10 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 23
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 36960
+      GoKind: 4
+    - __kind: BaseType
+      ID: 24
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 37536
+      GoKind: 15
+    - __kind: BaseType
+      ID: 25
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 37600
+      GoKind: 16
+    - __kind: PointerType
+      ID: 26
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26656
+      GoKind: 22
+      Pointee: 17 BaseType float64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26144
+      GoKind: 22
+      Pointee: 14 BaseType int64
+    - __kind: PointerType
+      ID: 28
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 26272
+      GoKind: 22
+      Pointee: 9 BaseType int
+    - __kind: PointerType
+      ID: 29
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26208
+      GoKind: 22
+      Pointee: 11 BaseType uint64
+    - __kind: PointerType
+      ID: 30
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25632
+      GoKind: 22
+      Pointee: 18 GoInterfaceType error
+    - __kind: PointerType
+      ID: 31
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26592
+      GoKind: 22
+      Pointee: 16 BaseType float32
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26336
+      GoKind: 22
+      Pointee: 12 BaseType uint
+    - __kind: PointerType
+      ID: 33
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 25952
+      GoKind: 22
+      Pointee: 7 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 34
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 35
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 34 GoStringDataType string.str
+    - __kind: EventRootType
+      ID: 36
       Name: Probe[main.noop]
-MaxTypeID: 1
+MaxTypeID: 36
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -261,3 +261,4 @@ Types:
       Name: Probe[main.noop]
 MaxTypeID: 36
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x191360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/busyloop.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 1 EventRootType Probe[main.noop]
+          Type: 36 EventRootType Probe[main.noop]
           InjectionPoints: [{PC: 741744, Frameless: true}]
           Condition: null
 Subprograms:
@@ -20,8 +20,244 @@ Subprograms:
       InlinePCRanges: []
       Variables: []
 Types:
-    - __kind: EventRootType
+    - __kind: BaseType
       ID: 1
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 41280
+      GoKind: 12
+    - __kind: BaseType
+      ID: 2
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 40960
+      GoKind: 10
+    - __kind: BaseType
+      ID: 3
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 40704
+      GoKind: 8
+    - __kind: BaseType
+      ID: 4
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 41600
+      GoKind: 1
+    - __kind: PointerType
+      ID: 5
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 28320
+      GoKind: 22
+      Pointee: 3 BaseType uint8
+    - __kind: BaseType
+      ID: 6
+      Name: uint16
+      ByteSize: 2
+      GoRuntimeType: 40832
+      GoKind: 9
+    - __kind: BaseType
+      ID: 7
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 41152
+      GoKind: 2
+    - __kind: BaseType
+      ID: 8
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 41088
+      GoKind: 11
+    - __kind: GoStringHeaderType
+      ID: 9
+      Name: string
+      ByteSize: 16
+      GoRuntimeType: 40576
+      GoKind: 24
+      RawFields:
+        - Name: str
+          Offset: 0
+          Type: 35 PointerType *string.str
+        - Name: len
+          Offset: 8
+          Type: 7 BaseType int
+      Data: 34 GoStringDataType string.str
+    - __kind: BaseType
+      ID: 10
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 41216
+      GoKind: 7
+    - __kind: PointerType
+      ID: 11
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 29216
+      GoKind: 22
+      Pointee: 4 BaseType bool
+    - __kind: BaseType
+      ID: 12
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 40896
+      GoKind: 5
+    - __kind: BaseType
+      ID: 13
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41024
+      GoKind: 6
+    - __kind: GoInterfaceType
+      ID: 14
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 61984
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 15 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 15 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 15
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 41664
+      GoKind: 26
+    - __kind: BaseType
+      ID: 16
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 40640
+      GoKind: 3
+    - __kind: BaseType
+      ID: 17
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 41472
+      GoKind: 13
+    - __kind: BaseType
+      ID: 18
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 41536
+      GoKind: 14
+    - __kind: PointerType
+      ID: 19
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 28896
+      GoKind: 22
+      Pointee: 1 BaseType uintptr
+    - __kind: PointerType
+      ID: 20
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28512
+      GoKind: 22
+      Pointee: 12 BaseType int32
+    - __kind: PointerType
+      ID: 21
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28576
+      GoKind: 22
+      Pointee: 2 BaseType uint32
+    - __kind: PointerType
+      ID: 22
+      Name: '*string'
+      ByteSize: 8
+      GoRuntimeType: 28192
+      GoKind: 22
+      Pointee: 9 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 23
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 40768
+      GoKind: 4
+    - __kind: BaseType
+      ID: 24
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 41344
+      GoKind: 15
+    - __kind: BaseType
+      ID: 25
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 41408
+      GoKind: 16
+    - __kind: PointerType
+      ID: 26
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29152
+      GoKind: 22
+      Pointee: 18 BaseType float64
+    - __kind: PointerType
+      ID: 27
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28640
+      GoKind: 22
+      Pointee: 13 BaseType int64
+    - __kind: PointerType
+      ID: 28
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 28768
+      GoKind: 22
+      Pointee: 7 BaseType int
+    - __kind: PointerType
+      ID: 29
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 28704
+      GoKind: 22
+      Pointee: 8 BaseType uint64
+    - __kind: PointerType
+      ID: 30
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 28128
+      GoKind: 22
+      Pointee: 14 GoInterfaceType error
+    - __kind: PointerType
+      ID: 31
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 29088
+      GoKind: 22
+      Pointee: 17 BaseType float32
+    - __kind: PointerType
+      ID: 32
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 28832
+      GoKind: 22
+      Pointee: 10 BaseType uint
+    - __kind: PointerType
+      ID: 33
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 28448
+      GoKind: 22
+      Pointee: 6 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 34
+      Name: string.str
+      ByteSize: 2048
+    - __kind: PointerType
+      ID: 35
+      Name: '*string.str'
+      ByteSize: 8
+      Pointee: 34 GoStringDataType string.str
+    - __kind: EventRootType
+      ID: 36
       Name: Probe[main.noop]
-MaxTypeID: 1
+MaxTypeID: 36
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -3118,3 +3118,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 268
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x1804ac0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 268 EventRootType Probe[main.HandleHTTP]
+          Type: 248 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 269 EventRootType Probe[main.LookAtTheRequest]
+          Type: 249 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0xd597c0..0xd59836
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd59848..0xd59881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 197 PointerType *bytes.Buffer
+          Type: 179 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd59958..0xd5997a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 200 StructureType context.backgroundCtx
+          Type: 182 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd597c0..0xd59a5c
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0xd59b20..0xd59b45
               Pieces:
@@ -110,247 +110,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.125248e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 399040
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.6784e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.118528e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.482688e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.044064e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 543008
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 542688
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 545888
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 542432
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 780576
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 797696
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 376128
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 545952
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 546016
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.885728e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 486112
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 202 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 398976
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.336544e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 542880
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.118976e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 636448
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 543392
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.219392e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.255712e+06
@@ -358,84 +139,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 38 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 129 GoChannelType <-chan struct {}
+          Type: 111 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 130 PointerType *net/http.Response
+          Type: 112 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 133 PointerType *net/http.pattern
+          Type: 115 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 542304
@@ -443,20 +224,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 205 PointerType *string.str
+          Type: 185 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 204 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 184 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376128
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542432
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 542880
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.00192e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.040992e+06
@@ -464,46 +264,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.141376e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469248e+06
@@ -511,120 +311,126 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 543328
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.963712e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 16
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 38 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 216 GoSliceDataType []bucket<string,[]string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 542560
       GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542688
+      GoKind: 10
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 38
+      ID: 20
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 41 ArrayType []val<[]string>
+          Type: 23 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 37 PointerType *bucket<string,[]string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 42 GoSliceHeaderType []string
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 39
+      ID: 21
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632608
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: ArrayType
-      ID: 40
+      ID: 22
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 41
+      ID: 23
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 42 GoSliceHeaderType []string
+      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 42
+      ID: 24
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 468992
@@ -632,30 +438,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 43 PointerType *string
+          Type: 25 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 207 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 187 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 25
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 376000
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 543008
+      GoKind: 12
     - __kind: PointerType
-      ID: 44
+      ID: 27
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 379904
       GoKind: 22
-      Pointee: 45 StructureType runtime.mapextra
+      Pointee: 28 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 45
+      ID: 28
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.465216e+06
@@ -663,22 +475,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 49 PointerType *runtime.bmap
+          Type: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 46
+      ID: 29
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470656
       GoKind: 22
-      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 30
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470592
@@ -686,28 +498,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **runtime.bmap
+          Type: 31 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 209 GoSliceDataType []*runtime.bmap.array
+          Type: 8 BaseType int
+      Data: 189 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 48
+      ID: 31
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 49 PointerType *runtime.bmap
+      Pointee: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 49
+      ID: 32
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137024e+06
       GoKind: 22
-      Pointee: 50 StructureType runtime.bmap
+      Pointee: 33 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 50
+      ID: 33
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.136896e+06
@@ -715,42 +527,48 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 34
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.092864e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 35
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645280
       GoKind: 19
     - __kind: BaseType
-      ID: 53
+      ID: 36
       Name: int64
       ByteSize: 8
       GoRuntimeType: 542752
       GoKind: 6
     - __kind: GoMapType
-      ID: 54
+      ID: 37
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.71184e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 55
+      ID: 38
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853728
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 39 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 56
+      ID: 39
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.325824e+06
@@ -758,96 +576,96 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 57 GoMapType map[string][]string
+          Type: 40 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 57
+      ID: 40
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899232
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 58
+      ID: 41
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904032
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 42
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 43
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 213 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 193 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
-      ID: 61
+      ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 63
+      ID: 46
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 47
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461504
@@ -855,29 +673,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType **mime/multipart.FileHeader
+          Type: 48 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 65
+      ID: 48
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 66 PointerType *mime/multipart.FileHeader
+      Pointee: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 66
+      ID: 49
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853632
       GoKind: 22
-      Pointee: 67 StructureType mime/multipart.FileHeader
+      Pointee: 50 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 67
+      ID: 50
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.88112e+06
@@ -885,34 +703,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 68 GoMapType net/textproto.MIMEHeader
+          Type: 51 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: content
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 68
+      ID: 51
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.637344e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 52
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 467840
@@ -920,23 +738,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 217 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 197 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 70
+      ID: 53
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852192
       GoKind: 22
-      Pointee: 71 StructureType crypto/tls.ConnectionState
+      Pointee: 54 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 71
+      ID: 54
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.160384e+06
@@ -944,54 +762,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 125 GoSliceHeaderType [][]uint8
+          Type: 107 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 128 BaseType crypto/tls.CurveID
+          Type: 110 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 55
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473760
@@ -999,28 +817,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **crypto/x509.Certificate
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 219 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 199 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 73
+      ID: 56
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 74 PointerType *crypto/x509.Certificate
+      Pointee: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 74
+      ID: 57
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.952864e+06
       GoKind: 22
-      Pointee: 75 StructureType crypto/x509.Certificate
+      Pointee: 58 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 75
+      ID: 58
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300416e+06
@@ -1028,179 +846,173 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+          Type: 59 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 80 PointerType *math/big.Int
+          Type: 62 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 101 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 110 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 113 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 120 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 76
+      ID: 59
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.097216e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 77
+      ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780768
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 78
+      ID: 61
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 797888
       GoKind: 20
-      UnderlyingStructure: 79 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 79
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 80
+      ID: 62
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.296864e+06
       GoKind: 22
-      Pointee: 81 StructureType math/big.Int
+      Pointee: 63 StructureType math/big.Int
     - __kind: StructureType
-      ID: 81
+      ID: 63
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340544e+06
@@ -1208,12 +1020,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 82 GoSliceHeaderType math/big.nat
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 64
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.279968e+06
@@ -1221,29 +1033,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType *math/big.Word
+          Type: 65 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 221 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 201 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 83
+      ID: 65
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403456
       GoKind: 22
-      Pointee: 84 BaseType math/big.Word
+      Pointee: 66 BaseType math/big.Word
     - __kind: BaseType
-      ID: 84
+      ID: 66
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546656
       GoKind: 7
     - __kind: StructureType
-      ID: 85
+      ID: 67
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.10512e+06
@@ -1251,39 +1063,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 68
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487136
@@ -1291,23 +1103,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417344
       GoKind: 22
-      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349024e+06
@@ -1315,12 +1127,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.037376e+06
@@ -1328,23 +1140,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *int
+          Type: 72 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 376576
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.280896e+06
@@ -1352,28 +1164,28 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 93 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: BaseType
-      ID: 92
+      ID: 74
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 542816
       GoKind: 11
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458112e+06
       GoKind: 22
-      Pointee: 94 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877376e+06
@@ -1381,27 +1193,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 95 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 98 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463104
@@ -1409,23 +1221,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 227 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 207 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370880
       GoKind: 22
-      Pointee: 97 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.45792e+06
@@ -1433,15 +1245,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463168
@@ -1449,23 +1261,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 229 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 209 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 99
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 370944
       GoKind: 22
-      Pointee: 100 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.663616e+06
@@ -1473,24 +1285,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 101
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546336
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486624
@@ -1498,23 +1310,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417536
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 104
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494592e+06
@@ -1522,15 +1334,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486688
@@ -1538,23 +1350,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037248e+06
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475040
@@ -1562,29 +1374,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400640
       GoKind: 22
-      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 109
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546400
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458240
@@ -1592,23 +1404,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 237 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 217 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 111
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.028544e+06
       GoKind: 22
-      Pointee: 112 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.000864e+06
@@ -1616,16 +1428,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 239 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 219 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486752
@@ -1633,22 +1445,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 241 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 221 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 114
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486816
@@ -1656,29 +1468,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 243 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 223 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 117 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 117
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122688e+06
       GoKind: 22
-      Pointee: 118 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 118
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.306944e+06
@@ -1686,12 +1498,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 112 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 119 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999232
@@ -1699,16 +1511,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 245 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 225 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 486880
@@ -1716,23 +1528,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 247 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 227 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.761792e+06
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762016e+06
@@ -1740,9 +1552,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473888
@@ -1750,22 +1562,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *[]*crypto/x509.Certificate
+          Type: 106 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 124
+      ID: 106
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 107
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457024
@@ -1773,47 +1585,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *[]uint8
+          Type: 108 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 251 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 231 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 126
+      ID: 108
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456768
       GoKind: 22
-      Pointee: 69 GoSliceHeaderType []uint8
+      Pointee: 52 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 127
+      ID: 109
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 982976
       GoKind: 19
     - __kind: BaseType
-      ID: 128
+      ID: 110
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778464
       GoKind: 9
     - __kind: GoChannelType
-      ID: 129
+      ID: 111
       Name: <-chan struct {}
       GoRuntimeType: 555296
       GoKind: 18
     - __kind: PointerType
-      ID: 130
+      ID: 112
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.63216e+06
       GoKind: 22
-      Pointee: 131 StructureType net/http.Response
+      Pointee: 113 StructureType net/http.Response
     - __kind: StructureType
-      ID: 131
+      ID: 113
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.123456e+06
@@ -1821,62 +1633,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 132
+      ID: 114
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215552e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.45312e+06
       GoKind: 22
-      Pointee: 134 StructureType net/http.pattern
+      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.744992e+06
@@ -1884,21 +1702,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 135 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459008
@@ -1906,23 +1724,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 136 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 253 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 136
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367808
       GoKind: 22
-      Pointee: 137 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.452928e+06
@@ -1930,99 +1748,99 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<string,string>
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<string,string>
+      Pointee: 122 GoHMapHeaderType hash<string,string>
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 122
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<string,string>
-      BucketsType: 255 GoSliceDataType []bucket<string,string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 235 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<string,string>
+      Pointee: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 124
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 143 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 141 PointerType *bucket<string,string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 27 GoStringHeaderType string
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 143
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 144
+      ID: 126
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.187104e+06
       GoKind: 22
-      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: StructureType
-      ID: 145
+      ID: 127
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.251424e+06
@@ -2030,81 +1848,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 151 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 133 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 157 GoMapType map[string]float64
+          Type: 139 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: context
           Offset: 216
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 196 GoSubroutineType func()
+          Type: 178 GoSubroutineType func()
     - __kind: StructureType
-      ID: 146
+      ID: 128
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.750592e+06
@@ -2112,21 +1930,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 147 StructureType sync.Mutex
+          Type: 129 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 147
+      ID: 129
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.313984e+06
@@ -2134,18 +1952,18 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
     - __kind: BaseType
-      ID: 148
+      ID: 130
       Name: int32
       ByteSize: 4
       GoRuntimeType: 542624
       GoKind: 5
     - __kind: StructureType
-      ID: 149
+      ID: 131
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315424e+06
@@ -2153,178 +1971,178 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 132 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
     - __kind: StructureType
-      ID: 150
+      ID: 132
       Name: sync/atomic.noCopy
       GoRuntimeType: 965792
       GoKind: 25
       RawFields: []
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.007296e+06
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 135
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<string,interface {}>
+          Type: 136 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<string,interface {}>
+          Type: 136 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 265 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 245 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 137
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 156 ArrayType []val<interface {}>
+          Type: 138 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 154 PointerType *bucket<string,interface {}>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 78 GoEmptyInterfaceType interface {}
+          Type: 136 PointerType *bucket<string,interface {}>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 61 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 156
+      ID: 138
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 78 GoEmptyInterfaceType interface {}
+      Element: 61 GoEmptyInterfaceType interface {}
     - __kind: GoMapType
-      ID: 157
+      ID: 139
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 904896
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,float64>
+      HeaderType: 141 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 158
+      ID: 140
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 159 GoHMapHeaderType hash<string,float64>
+      Pointee: 141 GoHMapHeaderType hash<string,float64>
     - __kind: GoHMapHeaderType
-      ID: 159
+      ID: 141
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 160 PointerType *bucket<string,float64>
+          Type: 142 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 160 PointerType *bucket<string,float64>
+          Type: 142 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 161 GoHMapBucketType bucket<string,float64>
-      BucketsType: 257 GoSliceDataType []bucket<string,float64>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<string,float64>
+      BucketsType: 237 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
-      ID: 160
+      ID: 142
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 161 GoHMapBucketType bucket<string,float64>
+      Pointee: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoHMapBucketType
-      ID: 161
+      ID: 143
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 162 ArrayType []val<float64>
+          Type: 144 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 160 PointerType *bucket<string,float64>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 163 BaseType float64
+          Type: 142 PointerType *bucket<string,float64>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 145 BaseType float64
     - __kind: ArrayType
-      ID: 162
+      ID: 144
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 163 BaseType float64
+      Element: 145 BaseType float64
     - __kind: BaseType
-      ID: 163
+      ID: 145
       Name: float64
       ByteSize: 8
       GoRuntimeType: 543264
       GoKind: 14
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463424
@@ -2332,23 +2150,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+          Type: 8 BaseType int
+      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.129216e+06
       GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: StructureType
-      ID: 166
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822016e+06
@@ -2356,24 +2174,24 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 149
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -2381,23 +2199,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 168
+      ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129344e+06
       GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: StructureType
-      ID: 169
+      ID: 151
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.663808e+06
@@ -2405,102 +2223,102 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 170 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 186 GoMapType map[string]interface {}
+          Type: 168 GoMapType map[string]interface {}
     - __kind: GoMapType
-      ID: 170
+      ID: 152
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 904992
       GoKind: 21
-      HeaderType: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 171
+      ID: 153
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoHMapHeaderType
-      ID: 172
+      ID: 154
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 262 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 242 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
-      ID: 173
+      ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoHMapBucketType
-      ID: 174
+      ID: 156
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 175 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 175
+      ID: 157
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130112e+06
       GoKind: 22
-      Pointee: 177 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 177
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822272e+06
@@ -2508,37 +2326,37 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 178 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 163 BaseType float64
+          Type: 145 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 178
+      ID: 160
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965024
       GoKind: 5
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.129984e+06
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: StructureType
-      ID: 180
+      ID: 162
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.129856e+06
@@ -2546,9 +2364,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 181 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 163
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463488
@@ -2556,29 +2374,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 182
+      ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 183
+      ID: 165
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129728e+06
       GoKind: 22
-      Pointee: 184 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 184
+      ID: 166
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.747904e+06
@@ -2586,41 +2404,41 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 185 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 163 BaseType float64
+          Type: 145 BaseType float64
     - __kind: BaseType
-      ID: 185
+      ID: 167
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965120
       GoKind: 5
     - __kind: GoMapType
-      ID: 186
+      ID: 168
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896352
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.916704e+06
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: StructureType
-      ID: 188
+      ID: 170
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.1248e+06
@@ -2628,55 +2446,55 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 195 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 177 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.131968e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.01696e+06
@@ -2684,36 +2502,36 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 191 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: full
           Offset: 72
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 193 PointerType *float64
+          Type: 175 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 176 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 191
+      ID: 173
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 463872
@@ -2721,57 +2539,57 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 192 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+          Type: 8 BaseType int
+      Data: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 192
+      ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 376960
       GoKind: 22
-      Pointee: 163 BaseType float64
+      Pointee: 145 BaseType float64
     - __kind: BaseType
-      ID: 194
+      ID: 176
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542112
       GoKind: 10
     - __kind: ArrayType
-      ID: 195
+      ID: 177
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847584
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: GoSubroutineType
-      ID: 196
+      ID: 178
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455360
       GoKind: 19
     - __kind: PointerType
-      ID: 197
+      ID: 179
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.17632e+06
       GoKind: 22
-      Pointee: 198 StructureType bytes.Buffer
+      Pointee: 180 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 198
+      ID: 180
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.450816e+06
@@ -2779,365 +2597,355 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 199 BaseType bytes.readOp
+          Type: 181 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 199
+      ID: 181
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541536
       GoKind: 3
     - __kind: StructureType
-      ID: 200
+      ID: 182
       Name: context.backgroundCtx
       GoRuntimeType: 1.708256e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 201 StructureType context.emptyCtx
+          Type: 183 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 201
+      ID: 183
       Name: context.emptyCtx
       GoRuntimeType: 1.43472e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 204
+      ID: 184
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 205
+      ID: 185
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 204 GoStringDataType string.str
+      Pointee: 184 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 186
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 187
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 208
+      ID: 188
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []string.array
+      Pointee: 187 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 189
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 49 PointerType *runtime.bmap
+      Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 210
+      ID: 190
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []*runtime.bmap.array
+      Pointee: 189 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 191
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 192
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 193
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 194
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 66 PointerType *mime/multipart.FileHeader
+      Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 215
+      ID: 195
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 194 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 197
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 218
+      ID: 198
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []uint8.array
+      Pointee: 197 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 199
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 PointerType *crypto/x509.Certificate
+      Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 220
+      ID: 200
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 199 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 201
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 84 BaseType math/big.Word
+      Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 222
+      ID: 202
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType math/big.nat.array
+      Pointee: 201 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 203
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 224
+      ID: 204
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 205
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 226
+      ID: 206
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 207
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 97 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 228
+      ID: 208
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []time.zone.array
+      Pointee: 207 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 209
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 100 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 230
+      ID: 210
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []time.zoneTrans.array
+      Pointee: 209 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 211
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 232
+      ID: 212
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 213
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 234
+      ID: 214
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 215
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 109 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 236
+      ID: 216
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 217
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 112 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 238
+      ID: 218
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []net.IP.array
+      Pointee: 217 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 219
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 240
+      ID: 220
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType net.IP.array
+      Pointee: 219 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 221
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 242
+      ID: 222
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*net/url.URL.array
+      Pointee: 221 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 223
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 117 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 244
+      ID: 224
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*net.IPNet.array
+      Pointee: 223 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 225
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 246
+      ID: 226
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType net.IPMask.array
+      Pointee: 225 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 227
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 248
+      ID: 228
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 227 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 229
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 250
+      ID: 230
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 231
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 69 GoSliceHeaderType []uint8
+      Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 252
+      ID: 232
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType [][]uint8.array
+      Pointee: 231 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 233
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 137 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 254
+      ID: 234
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType []net/http.segment.array
+      Pointee: 233 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 235
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<string,string>
+      Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<string,interface {}>
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 237
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 161 GoHMapBucketType bucket<string,float64>
+      Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 238
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 259
+      ID: 239
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 261
+      ID: 241
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 243
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 264
+      ID: 244
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 245
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<string,interface {}>
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 267
+      ID: 247
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 268
+      ID: 248
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3154,14 +2962,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 249
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3169,11 +2977,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 269
+MaxTypeID: 249
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 248 EventRootType Probe[main.HandleHTTP]
+          Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd597d3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 249 EventRootType Probe[main.LookAtTheRequest]
+          Type: 268 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd59b2e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -224,11 +224,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 185 PointerType *string.str
+          Type: 204 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 184 GoStringDataType string.str
+      Data: 203 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -369,7 +369,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 215 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -445,7 +445,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []string.array
+      Data: 206 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 25
       Name: '*string'
@@ -505,7 +505,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType []*runtime.bmap.array
+      Data: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 31
       Name: '**runtime.bmap'
@@ -632,7 +632,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 193 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 212 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -680,7 +680,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 213 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -745,7 +745,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []uint8.array
+      Data: 216 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -824,7 +824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 218 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1040,7 +1040,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType math/big.nat.array
+      Data: 220 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1110,7 +1110,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1147,7 +1147,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1228,7 +1228,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType []time.zone.array
+      Data: 226 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1268,7 +1268,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 209 GoSliceDataType []time.zoneTrans.array
+      Data: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1357,7 +1357,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1381,7 +1381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1411,7 +1411,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 217 GoSliceDataType []net.IP.array
+      Data: 236 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1435,7 +1435,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 219 GoSliceDataType net.IP.array
+      Data: 238 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 221 GoSliceDataType []*net/url.URL.array
+      Data: 240 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1475,7 +1475,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 223 GoSliceDataType []*net.IPNet.array
+      Data: 242 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1518,7 +1518,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 225 GoSliceDataType net.IPMask.array
+      Data: 244 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1535,7 +1535,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509.OID.array
+      Data: 246 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1569,7 +1569,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1592,7 +1592,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 231 GoSliceDataType [][]uint8.array
+      Data: 250 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1731,7 +1731,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 233 GoSliceDataType []net/http.segment.array
+      Data: 252 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1800,7 +1800,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 235 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 254 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2026,7 +2026,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 245 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 264 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<string,interface {}>'
@@ -2103,7 +2103,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 237 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 256 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
       ID: 142
       Name: '*bucket<string,float64>'
@@ -2157,7 +2157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2206,7 +2206,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2278,7 +2278,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 242 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketsType: 261 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
       ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
@@ -2381,7 +2381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2546,7 +2546,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2625,327 +2625,460 @@ Types:
       GoRuntimeType: 1.43472e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 184
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 377024
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 185
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 376704
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: BaseType
+      ID: 186
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 542368
+      GoKind: 3
+    - __kind: BaseType
+      ID: 187
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 542944
+      GoKind: 7
+    - __kind: BaseType
+      ID: 188
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 543200
+      GoKind: 13
+    - __kind: GoInterfaceType
+      ID: 189
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.01088e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 190
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 376320
+      GoKind: 22
+      Pointee: 130 BaseType int32
+    - __kind: PointerType
+      ID: 191
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 376384
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: BaseType
+      ID: 192
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 543072
+      GoKind: 15
+    - __kind: BaseType
+      ID: 193
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 543136
+      GoKind: 16
+    - __kind: PointerType
+      ID: 194
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 376448
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 195
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 376512
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 196
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 376256
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 197
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 376192
+      GoKind: 22
+      Pointee: 198 BaseType int16
+    - __kind: BaseType
+      ID: 198
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 542496
+      GoKind: 4
+    - __kind: PointerType
+      ID: 199
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 376064
+      GoKind: 22
+      Pointee: 186 BaseType int8
+    - __kind: PointerType
+      ID: 200
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 375936
+      GoKind: 22
+      Pointee: 189 GoInterfaceType error
+    - __kind: PointerType
+      ID: 201
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 376640
+      GoKind: 22
+      Pointee: 187 BaseType uint
+    - __kind: PointerType
+      ID: 202
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 376896
+      GoKind: 22
+      Pointee: 188 BaseType float32
+    - __kind: GoStringDataType
+      ID: 203
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 185
+      ID: 204
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 184 GoStringDataType string.str
+      Pointee: 203 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 206
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 188
+      ID: 207
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []string.array
+      Pointee: 206 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 208
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 190
+      ID: 209
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*runtime.bmap.array
+      Pointee: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 210
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 211
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 212
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 213
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 195
+      ID: 214
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 213 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 215
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 216
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 198
+      ID: 217
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []uint8.array
+      Pointee: 216 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 218
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 219
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 218 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 220
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 202
+      ID: 221
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType math/big.nat.array
+      Pointee: 220 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 222
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 204
+      ID: 223
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 224
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 206
+      ID: 225
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 226
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 208
+      ID: 227
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []time.zone.array
+      Pointee: 226 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 228
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 210
+      ID: 229
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []time.zoneTrans.array
+      Pointee: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 230
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 212
+      ID: 231
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 232
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 214
+      ID: 233
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 234
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 216
+      ID: 235
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 236
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 218
+      ID: 237
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []net.IP.array
+      Pointee: 236 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 238
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 220
+      ID: 239
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType net.IP.array
+      Pointee: 238 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 240
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 222
+      ID: 241
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType []*net/url.URL.array
+      Pointee: 240 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 242
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 224
+      ID: 243
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []*net.IPNet.array
+      Pointee: 242 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 244
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 226
+      ID: 245
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType net.IPMask.array
+      Pointee: 244 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 246
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 228
+      ID: 247
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 246 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 248
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 230
+      ID: 249
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 250
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 232
+      ID: 251
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType [][]uint8.array
+      Pointee: 250 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 252
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 234
+      ID: 253
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []net/http.segment.array
+      Pointee: 252 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 254
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 255
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 256
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 257
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 239
+      ID: 258
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 259
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 241
+      ID: 260
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 261
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
       Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 262
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 244
+      ID: 263
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 264
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 265
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 247
+      ID: 266
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 248
+      ID: 267
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2969,7 +3102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 249
+      ID: 268
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2983,5 +3116,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 249
+MaxTypeID: 268
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 284 EventRootType Probe[main.HandleHTTP]
+          Type: 303 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 285 EventRootType Probe[main.LookAtTheRequest]
+          Type: 304 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -224,11 +224,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 211 PointerType *string.str
+          Type: 230 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 210 GoStringDataType string.str
+      Data: 229 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -366,7 +366,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -433,7 +433,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -490,7 +490,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 214 GoSliceDataType []string.array
+      Data: 233 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 29
       Name: '*string'
@@ -599,7 +599,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 239 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -648,7 +648,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -705,7 +705,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 222 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 241 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -770,7 +770,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 226 GoSliceDataType []uint8.array
+      Data: 245 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -849,7 +849,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 228 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 247 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1087,7 +1087,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 230 GoSliceDataType math/big.nat.array
+      Data: 249 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1157,7 +1157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1194,7 +1194,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1269,7 +1269,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 236 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1309,7 +1309,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1358,7 +1358,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1398,7 +1398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1422,7 +1422,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []net.IP.array
+      Data: 265 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1476,7 +1476,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType net.IP.array
+      Data: 267 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1493,7 +1493,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType []*net/url.URL.array
+      Data: 269 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1516,7 +1516,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType []*net.IPNet.array
+      Data: 271 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1559,7 +1559,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 254 GoSliceDataType net.IPMask.array
+      Data: 273 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1576,7 +1576,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.OID.array
+      Data: 275 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1610,7 +1610,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1647,7 +1647,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1670,7 +1670,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType [][]uint8.array
+      Data: 281 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1809,7 +1809,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 264 GoSliceDataType []net/http.segment.array
+      Data: 283 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1875,7 +1875,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 285 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1924,7 +1924,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 286 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2181,7 +2181,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 299 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 147
@@ -2230,7 +2230,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 300 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 151
       Name: '*noalg.map.group[string]interface {}'
@@ -2313,7 +2313,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 270 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,float64>.array
       GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 158
@@ -2362,7 +2362,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 162
       Name: '*noalg.map.group[string]float64'
@@ -2425,7 +2425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2474,7 +2474,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2543,7 +2543,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 295 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 176
@@ -2592,7 +2592,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2704,7 +2704,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2869,7 +2869,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2948,377 +2948,510 @@ Types:
       GoRuntimeType: 1.618752e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 210
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 402720
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: GoInterfaceType
+      ID: 211
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.049984e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 212
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 590432
+      GoKind: 3
+    - __kind: BaseType
+      ID: 213
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 591008
+      GoKind: 7
+    - __kind: BaseType
+      ID: 214
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 591264
+      GoKind: 13
+    - __kind: PointerType
+      ID: 215
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 402400
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: PointerType
+      ID: 216
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 402016
+      GoKind: 22
+      Pointee: 140 BaseType int32
+    - __kind: PointerType
+      ID: 217
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 402080
+      GoKind: 22
+      Pointee: 141 BaseType uint32
+    - __kind: BaseType
+      ID: 218
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 591136
+      GoKind: 15
+    - __kind: BaseType
+      ID: 219
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 591200
+      GoKind: 16
+    - __kind: PointerType
+      ID: 220
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 402144
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 221
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 402208
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 222
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 401952
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 223
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 401888
+      GoKind: 22
+      Pointee: 224 BaseType int16
+    - __kind: BaseType
+      ID: 224
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 590560
+      GoKind: 4
+    - __kind: PointerType
+      ID: 225
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 401760
+      GoKind: 22
+      Pointee: 212 BaseType int8
+    - __kind: PointerType
+      ID: 226
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 401632
+      GoKind: 22
+      Pointee: 211 GoInterfaceType error
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 402336
+      GoKind: 22
+      Pointee: 213 BaseType uint
+    - __kind: PointerType
+      ID: 228
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 402592
+      GoKind: 22
+      Pointee: 214 BaseType float32
+    - __kind: GoStringDataType
+      ID: 229
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 211
+      ID: 230
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 210 GoStringDataType string.str
+      Pointee: 229 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 233
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 215
+      ID: 234
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []string.array
+      Pointee: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 235
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 236
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 237
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 238
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 239
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 240
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 241
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 223
+      ID: 242
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 241 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 243
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 244
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 245
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 227
+      ID: 246
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []uint8.array
+      Pointee: 245 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 247
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 229
+      ID: 248
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 247 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 249
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 231
+      ID: 250
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType math/big.nat.array
+      Pointee: 249 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 251
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 233
+      ID: 252
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 253
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 235
+      ID: 254
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 255
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 237
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 257
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 239
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 259
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 241
+      ID: 260
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 261
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 243
+      ID: 262
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 263
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 245
+      ID: 264
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 265
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 247
+      ID: 266
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []net.IP.array
+      Pointee: 265 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 267
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 249
+      ID: 268
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType net.IP.array
+      Pointee: 267 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 269
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 251
+      ID: 270
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []*net/url.URL.array
+      Pointee: 269 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 271
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 253
+      ID: 272
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []*net.IPNet.array
+      Pointee: 271 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 273
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 255
+      ID: 274
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType net.IPMask.array
+      Pointee: 273 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 275
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 257
+      ID: 276
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 275 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 277
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 259
+      ID: 278
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 279
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 261
+      ID: 280
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 281
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 263
+      ID: 282
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType [][]uint8.array
+      Pointee: 281 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 283
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 265
+      ID: 284
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []net/http.segment.array
+      Pointee: 283 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 285
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 286
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 287
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 288
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 289
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 290
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 291
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 273
+      ID: 292
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 293
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 275
+      ID: 294
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 295
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 296
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 297
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 279
+      ID: 298
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 299
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 300
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 301
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 283
+      ID: 302
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 284
+      ID: 303
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3342,7 +3475,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 304
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3356,5 +3489,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 285
+MaxTypeID: 304
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 304 EventRootType Probe[main.HandleHTTP]
+          Type: 284 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd31373", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 305 EventRootType Probe[main.LookAtTheRequest]
+          Type: 285 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd316ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0xd31360..0xd313d6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0xd313e8..0xd31421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 223 PointerType *bytes.Buffer
+          Type: 205 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd314f7..0xd31512
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 226 StructureType context.backgroundCtx
+          Type: 208 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd31360..0xd315f9
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0xd316c0..0xd316e5
               Pieces:
@@ -110,247 +110,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.206848e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 425184
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.795904e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.255488e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.66736e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.1768e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 591072
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 590752
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 593952
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 590496
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 846048
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 862016
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 401824
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 594016
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 594080
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 2.014656e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 517696
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 228 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 425120
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.512512e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 590944
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.255936e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 692032
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 591456
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.360384e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.398144e+06
@@ -358,84 +139,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 49 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 52 PointerType *mime/multipart.Form
+          Type: 34 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 114 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 115 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 118 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 590368
@@ -443,20 +224,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 231 PointerType *string.str
+          Type: 211 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 230 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 210 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 401824
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 590496
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 590944
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.16048e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.173728e+06
@@ -464,46 +264,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.222208e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653536e+06
@@ -511,130 +311,136 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 591392
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.148192e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 35
+      ID: 16
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 37 PointerType **table<string,[]string>
+          Type: 19 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 43 StructureType noalg.map.group[string][]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 590880
       GoKind: 11
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 591072
+      GoKind: 12
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 38 PointerType *table<string,[]string>
+      Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 38
+      ID: 20
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 39 StructureType table<string,[]string>
+      Pointee: 21 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 39
+      ID: 21
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 41 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: BaseType
-      ID: 40
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 590624
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 41
+      ID: 23
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 42 PointerType *noalg.map.group[string][]string
+          Type: 24 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 43 StructureType noalg.map.group[string][]string
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 42
+      ID: 24
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 43 StructureType noalg.map.group[string][]string
+      Pointee: 25 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 43
+      ID: 25
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.312128e+06
@@ -642,21 +448,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 44 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 44
+      ID: 26
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 45 StructureType noalg.struct { key string; elem []string }
+      Element: 27 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 45
+      ID: 27
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.312e+06
@@ -664,12 +470,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 46
+      ID: 28
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498176
@@ -677,56 +483,62 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 47 PointerType *string
+          Type: 29 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 234 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 214 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 47
+      ID: 29
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 401696
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 30
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.130304e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 49
+      ID: 31
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701280
       GoKind: 19
     - __kind: BaseType
-      ID: 50
+      ID: 32
       Name: int64
       ByteSize: 8
       GoRuntimeType: 590816
       GoKind: 6
     - __kind: GoMapType
-      ID: 51
+      ID: 33
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.9208e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 52
+      ID: 34
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920960
       GoKind: 22
-      Pointee: 53 StructureType mime/multipart.Form
+      Pointee: 35 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 53
+      ID: 35
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.501472e+06
@@ -734,116 +546,116 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 54 GoMapType map[string][]string
+          Type: 36 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 55 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 54
+      ID: 36
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.148352e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 55
+      ID: 37
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.15296e+06
       GoKind: 21
-      HeaderType: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 56
+      ID: 38
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapHeaderType
-      ID: 57
+      ID: 39
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 58 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 220 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 40
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 41
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 60
+      ID: 42
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 61 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapGroupsType
-      ID: 61
+      ID: 43
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 62 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 62
+      ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 63
+      ID: 45
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.3216e+06
@@ -851,21 +663,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 64 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 64
+      ID: 46
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707328
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 65 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 65
+      ID: 47
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.321472e+06
@@ -873,12 +685,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 66 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 48
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 489088
@@ -886,29 +698,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType **mime/multipart.FileHeader
+          Type: 49 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 242 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 222 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 67
+      ID: 49
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 68 PointerType *mime/multipart.FileHeader
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 68
+      ID: 50
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920864
       GoKind: 22
-      Pointee: 69 StructureType mime/multipart.FileHeader
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 69
+      ID: 51
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.010048e+06
@@ -916,34 +728,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 70 GoMapType net/textproto.MIMEHeader
+          Type: 52 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: content
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 70
+      ID: 52
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.85488e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 53
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 497024
@@ -951,23 +763,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 246 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 226 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 72
+      ID: 54
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 919424
       GoKind: 22
-      Pointee: 73 StructureType crypto/tls.ConnectionState
+      Pointee: 55 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 73
+      ID: 55
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.302368e+06
@@ -975,54 +787,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 74 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 110 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 113 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 74
+      ID: 56
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -1030,29 +842,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 75 PointerType **crypto/x509.Certificate
+          Type: 57 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 228 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 75
+      ID: 57
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 PointerType *crypto/x509.Certificate
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 76
+      ID: 58
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.082688e+06
       GoKind: 22
-      Pointee: 77 StructureType crypto/x509.Certificate
+      Pointee: 59 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 77
+      ID: 59
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.453248e+06
@@ -1060,200 +872,194 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 78 BaseType crypto/x509.SignatureAlgorithm
+          Type: 60 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 79 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 82 PointerType *math/big.Int
+          Type: 63 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 102 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 108 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 111 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 114 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 121 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 124 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 78
+      ID: 60
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134784e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 79
+      ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 846240
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 80
+      ID: 62
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863648
       GoKind: 20
-      UnderlyingStructure: 81 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 81
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 82
+      ID: 63
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440832e+06
       GoKind: 22
-      Pointee: 83 StructureType math/big.Int
+      Pointee: 64 StructureType math/big.Int
     - __kind: StructureType
-      ID: 83
+      ID: 64
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.518112e+06
@@ -1261,12 +1067,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 84 GoSliceHeaderType math/big.nat
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 65
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.4216e+06
@@ -1274,29 +1080,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *math/big.Word
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 250 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 230 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 85
+      ID: 66
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429856
       GoKind: 22
-      Pointee: 86 BaseType math/big.Word
+      Pointee: 67 BaseType math/big.Word
     - __kind: BaseType
-      ID: 86
+      ID: 67
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594656
       GoKind: 7
     - __kind: StructureType
-      ID: 87
+      ID: 68
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.241664e+06
@@ -1304,39 +1110,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 69
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519168
@@ -1344,23 +1150,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 89
+      ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443680
       GoKind: 22
-      Pointee: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 90
+      ID: 71
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.527392e+06
@@ -1368,12 +1174,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.075328e+06
@@ -1381,23 +1187,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *int
+          Type: 73 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 254 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 92
+      ID: 73
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 402272
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 93
+      ID: 74
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.424416e+06
@@ -1405,22 +1211,22 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 94 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: PointerType
-      ID: 94
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642784e+06
       GoKind: 22
-      Pointee: 95 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 95
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.006016e+06
@@ -1428,27 +1234,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 96 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 99 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 491072
@@ -1456,23 +1262,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 256 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 236 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 97
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 98 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.642592e+06
@@ -1480,15 +1286,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491136
@@ -1496,23 +1302,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 258 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 238 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 100
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396704
       GoKind: 22
-      Pointee: 101 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 101
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.781504e+06
@@ -1520,24 +1326,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 102
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594400
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1545,23 +1351,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 104
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443872
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 105
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678688e+06
@@ -1569,15 +1375,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1585,23 +1391,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 262 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 107
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.0752e+06
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505280
@@ -1609,29 +1415,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 264 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 109
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 110 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 110
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484896
@@ -1639,23 +1445,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 266 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 246 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 112
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.198272e+06
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.17104e+06
@@ -1663,16 +1469,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 268 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 248 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1680,22 +1486,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 270 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 250 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 115
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1703,29 +1509,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 272 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 252 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 117
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 118 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.204416e+06
       GoKind: 22
-      Pointee: 119 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 119
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.482432e+06
@@ -1733,12 +1539,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 113 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 120 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.03808e+06
@@ -1746,16 +1552,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 274 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518656
@@ -1763,23 +1569,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 276 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 122
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.989632e+06
       GoKind: 22
-      Pointee: 123 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 123
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989888e+06
@@ -1787,9 +1593,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 105
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518720
@@ -1797,23 +1603,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.PolicyMapping
+          Type: 106 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.PolicyMapping.array
+          Type: 8 BaseType int
+      Data: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 125
+      ID: 106
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426976
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.PolicyMapping
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
     - __kind: StructureType
-      ID: 126
+      ID: 107
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.515072e+06
@@ -1821,12 +1627,12 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 108
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503936
@@ -1834,22 +1640,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 109 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 280 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 128
+      ID: 109
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 110
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483936
@@ -1857,47 +1663,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 111 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 282 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 262 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 130
+      ID: 111
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483552
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType []uint8
+      Pointee: 53 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 112
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020736e+06
       GoKind: 19
     - __kind: BaseType
-      ID: 132
+      ID: 113
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843936
       GoKind: 9
     - __kind: GoChannelType
-      ID: 133
+      ID: 114
       Name: <-chan struct {}
       GoRuntimeType: 603424
       GoKind: 18
     - __kind: PointerType
-      ID: 134
+      ID: 115
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.751392e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 116 StructureType net/http.Response
     - __kind: StructureType
-      ID: 135
+      ID: 116
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.260416e+06
@@ -1905,62 +1711,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 117
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298688e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 137
+      ID: 118
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.637792e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 138
+      ID: 119
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.866368e+06
@@ -1968,21 +1780,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 120 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 120
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486528
@@ -1990,23 +1802,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 121 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 284 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 264 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 121
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393504
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
-      ID: 141
+      ID: 122
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.6376e+06
@@ -2014,112 +1826,112 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.149376e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 286 GoSliceDataType []*table<string,string>.array
-      GroupType: 150 StructureType noalg.map.group[string]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 145
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 146
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 147 StructureType table<string,string>
+      Pointee: 128 StructureType table<string,string>
     - __kind: StructureType
-      ID: 147
+      ID: 128
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,string>
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
     - __kind: GoSwissMapGroupsType
-      ID: 148
+      ID: 129
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]string
+          Type: 130 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]string
-      GroupSliceType: 287 GoSliceDataType []noalg.map.group[string]string.array
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
-      ID: 149
+      ID: 130
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]string
+      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 150
+      ID: 131
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.314432e+06
@@ -2127,21 +1939,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: ArrayType
-      ID: 151
+      ID: 132
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem string }
+      Element: 133 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 152
+      ID: 133
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.314304e+06
@@ -2149,19 +1961,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 153
+      ID: 134
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.32752e+06
       GoKind: 22
-      Pointee: 154 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: StructureType
-      ID: 154
+      ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.39312e+06
@@ -2169,81 +1981,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 162 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 144 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 173 GoMapType map[string]float64
+          Type: 155 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 185 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 170 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: context
           Offset: 216
-          Type: 213 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 195 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 222 GoSubroutineType func()
+          Type: 204 GoSubroutineType func()
     - __kind: StructureType
-      ID: 155
+      ID: 136
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.872192e+06
@@ -2251,21 +2063,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 156 StructureType sync.Mutex
+          Type: 137 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 156
+      ID: 137
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.489632e+06
@@ -2273,18 +2085,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync.noCopy
+          Type: 138 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 158 StructureType internal/sync.Mutex
+          Type: 139 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 138
       Name: sync.noCopy
       GoRuntimeType: 1.003072e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 158
+      ID: 139
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.512992e+06
@@ -2292,18 +2104,24 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
     - __kind: BaseType
-      ID: 159
+      ID: 140
       Name: int32
       ByteSize: 4
       GoRuntimeType: 590688
       GoKind: 5
+    - __kind: BaseType
+      ID: 141
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 590752
+      GoKind: 10
     - __kind: StructureType
-      ID: 160
+      ID: 142
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.490912e+06
@@ -2311,115 +2129,115 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 161 StructureType sync/atomic.noCopy
+          Type: 143 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
     - __kind: StructureType
-      ID: 161
+      ID: 143
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.003168e+06
       GoKind: 25
       RawFields: []
     - __kind: GoMapType
-      ID: 162
+      ID: 144
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299968e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 163
+      ID: 145
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 146
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<string,interface {}>
+          Type: 147 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 300 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 170 StructureType noalg.map.group[string]interface {}
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<string,interface {}>
+      Pointee: 148 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 166
+      ID: 148
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 StructureType table<string,interface {}>
+      Pointee: 149 StructureType table<string,interface {}>
     - __kind: StructureType
-      ID: 167
+      ID: 149
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 150
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[string]interface {}
+          Type: 151 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 301 GoSliceDataType []noalg.map.group[string]interface {}.array
+          Type: 17 BaseType uint64
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
-      ID: 169
+      ID: 151
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[string]interface {}
+      Pointee: 152 StructureType noalg.map.group[string]interface {}
     - __kind: StructureType
-      ID: 170
+      ID: 152
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.309568e+06
@@ -2427,21 +2245,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 171
+      ID: 153
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688768
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key string; elem interface {} }
+      Element: 154 StructureType noalg.struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 172
+      ID: 154
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.30944e+06
@@ -2449,109 +2267,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoMapType
-      ID: 173
+      ID: 155
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.1536e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 174
+      ID: 156
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,float64>
+      Pointee: 157 GoSwissMapHeaderType map<string,float64>
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 157
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,float64>
+          Type: 158 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<string,float64>.array
-      GroupType: 181 StructureType noalg.map.group[string]float64
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 270 GoSliceDataType []*table<string,float64>.array
+      GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,float64>
+      Pointee: 159 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 177
+      ID: 159
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 178 StructureType table<string,float64>
+      Pointee: 160 StructureType table<string,float64>
     - __kind: StructureType
-      ID: 178
+      ID: 160
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 161
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]float64
+          Type: 162 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]float64
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[string]float64.array
+          Type: 17 BaseType uint64
+      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
-      ID: 180
+      ID: 162
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]float64
+      Pointee: 163 StructureType noalg.map.group[string]float64
     - __kind: StructureType
-      ID: 181
+      ID: 163
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.327616e+06
@@ -2559,21 +2377,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 182
+      ID: 164
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711808
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem float64 }
+      Element: 165 StructureType noalg.struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 183
+      ID: 165
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.327488e+06
@@ -2581,18 +2399,18 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
     - __kind: BaseType
-      ID: 184
+      ID: 166
       Name: float64
       ByteSize: 8
       GoRuntimeType: 591328
       GoKind: 14
     - __kind: GoSliceHeaderType
-      ID: 185
+      ID: 167
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -2600,23 +2418,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 186 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+          Type: 8 BaseType int
+      Data: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 186
+      ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210688e+06
       GoKind: 22
-      Pointee: 187 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: StructureType
-      ID: 187
+      ID: 169
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.947136e+06
@@ -2624,24 +2442,24 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
     - __kind: GoSliceHeaderType
-      ID: 188
+      ID: 170
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491712
@@ -2649,23 +2467,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 294 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+          Type: 8 BaseType int
+      Data: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210816e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781696e+06
@@ -2673,115 +2491,115 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 191 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 212 GoMapType map[string]interface {}
+          Type: 194 GoMapType map[string]interface {}
     - __kind: GoMapType
-      ID: 191
+      ID: 173
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153728e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 192
+      ID: 174
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 175
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 296 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 276 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 194
+      ID: 176
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 195
+      ID: 177
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 196
+      ID: 178
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 179
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 297 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+          Type: 17 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
-      ID: 198
+      ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 199
+      ID: 181
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.327872e+06
@@ -2789,21 +2607,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 200
+      ID: 182
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 201
+      ID: 183
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327744e+06
@@ -2811,19 +2629,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 202
+      ID: 184
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211584e+06
       GoKind: 22
-      Pointee: 203 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 203
+      ID: 185
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.947392e+06
@@ -2831,37 +2649,37 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 204 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 204
+      ID: 186
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.0024e+06
       GoKind: 5
     - __kind: PointerType
-      ID: 205
+      ID: 187
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.211456e+06
       GoKind: 22
-      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: StructureType
-      ID: 206
+      ID: 188
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.211328e+06
@@ -2869,9 +2687,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 207 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 189
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -2879,29 +2697,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 298 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+          Type: 8 BaseType int
+      Data: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 208
+      ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 209
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.2112e+06
       GoKind: 22
-      Pointee: 210 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.869504e+06
@@ -2909,41 +2727,41 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 211 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
     - __kind: BaseType
-      ID: 211
+      ID: 193
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.002496e+06
       GoKind: 5
     - __kind: GoMapType
-      ID: 212
+      ID: 194
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146944e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 213
+      ID: 195
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.046208e+06
       GoKind: 22
-      Pointee: 214 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: StructureType
-      ID: 214
+      ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.26176e+06
@@ -2951,55 +2769,55 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 197 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 221 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 203 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 185 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: PointerType
-      ID: 215
+      ID: 197
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.27024e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: StructureType
-      ID: 216
+      ID: 198
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.148896e+06
@@ -3007,36 +2825,36 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 217 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 199 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: full
           Offset: 72
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 219 PointerType *float64
+          Type: 201 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 199
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491968
@@ -3044,57 +2862,57 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 302 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+          Type: 8 BaseType int
+      Data: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 218
+      ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 219
+      ID: 201
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 402656
       GoKind: 22
-      Pointee: 184 BaseType float64
+      Pointee: 166 BaseType float64
     - __kind: BaseType
-      ID: 220
+      ID: 202
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 590176
       GoKind: 10
     - __kind: ArrayType
-      ID: 221
+      ID: 203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914912
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: GoSubroutineType
-      ID: 222
+      ID: 204
       Name: func()
       ByteSize: 8
       GoRuntimeType: 482080
       GoKind: 19
     - __kind: PointerType
-      ID: 223
+      ID: 205
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316768e+06
       GoKind: 22
-      Pointee: 224 StructureType bytes.Buffer
+      Pointee: 206 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 224
+      ID: 206
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.635488e+06
@@ -3102,415 +2920,405 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 225 BaseType bytes.readOp
+          Type: 207 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 225
+      ID: 207
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589536
       GoKind: 3
     - __kind: StructureType
-      ID: 226
+      ID: 208
       Name: context.backgroundCtx
       GoRuntimeType: 1.827296e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 227 StructureType context.emptyCtx
+          Type: 209 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 227
+      ID: 209
       Name: context.emptyCtx
       GoRuntimeType: 1.618752e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 228
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 229
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 228 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 230
+      ID: 210
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 231
+      ID: 211
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 230 GoStringDataType string.str
+      Pointee: 210 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 212
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 213
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 214
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 235
+      ID: 215
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []string.array
+      Pointee: 214 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 216
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 217
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 218
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 219
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 220
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 221
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 222
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 68 PointerType *mime/multipart.FileHeader
+      Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 243
+      ID: 223
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 222 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 226
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 247
+      ID: 227
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []uint8.array
+      Pointee: 226 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 228
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 76 PointerType *crypto/x509.Certificate
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 229
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 228 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 230
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 86 BaseType math/big.Word
+      Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 251
+      ID: 231
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType math/big.nat.array
+      Pointee: 230 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 232
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 253
+      ID: 233
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 234
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 255
+      ID: 235
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 98 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 257
+      ID: 237
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zone.array
+      Pointee: 236 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 238
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 259
+      ID: 239
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []time.zoneTrans.array
+      Pointee: 238 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 261
+      ID: 241
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 263
+      ID: 243
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 244
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 110 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 265
+      ID: 245
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 267
+      ID: 247
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []net.IP.array
+      Pointee: 246 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 248
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 269
+      ID: 249
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType net.IP.array
+      Pointee: 248 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 250
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 271
+      ID: 251
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []*net/url.URL.array
+      Pointee: 250 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 252
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 118 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 273
+      ID: 253
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []*net.IPNet.array
+      Pointee: 252 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 254
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 275
+      ID: 255
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType net.IPMask.array
+      Pointee: 254 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 256
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 123 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 277
+      ID: 257
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 256 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 258
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.PolicyMapping
+      Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 279
+      ID: 259
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 260
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 281
+      ID: 261
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 262
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType []uint8
+      Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 283
+      ID: 263
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType [][]uint8.array
+      Pointee: 262 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 264
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 285
+      ID: 265
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []net/http.segment.array
+      Pointee: 264 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 266
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 267
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]string
+      Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 268
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 269
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[string]interface {}
+      Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 270
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<string,float64>
+      Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 271
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]float64
+      Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 272
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 187 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 293
+      ID: 273
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 274
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 295
+      ID: 275
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 276
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 277
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 278
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 299
+      ID: 279
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[string]interface {}
+      Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 282
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 303
+      ID: 283
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3527,14 +3335,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3542,11 +3350,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 305
+MaxTypeID: 285
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=amd64,toolchain=go1.24.3.yaml
@@ -3491,3 +3491,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 304
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x18b56e0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -3117,3 +3117,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 268
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x137dc20", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 248 EventRootType Probe[main.HandleHTTP]
+          Type: 267 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 249 EventRootType Probe[main.LookAtTheRequest]
+          Type: 268 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -224,11 +224,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 185 PointerType *string.str
+          Type: 204 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 184 GoStringDataType string.str
+      Data: 203 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -369,7 +369,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 215 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -445,7 +445,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 187 GoSliceDataType []string.array
+      Data: 206 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 25
       Name: '*string'
@@ -505,7 +505,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 189 GoSliceDataType []*runtime.bmap.array
+      Data: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 31
       Name: '**runtime.bmap'
@@ -632,7 +632,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 193 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 212 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -680,7 +680,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 213 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -745,7 +745,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 197 GoSliceDataType []uint8.array
+      Data: 216 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -824,7 +824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 199 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 218 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1040,7 +1040,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 201 GoSliceDataType math/big.nat.array
+      Data: 220 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1110,7 +1110,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1147,7 +1147,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1228,7 +1228,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 207 GoSliceDataType []time.zone.array
+      Data: 226 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1268,7 +1268,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 209 GoSliceDataType []time.zoneTrans.array
+      Data: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1317,7 +1317,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1357,7 +1357,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1381,7 +1381,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1411,7 +1411,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 217 GoSliceDataType []net.IP.array
+      Data: 236 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1435,7 +1435,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 219 GoSliceDataType net.IP.array
+      Data: 238 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 221 GoSliceDataType []*net/url.URL.array
+      Data: 240 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1474,7 +1474,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 223 GoSliceDataType []*net.IPNet.array
+      Data: 242 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1517,7 +1517,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 225 GoSliceDataType net.IPMask.array
+      Data: 244 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1534,7 +1534,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 227 GoSliceDataType []crypto/x509.OID.array
+      Data: 246 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1568,7 +1568,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1591,7 +1591,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 231 GoSliceDataType [][]uint8.array
+      Data: 250 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1730,7 +1730,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 233 GoSliceDataType []net/http.segment.array
+      Data: 252 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1799,7 +1799,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 235 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 254 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -2025,7 +2025,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 245 GoSliceDataType []bucket<string,interface {}>.array
+      BucketsType: 264 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<string,interface {}>'
@@ -2102,7 +2102,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 143 GoHMapBucketType bucket<string,float64>
-      BucketsType: 237 GoSliceDataType []bucket<string,float64>.array
+      BucketsType: 256 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
       ID: 142
       Name: '*bucket<string,float64>'
@@ -2156,7 +2156,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2205,7 +2205,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2277,7 +2277,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 242 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      BucketsType: 261 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
       ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
@@ -2380,7 +2380,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2545,7 +2545,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2624,327 +2624,460 @@ Types:
       GoRuntimeType: 1.435104e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 184
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 377120
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 185
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 376800
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: BaseType
+      ID: 186
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 543168
+      GoKind: 7
+    - __kind: BaseType
+      ID: 187
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 542592
+      GoKind: 3
+    - __kind: BaseType
+      ID: 188
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 543424
+      GoKind: 13
+    - __kind: GoInterfaceType
+      ID: 189
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.011104e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 190
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 376416
+      GoKind: 22
+      Pointee: 130 BaseType int32
+    - __kind: PointerType
+      ID: 191
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 376480
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: BaseType
+      ID: 192
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 542720
+      GoKind: 4
+    - __kind: BaseType
+      ID: 193
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 543296
+      GoKind: 15
+    - __kind: BaseType
+      ID: 194
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 543360
+      GoKind: 16
+    - __kind: PointerType
+      ID: 195
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 376544
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 196
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 376608
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 197
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 376352
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 198
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 376288
+      GoKind: 22
+      Pointee: 192 BaseType int16
+    - __kind: PointerType
+      ID: 199
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 376160
+      GoKind: 22
+      Pointee: 187 BaseType int8
+    - __kind: PointerType
+      ID: 200
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 376032
+      GoKind: 22
+      Pointee: 189 GoInterfaceType error
+    - __kind: PointerType
+      ID: 201
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 376736
+      GoKind: 22
+      Pointee: 186 BaseType uint
+    - __kind: PointerType
+      ID: 202
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 376992
+      GoKind: 22
+      Pointee: 188 BaseType float32
+    - __kind: GoStringDataType
+      ID: 203
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 185
+      ID: 204
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 184 GoStringDataType string.str
+      Pointee: 203 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 205
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 206
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 188
+      ID: 207
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []string.array
+      Pointee: 206 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 208
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 190
+      ID: 209
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*runtime.bmap.array
+      Pointee: 208 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 210
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 211
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 212
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 213
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 195
+      ID: 214
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 213 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 215
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 216
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 198
+      ID: 217
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []uint8.array
+      Pointee: 216 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 218
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 200
+      ID: 219
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 218 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 220
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 202
+      ID: 221
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType math/big.nat.array
+      Pointee: 220 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 222
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 204
+      ID: 223
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 222 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 224
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 206
+      ID: 225
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 224 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 226
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 208
+      ID: 227
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []time.zone.array
+      Pointee: 226 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 228
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 210
+      ID: 229
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []time.zoneTrans.array
+      Pointee: 228 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 230
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 212
+      ID: 231
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 230 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 232
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 214
+      ID: 233
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 232 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 234
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 216
+      ID: 235
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 234 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 236
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 218
+      ID: 237
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []net.IP.array
+      Pointee: 236 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 238
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 220
+      ID: 239
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType net.IP.array
+      Pointee: 238 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 240
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 222
+      ID: 241
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType []*net/url.URL.array
+      Pointee: 240 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 242
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 224
+      ID: 243
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []*net.IPNet.array
+      Pointee: 242 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 244
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 226
+      ID: 245
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType net.IPMask.array
+      Pointee: 244 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 246
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 228
+      ID: 247
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 246 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 248
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 230
+      ID: 249
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 248 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 250
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 232
+      ID: 251
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType [][]uint8.array
+      Pointee: 250 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 252
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 234
+      ID: 253
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []net/http.segment.array
+      Pointee: 252 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 254
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 255
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 256
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
       Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 257
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 239
+      ID: 258
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 257 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 259
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 241
+      ID: 260
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 259 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 261
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
       Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 262
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 244
+      ID: 263
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 262 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 264
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 265
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 247
+      ID: 266
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 265 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 248
+      ID: 267
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2968,7 +3101,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 249
+      ID: 268
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2982,5 +3115,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 249
+MaxTypeID: 268
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 268 EventRootType Probe[main.HandleHTTP]
+          Type: 248 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8dff40", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 269 EventRootType Probe[main.LookAtTheRequest]
+          Type: 249 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8e025c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0x8dff30..0x8dff94
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8dffa8..0x8dffd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 197 PointerType *bytes.Buffer
+          Type: 179 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8e007c..0x8e0098
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 200 StructureType context.backgroundCtx
+          Type: 182 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8dff30..0x8e0170
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0x8e0250..0x8e0274
               Pieces:
@@ -110,247 +110,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.125472e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 399136
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.678976e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.119104e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.483072e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.04464e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 543232
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 542912
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 546112
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 542656
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 780704
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 797824
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 376224
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 546176
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 546240
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.886304e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 486272
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 202 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 399072
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.336768e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 543104
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.119552e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 636768
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 543616
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.219968e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.256288e+06
@@ -358,84 +139,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 38 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 129 GoChannelType <-chan struct {}
+          Type: 111 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 130 PointerType *net/http.Response
+          Type: 112 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 133 PointerType *net/http.pattern
+          Type: 115 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 542528
@@ -443,20 +224,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 205 PointerType *string.str
+          Type: 185 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 204 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 184 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 376224
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 542656
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 543104
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.002496e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.041568e+06
@@ -464,46 +264,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1416e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.469632e+06
@@ -511,120 +311,126 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 543552
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.964288e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 16
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 38 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 216 GoSliceDataType []bucket<string,[]string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 542784
       GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 542912
+      GoKind: 10
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 38
+      ID: 20
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 41 ArrayType []val<[]string>
+          Type: 23 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 37 PointerType *bucket<string,[]string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 42 GoSliceHeaderType []string
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 39
+      ID: 21
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 632832
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: ArrayType
-      ID: 40
+      ID: 22
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 41
+      ID: 23
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 42 GoSliceHeaderType []string
+      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 42
+      ID: 24
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 469152
@@ -632,30 +438,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 43 PointerType *string
+          Type: 25 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 207 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 187 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 25
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 376096
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 543232
+      GoKind: 12
     - __kind: PointerType
-      ID: 44
+      ID: 27
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 380000
       GoKind: 22
-      Pointee: 45 StructureType runtime.mapextra
+      Pointee: 28 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 45
+      ID: 28
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.4656e+06
@@ -663,22 +475,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 49 PointerType *runtime.bmap
+          Type: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 46
+      ID: 29
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 470816
       GoKind: 22
-      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 30
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 470752
@@ -686,28 +498,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **runtime.bmap
+          Type: 31 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 209 GoSliceDataType []*runtime.bmap.array
+          Type: 8 BaseType int
+      Data: 189 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 48
+      ID: 31
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 49 PointerType *runtime.bmap
+      Pointee: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 49
+      ID: 32
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.137248e+06
       GoKind: 22
-      Pointee: 50 StructureType runtime.bmap
+      Pointee: 33 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 50
+      ID: 33
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.13712e+06
@@ -715,42 +527,48 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 34
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.093088e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 35
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 645600
       GoKind: 19
     - __kind: BaseType
-      ID: 53
+      ID: 36
       Name: int64
       ByteSize: 8
       GoRuntimeType: 542976
       GoKind: 6
     - __kind: GoMapType
-      ID: 54
+      ID: 37
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.712416e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 55
+      ID: 38
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 853856
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 39 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 56
+      ID: 39
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.326048e+06
@@ -758,96 +576,96 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 57 GoMapType map[string][]string
+          Type: 40 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 57
+      ID: 40
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 899360
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 58
+      ID: 41
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 904160
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 42
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 43
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 213 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 193 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
-      ID: 61
+      ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 63
+      ID: 46
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 47
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 461664
@@ -855,29 +673,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType **mime/multipart.FileHeader
+          Type: 48 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 65
+      ID: 48
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 66 PointerType *mime/multipart.FileHeader
+      Pointee: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 66
+      ID: 49
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 853760
       GoKind: 22
-      Pointee: 67 StructureType mime/multipart.FileHeader
+      Pointee: 50 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 67
+      ID: 50
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.881696e+06
@@ -885,34 +703,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 68 GoMapType net/textproto.MIMEHeader
+          Type: 51 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: content
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 68
+      ID: 51
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.63792e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 52
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 468000
@@ -920,23 +738,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 217 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 197 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 70
+      ID: 53
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 852320
       GoKind: 22
-      Pointee: 71 StructureType crypto/tls.ConnectionState
+      Pointee: 54 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 71
+      ID: 54
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.16096e+06
@@ -944,54 +762,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 125 GoSliceHeaderType [][]uint8
+          Type: 107 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 128 BaseType crypto/tls.CurveID
+          Type: 110 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 55
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 473920
@@ -999,28 +817,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **crypto/x509.Certificate
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 219 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 199 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 73
+      ID: 56
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 74 PointerType *crypto/x509.Certificate
+      Pointee: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 74
+      ID: 57
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.95344e+06
       GoKind: 22
-      Pointee: 75 StructureType crypto/x509.Certificate
+      Pointee: 58 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 75
+      ID: 58
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.300992e+06
@@ -1028,179 +846,173 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+          Type: 59 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 80 PointerType *math/big.Int
+          Type: 62 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 101 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 110 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 113 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 120 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 76
+      ID: 59
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.09744e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 77
+      ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 780896
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 78
+      ID: 61
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 798016
       GoKind: 20
-      UnderlyingStructure: 79 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 79
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 80
+      ID: 62
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.29744e+06
       GoKind: 22
-      Pointee: 81 StructureType math/big.Int
+      Pointee: 63 StructureType math/big.Int
     - __kind: StructureType
-      ID: 81
+      ID: 63
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.340768e+06
@@ -1208,12 +1020,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 82 GoSliceHeaderType math/big.nat
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 64
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.280544e+06
@@ -1221,29 +1033,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType *math/big.Word
+          Type: 65 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 221 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 201 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 83
+      ID: 65
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 403552
       GoKind: 22
-      Pointee: 84 BaseType math/big.Word
+      Pointee: 66 BaseType math/big.Word
     - __kind: BaseType
-      ID: 84
+      ID: 66
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 546880
       GoKind: 7
     - __kind: StructureType
-      ID: 85
+      ID: 67
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.105696e+06
@@ -1251,39 +1063,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 68
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 487296
@@ -1291,23 +1103,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 417504
       GoKind: 22
-      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.349408e+06
@@ -1315,12 +1127,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.0376e+06
@@ -1328,23 +1140,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *int
+          Type: 72 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 376672
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.281472e+06
@@ -1352,28 +1164,28 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 93 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: BaseType
-      ID: 92
+      ID: 74
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 543040
       GoKind: 11
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.458496e+06
       GoKind: 22
-      Pointee: 94 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.877952e+06
@@ -1381,27 +1193,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 95 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 98 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 463264
@@ -1409,23 +1221,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 227 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 207 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 370976
       GoKind: 22
-      Pointee: 97 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.458304e+06
@@ -1433,15 +1245,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 463328
@@ -1449,23 +1261,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 229 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 209 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 99
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 371040
       GoKind: 22
-      Pointee: 100 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.664192e+06
@@ -1473,24 +1285,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 101
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 546560
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 486784
@@ -1498,23 +1310,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 417696
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 104
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.494976e+06
@@ -1522,15 +1334,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 486848
@@ -1538,23 +1350,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.037472e+06
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 475200
@@ -1562,29 +1374,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 400736
       GoKind: 22
-      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 109
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 546624
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 458400
@@ -1592,23 +1404,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 237 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 217 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 111
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.02912e+06
       GoKind: 22
-      Pointee: 112 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.00144e+06
@@ -1616,16 +1428,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 239 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 219 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 486912
@@ -1633,21 +1445,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 241 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 221 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 114
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 486976
@@ -1655,29 +1467,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 243 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 223 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 117 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 117
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.122912e+06
       GoKind: 22
-      Pointee: 118 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 118
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.307168e+06
@@ -1685,12 +1497,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 112 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 119 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 999456
@@ -1698,16 +1510,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 245 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 225 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 487040
@@ -1715,23 +1527,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 247 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 227 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.762368e+06
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.762592e+06
@@ -1739,9 +1551,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 474048
@@ -1749,22 +1561,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *[]*crypto/x509.Certificate
+          Type: 106 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 124
+      ID: 106
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 107
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 457184
@@ -1772,47 +1584,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *[]uint8
+          Type: 108 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 251 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 231 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 126
+      ID: 108
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 456928
       GoKind: 22
-      Pointee: 69 GoSliceHeaderType []uint8
+      Pointee: 52 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 127
+      ID: 109
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 983200
       GoKind: 19
     - __kind: BaseType
-      ID: 128
+      ID: 110
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 778592
       GoKind: 9
     - __kind: GoChannelType
-      ID: 129
+      ID: 111
       Name: <-chan struct {}
       GoRuntimeType: 555520
       GoKind: 18
     - __kind: PointerType
-      ID: 130
+      ID: 112
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.632736e+06
       GoKind: 22
-      Pointee: 131 StructureType net/http.Response
+      Pointee: 113 StructureType net/http.Response
     - __kind: StructureType
-      ID: 131
+      ID: 113
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.124032e+06
@@ -1820,62 +1632,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 132
+      ID: 114
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.215776e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.453504e+06
       GoKind: 22
-      Pointee: 134 StructureType net/http.pattern
+      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.745568e+06
@@ -1883,21 +1701,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 135 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1905,23 +1723,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 136 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 253 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 233 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 136
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 367904
       GoKind: 22
-      Pointee: 137 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.453312e+06
@@ -1929,99 +1747,99 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 900992
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<string,string>
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<string,string>
+      Pointee: 122 GoHMapHeaderType hash<string,string>
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 122
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<string,string>
-      BucketsType: 255 GoSliceDataType []bucket<string,string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 235 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<string,string>
+      Pointee: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 124
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 143 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 141 PointerType *bucket<string,string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 27 GoStringHeaderType string
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 143
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 144
+      ID: 126
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.18768e+06
       GoKind: 22
-      Pointee: 145 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 127 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: StructureType
-      ID: 145
+      ID: 127
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.252e+06
@@ -2029,81 +1847,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 151 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 133 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 157 GoMapType map[string]float64
+          Type: 139 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 149 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: context
           Offset: 216
-          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 169 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 196 GoSubroutineType func()
+          Type: 178 GoSubroutineType func()
     - __kind: StructureType
-      ID: 146
+      ID: 128
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.751168e+06
@@ -2111,21 +1929,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 147 StructureType sync.Mutex
+          Type: 129 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 147
+      ID: 129
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.314208e+06
@@ -2133,18 +1951,18 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
     - __kind: BaseType
-      ID: 148
+      ID: 130
       Name: int32
       ByteSize: 4
       GoRuntimeType: 542848
       GoKind: 5
     - __kind: StructureType
-      ID: 149
+      ID: 131
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.315648e+06
@@ -2152,178 +1970,178 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 150 StructureType sync/atomic.noCopy
+          Type: 132 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 148 BaseType int32
+          Type: 130 BaseType int32
     - __kind: StructureType
-      ID: 150
+      ID: 132
       Name: sync/atomic.noCopy
       GoRuntimeType: 966016
       GoKind: 25
       RawFields: []
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.00752e+06
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*hash<string,interface {}>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<string,interface {}>
+      Pointee: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 135
       Name: hash<string,interface {}>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<string,interface {}>
+          Type: 136 PointerType *bucket<string,interface {}>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<string,interface {}>
+          Type: 136 PointerType *bucket<string,interface {}>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<string,interface {}>
-      BucketsType: 265 GoSliceDataType []bucket<string,interface {}>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<string,interface {}>
+      BucketsType: 245 GoSliceDataType []bucket<string,interface {}>.array
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*bucket<string,interface {}>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<string,interface {}>
+      Pointee: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 137
       Name: bucket<string,interface {}>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 156 ArrayType []val<interface {}>
+          Type: 138 ArrayType []val<interface {}>
         - Name: overflow
           Offset: 264
-          Type: 154 PointerType *bucket<string,interface {}>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 78 GoEmptyInterfaceType interface {}
+          Type: 136 PointerType *bucket<string,interface {}>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 61 GoEmptyInterfaceType interface {}
     - __kind: ArrayType
-      ID: 156
+      ID: 138
       Name: '[]val<interface {}>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 78 GoEmptyInterfaceType interface {}
+      Element: 61 GoEmptyInterfaceType interface {}
     - __kind: GoMapType
-      ID: 157
+      ID: 139
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 905024
       GoKind: 21
-      HeaderType: 159 GoHMapHeaderType hash<string,float64>
+      HeaderType: 141 GoHMapHeaderType hash<string,float64>
     - __kind: PointerType
-      ID: 158
+      ID: 140
       Name: '*hash<string,float64>'
       ByteSize: 8
-      Pointee: 159 GoHMapHeaderType hash<string,float64>
+      Pointee: 141 GoHMapHeaderType hash<string,float64>
     - __kind: GoHMapHeaderType
-      ID: 159
+      ID: 141
       Name: hash<string,float64>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 160 PointerType *bucket<string,float64>
+          Type: 142 PointerType *bucket<string,float64>
         - Name: oldbuckets
           Offset: 24
-          Type: 160 PointerType *bucket<string,float64>
+          Type: 142 PointerType *bucket<string,float64>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 161 GoHMapBucketType bucket<string,float64>
-      BucketsType: 257 GoSliceDataType []bucket<string,float64>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 143 GoHMapBucketType bucket<string,float64>
+      BucketsType: 237 GoSliceDataType []bucket<string,float64>.array
     - __kind: PointerType
-      ID: 160
+      ID: 142
       Name: '*bucket<string,float64>'
       ByteSize: 8
-      Pointee: 161 GoHMapBucketType bucket<string,float64>
+      Pointee: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoHMapBucketType
-      ID: 161
+      ID: 143
       Name: bucket<string,float64>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 162 ArrayType []val<float64>
+          Type: 144 ArrayType []val<float64>
         - Name: overflow
           Offset: 200
-          Type: 160 PointerType *bucket<string,float64>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 163 BaseType float64
+          Type: 142 PointerType *bucket<string,float64>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 145 BaseType float64
     - __kind: ArrayType
-      ID: 162
+      ID: 144
       Name: '[]val<float64>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 163 BaseType float64
+      Element: 145 BaseType float64
     - __kind: BaseType
-      ID: 163
+      ID: 145
       Name: float64
       ByteSize: 8
       GoRuntimeType: 543488
       GoKind: 14
     - __kind: GoSliceHeaderType
-      ID: 164
+      ID: 146
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 463584
@@ -2331,23 +2149,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 147 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+          Type: 8 BaseType int
+      Data: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.12944e+06
       GoKind: 22
-      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: StructureType
-      ID: 166
+      ID: 148
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.822592e+06
@@ -2355,24 +2173,24 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
     - __kind: GoSliceHeaderType
-      ID: 167
+      ID: 149
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 463776
@@ -2380,23 +2198,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 150 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 168
+      ID: 150
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.129568e+06
       GoKind: 22
-      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: StructureType
-      ID: 169
+      ID: 151
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.664384e+06
@@ -2404,102 +2222,102 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 170 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 152 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 186 GoMapType map[string]interface {}
+          Type: 168 GoMapType map[string]interface {}
     - __kind: GoMapType
-      ID: 170
+      ID: 152
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 905120
       GoKind: 21
-      HeaderType: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 171
+      ID: 153
       Name: '*hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 172 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 154 GoHMapHeaderType hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoHMapHeaderType
-      ID: 172
+      ID: 154
       Name: hash<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: oldbuckets
           Offset: 24
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      BucketsType: 262 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      BucketsType: 242 GoSliceDataType []bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
     - __kind: PointerType
-      ID: 173
+      ID: 155
       Name: '*bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoHMapBucketType
-      ID: 174
+      ID: 156
       Name: bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 175 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 157 ArrayType []val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: overflow
           Offset: 200
-          Type: 173 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 155 PointerType *bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: ArrayType
-      ID: 175
+      ID: 157
       Name: '[]val<*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 176 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 158 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130336e+06
       GoKind: 22
-      Pointee: 177 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 159 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 177
+      ID: 159
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.822848e+06
@@ -2507,37 +2325,37 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 178 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 160 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 163 BaseType float64
+          Type: 145 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 179 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 161 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 178
+      ID: 160
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 965248
       GoKind: 5
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.130208e+06
       GoKind: 22
-      Pointee: 180 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 162 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: StructureType
-      ID: 180
+      ID: 162
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.13008e+06
@@ -2545,9 +2363,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 181 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 163 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 181
+      ID: 163
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 463648
@@ -2555,29 +2373,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 182 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 164 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+          Type: 8 BaseType int
+      Data: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 182
+      ID: 164
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 183
+      ID: 165
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.129952e+06
       GoKind: 22
-      Pointee: 184 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 184
+      ID: 166
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.74848e+06
@@ -2585,41 +2403,41 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 185 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 167 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 163 BaseType float64
+          Type: 145 BaseType float64
     - __kind: BaseType
-      ID: 185
+      ID: 167
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 965344
       GoKind: 5
     - __kind: GoMapType
-      ID: 186
+      ID: 168
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 896480
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<string,interface {}>
+      HeaderType: 135 GoHMapHeaderType hash<string,interface {}>
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 1.91728e+06
       GoKind: 22
-      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 170 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: StructureType
-      ID: 188
+      ID: 170
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.125376e+06
@@ -2627,55 +2445,55 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 149 StructureType sync/atomic.Int32
+          Type: 131 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 195 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 177 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 164 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 146 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.132544e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.017536e+06
@@ -2683,36 +2501,36 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 146 StructureType sync.RWMutex
+          Type: 128 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 191 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 173 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: full
           Offset: 72
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 193 PointerType *float64
+          Type: 175 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 194 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 176 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 191
+      ID: 173
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 464032
@@ -2720,57 +2538,57 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 192 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 174 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+          Type: 8 BaseType int
+      Data: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 192
+      ID: 174
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 377056
       GoKind: 22
-      Pointee: 163 BaseType float64
+      Pointee: 145 BaseType float64
     - __kind: BaseType
-      ID: 194
+      ID: 176
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 542336
       GoKind: 10
     - __kind: ArrayType
-      ID: 195
+      ID: 177
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 847712
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: GoSubroutineType
-      ID: 196
+      ID: 178
       Name: func()
       ByteSize: 8
       GoRuntimeType: 455520
       GoKind: 19
     - __kind: PointerType
-      ID: 197
+      ID: 179
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.176896e+06
       GoKind: 22
-      Pointee: 198 StructureType bytes.Buffer
+      Pointee: 180 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 198
+      ID: 180
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.4512e+06
@@ -2778,365 +2596,355 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 199 BaseType bytes.readOp
+          Type: 181 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 199
+      ID: 181
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 541760
       GoKind: 3
     - __kind: StructureType
-      ID: 200
+      ID: 182
       Name: context.backgroundCtx
       GoRuntimeType: 1.708832e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 201 StructureType context.emptyCtx
+          Type: 183 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 201
+      ID: 183
       Name: context.emptyCtx
       GoRuntimeType: 1.435104e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 202
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 203
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 202 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 204
+      ID: 184
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 205
+      ID: 185
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 204 GoStringDataType string.str
+      Pointee: 184 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 186
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 187
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 208
+      ID: 188
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []string.array
+      Pointee: 187 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 189
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 49 PointerType *runtime.bmap
+      Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 210
+      ID: 190
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []*runtime.bmap.array
+      Pointee: 189 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 191
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 192
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 193
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 194
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 66 PointerType *mime/multipart.FileHeader
+      Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 215
+      ID: 195
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 194 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 197
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 218
+      ID: 198
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 217 GoSliceDataType []uint8.array
+      Pointee: 197 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 199
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 PointerType *crypto/x509.Certificate
+      Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 220
+      ID: 200
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 219 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 199 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 201
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 84 BaseType math/big.Word
+      Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 222
+      ID: 202
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 221 GoSliceDataType math/big.nat.array
+      Pointee: 201 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 223
+      ID: 203
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 224
+      ID: 204
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 223 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 203 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 205
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 226
+      ID: 206
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 225 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 205 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 207
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 97 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 228
+      ID: 208
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []time.zone.array
+      Pointee: 207 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 209
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 100 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 230
+      ID: 210
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 229 GoSliceDataType []time.zoneTrans.array
+      Pointee: 209 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 211
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 232
+      ID: 212
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 231 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 211 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 213
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 234
+      ID: 214
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 233 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 213 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 215
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 109 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 236
+      ID: 216
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 235 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 215 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 217
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 112 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 238
+      ID: 218
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []net.IP.array
+      Pointee: 217 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 219
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 240
+      ID: 220
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 239 GoSliceDataType net.IP.array
+      Pointee: 219 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 221
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 242
+      ID: 222
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 241 GoSliceDataType []*net/url.URL.array
+      Pointee: 221 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 223
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 117 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 244
+      ID: 224
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []*net.IPNet.array
+      Pointee: 223 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 225
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 246
+      ID: 226
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType net.IPMask.array
+      Pointee: 225 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 227
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 248
+      ID: 228
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 247 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 227 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 229
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 250
+      ID: 230
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 249 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 229 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 231
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 69 GoSliceHeaderType []uint8
+      Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 252
+      ID: 232
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 251 GoSliceDataType [][]uint8.array
+      Pointee: 231 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 233
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 137 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 254
+      ID: 234
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 253 GoSliceDataType []net/http.segment.array
+      Pointee: 233 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 235
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<string,string>
+      Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<string,interface {}>
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 237
       Name: '[]bucket<string,float64>.array'
       ByteSize: 2048
-      Element: 161 GoHMapBucketType bucket<string,float64>
+      Element: 143 GoHMapBucketType bucket<string,float64>
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 238
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 166 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 148 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 259
+      ID: 239
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 238 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 151 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 261
+      ID: 241
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 240 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 2048
-      Element: 174 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 156 GoHMapBucketType bucket<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 243
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 183 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 165 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 264
+      ID: 244
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 243 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 245
       Name: '[]bucket<string,interface {}>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<string,interface {}>
+      Element: 137 GoHMapBucketType bucket<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 144 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 126 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 267
+      ID: 247
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 246 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 268
+      ID: 248
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3153,14 +2961,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 249
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3168,11 +2976,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 269
+MaxTypeID: 249
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 304 EventRootType Probe[main.HandleHTTP]
+          Type: 284 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 305 EventRootType Probe[main.LookAtTheRequest]
+          Type: 285 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0x8a0c90..0x8a0cf4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,14 +65,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: span
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
           Locations:
             - Range: 0x8a0d08..0x8a0d38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: '&buf'
-          Type: 223 PointerType *bytes.Buffer
+          Type: 205 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8a0ddc..0x8a0df0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -81,7 +81,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 226 StructureType context.backgroundCtx
+          Type: 208 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8a0c90..0x8a0ec0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -93,7 +93,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0x8a0f90..0x8a0fb4
               Pieces:
@@ -110,247 +110,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.206176e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 425120
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.795392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.254752e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.666848e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.176064e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 590880
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 590560
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 593760
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 590304
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 845472
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 861440
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 401760
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 593824
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 593888
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 2.01392e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 517568
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 228 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 425056
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.51184e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 590752
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.2552e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 691840
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 591264
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.359648e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.397408e+06
@@ -358,84 +139,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 49 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 52 PointerType *mime/multipart.Form
+          Type: 34 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 114 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 115 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 118 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 590176
@@ -443,20 +224,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 231 PointerType *string.str
+          Type: 211 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 230 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 210 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 401760
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 590304
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 590752
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.159744e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.172992e+06
@@ -464,46 +264,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.221536e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.653024e+06
@@ -511,130 +311,136 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 591200
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.147456e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 35
+      ID: 16
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 37 PointerType **table<string,[]string>
+          Type: 19 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 244 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 43 StructureType noalg.map.group[string][]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 590688
       GoKind: 11
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 590880
+      GoKind: 12
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 38 PointerType *table<string,[]string>
+      Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 38
+      ID: 20
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 39 StructureType table<string,[]string>
+      Pointee: 21 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 39
+      ID: 21
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 41 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: BaseType
-      ID: 40
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 590432
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 41
+      ID: 23
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 42 PointerType *noalg.map.group[string][]string
+          Type: 24 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 43 StructureType noalg.map.group[string][]string
-      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 42
+      ID: 24
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 43 StructureType noalg.map.group[string][]string
+      Pointee: 25 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 43
+      ID: 25
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.311456e+06
@@ -642,21 +448,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 44 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 44
+      ID: 26
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 697120
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 45 StructureType noalg.struct { key string; elem []string }
+      Element: 27 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 45
+      ID: 27
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.311328e+06
@@ -664,12 +470,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 46
+      ID: 28
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 498048
@@ -677,56 +483,62 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 47 PointerType *string
+          Type: 29 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 234 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 214 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 47
+      ID: 29
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 401632
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 30
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.129632e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 49
+      ID: 31
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 701088
       GoKind: 19
     - __kind: BaseType
-      ID: 50
+      ID: 32
       Name: int64
       ByteSize: 8
       GoRuntimeType: 590624
       GoKind: 6
     - __kind: GoMapType
-      ID: 51
+      ID: 33
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.920064e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 52
+      ID: 34
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 920384
       GoKind: 22
-      Pointee: 53 StructureType mime/multipart.Form
+      Pointee: 35 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 53
+      ID: 35
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.5008e+06
@@ -734,116 +546,116 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 54 GoMapType map[string][]string
+          Type: 36 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 55 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 54
+      ID: 36
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.14768e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 55
+      ID: 37
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.152288e+06
       GoKind: 21
-      HeaderType: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 56
+      ID: 38
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapHeaderType
-      ID: 57
+      ID: 39
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 58 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 240 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 220 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 40
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 41
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 60
+      ID: 42
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 61 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapGroupsType
-      ID: 61
+      ID: 43
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 62 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 241 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 62
+      ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 63
+      ID: 45
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.320928e+06
@@ -851,21 +663,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 64 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 64
+      ID: 46
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 707136
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 65 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 65
+      ID: 47
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.3208e+06
@@ -873,12 +685,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 66 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 48
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 488960
@@ -886,29 +698,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType **mime/multipart.FileHeader
+          Type: 49 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 242 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 222 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 67
+      ID: 49
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 68 PointerType *mime/multipart.FileHeader
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 68
+      ID: 50
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 920288
       GoKind: 22
-      Pointee: 69 StructureType mime/multipart.FileHeader
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 69
+      ID: 51
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 2.009312e+06
@@ -916,34 +728,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 70 GoMapType net/textproto.MIMEHeader
+          Type: 52 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: content
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 70
+      ID: 52
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.854368e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 53
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 496896
@@ -951,23 +763,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 246 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 226 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 72
+      ID: 54
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 918848
       GoKind: 22
-      Pointee: 73 StructureType crypto/tls.ConnectionState
+      Pointee: 55 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 73
+      ID: 55
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.301632e+06
@@ -975,54 +787,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 74 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 110 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 113 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 74
+      ID: 56
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503680
@@ -1030,29 +842,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 75 PointerType **crypto/x509.Certificate
+          Type: 57 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 248 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 228 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 75
+      ID: 57
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 PointerType *crypto/x509.Certificate
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 76
+      ID: 58
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.081952e+06
       GoKind: 22
-      Pointee: 77 StructureType crypto/x509.Certificate
+      Pointee: 59 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 77
+      ID: 59
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.452512e+06
@@ -1060,200 +872,194 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 78 BaseType crypto/x509.SignatureAlgorithm
+          Type: 60 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 79 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 82 PointerType *math/big.Int
+          Type: 63 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 102 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 108 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 111 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 114 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 121 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 124 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 78
+      ID: 60
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.134112e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 79
+      ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 845664
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 80
+      ID: 62
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 863072
       GoKind: 20
-      UnderlyingStructure: 81 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 81
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 82
+      ID: 63
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.440096e+06
       GoKind: 22
-      Pointee: 83 StructureType math/big.Int
+      Pointee: 64 StructureType math/big.Int
     - __kind: StructureType
-      ID: 83
+      ID: 64
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.51744e+06
@@ -1261,12 +1067,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 84 GoSliceHeaderType math/big.nat
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 65
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.420864e+06
@@ -1274,29 +1080,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *math/big.Word
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 250 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 230 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 85
+      ID: 66
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 429728
       GoKind: 22
-      Pointee: 86 BaseType math/big.Word
+      Pointee: 67 BaseType math/big.Word
     - __kind: BaseType
-      ID: 86
+      ID: 67
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 594464
       GoKind: 7
     - __kind: StructureType
-      ID: 87
+      ID: 68
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.240928e+06
@@ -1304,39 +1110,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 69
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 519040
@@ -1344,23 +1150,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 252 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 89
+      ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 443616
       GoKind: 22
-      Pointee: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 90
+      ID: 71
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.52688e+06
@@ -1368,12 +1174,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.074656e+06
@@ -1381,23 +1187,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *int
+          Type: 73 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 254 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 92
+      ID: 73
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 402208
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 93
+      ID: 74
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.42368e+06
@@ -1405,22 +1211,22 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 94 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: PointerType
-      ID: 94
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.642272e+06
       GoKind: 22
-      Pointee: 95 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 95
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 2.00528e+06
@@ -1428,27 +1234,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 96 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 99 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 490944
@@ -1456,23 +1262,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 256 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 236 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 97
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 396576
       GoKind: 22
-      Pointee: 98 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.64208e+06
@@ -1480,15 +1286,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 491008
@@ -1496,23 +1302,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 258 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 238 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 100
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 396640
       GoKind: 22
-      Pointee: 101 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 101
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.780992e+06
@@ -1520,24 +1326,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 102
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 594208
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 518272
@@ -1545,23 +1351,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 260 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 104
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 443808
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 105
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.678176e+06
@@ -1569,15 +1375,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 518336
@@ -1585,23 +1391,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 262 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 107
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.074528e+06
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 505152
@@ -1609,29 +1415,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 264 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 109
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 426848
       GoKind: 22
-      Pointee: 110 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 110
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 594272
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 484768
@@ -1639,23 +1445,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 266 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 246 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 112
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.197536e+06
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.170304e+06
@@ -1663,16 +1469,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 268 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 248 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 518400
@@ -1680,21 +1486,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 270 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 250 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 115
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 518464
@@ -1702,29 +1508,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 272 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 252 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 117
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 118 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.203744e+06
       GoKind: 22
-      Pointee: 119 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 119
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.48176e+06
@@ -1732,12 +1538,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 113 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 120 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.037408e+06
@@ -1745,16 +1551,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 274 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 254 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 518528
@@ -1762,23 +1568,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 276 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 256 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 122
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.988896e+06
       GoKind: 22
-      Pointee: 123 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 123
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.989152e+06
@@ -1786,9 +1592,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 105
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 518592
@@ -1796,23 +1602,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.PolicyMapping
+          Type: 106 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 278 GoSliceDataType []crypto/x509.PolicyMapping.array
+          Type: 8 BaseType int
+      Data: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 125
+      ID: 106
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 426912
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.PolicyMapping
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
     - __kind: StructureType
-      ID: 126
+      ID: 107
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.5144e+06
@@ -1820,12 +1626,12 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 108
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 503808
@@ -1833,22 +1639,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 109 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 280 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 128
+      ID: 109
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 110
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 483808
@@ -1856,47 +1662,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 111 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 282 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 262 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 130
+      ID: 111
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 483424
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType []uint8
+      Pointee: 53 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 112
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 1.020064e+06
       GoKind: 19
     - __kind: BaseType
-      ID: 132
+      ID: 113
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 843360
       GoKind: 9
     - __kind: GoChannelType
-      ID: 133
+      ID: 114
       Name: <-chan struct {}
       GoRuntimeType: 603232
       GoKind: 18
     - __kind: PointerType
-      ID: 134
+      ID: 115
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.75088e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 116 StructureType net/http.Response
     - __kind: StructureType
-      ID: 135
+      ID: 116
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.25968e+06
@@ -1904,62 +1710,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 117
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.298016e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 137
+      ID: 118
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.63728e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 138
+      ID: 119
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.865856e+06
@@ -1967,21 +1779,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 120 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 120
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 486400
@@ -1989,23 +1801,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 121 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 284 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 264 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 121
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 393440
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
-      ID: 141
+      ID: 122
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.637088e+06
@@ -2013,112 +1825,112 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.148704e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 286 GoSliceDataType []*table<string,string>.array
-      GroupType: 150 StructureType noalg.map.group[string]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 266 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 145
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 146
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 147 StructureType table<string,string>
+      Pointee: 128 StructureType table<string,string>
     - __kind: StructureType
-      ID: 147
+      ID: 128
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,string>
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
     - __kind: GoSwissMapGroupsType
-      ID: 148
+      ID: 129
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]string
+          Type: 130 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]string
-      GroupSliceType: 287 GoSliceDataType []noalg.map.group[string]string.array
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
-      ID: 149
+      ID: 130
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]string
+      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 150
+      ID: 131
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.31376e+06
@@ -2126,21 +1938,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: ArrayType
-      ID: 151
+      ID: 132
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 701280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem string }
+      Element: 133 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 152
+      ID: 133
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.313632e+06
@@ -2148,19 +1960,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 153
+      ID: 134
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoRuntimeType: 2.326784e+06
       GoKind: 22
-      Pointee: 154 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 135 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: StructureType
-      ID: 154
+      ID: 135
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
       ByteSize: 288
       GoRuntimeType: 2.392384e+06
@@ -2168,81 +1980,81 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: name
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: service
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: resource
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanType
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: start
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: duration
           Offset: 96
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: meta
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: metaStruct
           Offset: 112
-          Type: 162 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
+          Type: 144 GoMapType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
         - Name: metrics
           Offset: 120
-          Type: 173 GoMapType map[string]float64
+          Type: 155 GoMapType map[string]float64
         - Name: spanID
           Offset: 128
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: traceID
           Offset: 136
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: parentID
           Offset: 144
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: error
           Offset: 152
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
         - Name: spanLinks
           Offset: 160
-          Type: 185 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: spanEvents
           Offset: 184
-          Type: 188 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 170 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: goExecTraced
           Offset: 208
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: noDebugStack
           Offset: 209
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: finished
           Offset: 210
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: context
           Offset: 216
-          Type: 213 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+          Type: 195 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
         - Name: integration
           Offset: 224
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: supportsEvents
           Offset: 240
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: pprofCtxActive
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pprofCtxRestore
           Offset: 264
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: taskEnd
           Offset: 280
-          Type: 222 GoSubroutineType func()
+          Type: 204 GoSubroutineType func()
     - __kind: StructureType
-      ID: 155
+      ID: 136
       Name: sync.RWMutex
       ByteSize: 24
       GoRuntimeType: 1.87168e+06
@@ -2250,21 +2062,21 @@ Types:
       RawFields:
         - Name: w
           Offset: 0
-          Type: 156 StructureType sync.Mutex
+          Type: 137 StructureType sync.Mutex
         - Name: writerSem
           Offset: 8
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: readerSem
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: readerCount
           Offset: 16
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
         - Name: readerWait
           Offset: 20
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 156
+      ID: 137
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.48896e+06
@@ -2272,18 +2084,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 157 StructureType sync.noCopy
+          Type: 138 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 158 StructureType internal/sync.Mutex
+          Type: 139 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 157
+      ID: 138
       Name: sync.noCopy
       GoRuntimeType: 1.0024e+06
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 158
+      ID: 139
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.51232e+06
@@ -2291,18 +2103,24 @@ Types:
       RawFields:
         - Name: state
           Offset: 0
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
         - Name: sema
           Offset: 4
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
     - __kind: BaseType
-      ID: 159
+      ID: 140
       Name: int32
       ByteSize: 4
       GoRuntimeType: 590496
       GoKind: 5
+    - __kind: BaseType
+      ID: 141
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 590560
+      GoKind: 10
     - __kind: StructureType
-      ID: 160
+      ID: 142
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.49024e+06
@@ -2310,115 +2128,115 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 161 StructureType sync/atomic.noCopy
+          Type: 143 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
-          Type: 159 BaseType int32
+          Type: 140 BaseType int32
     - __kind: StructureType
-      ID: 161
+      ID: 143
       Name: sync/atomic.noCopy
       GoRuntimeType: 1.002496e+06
       GoKind: 25
       RawFields: []
     - __kind: GoMapType
-      ID: 162
+      ID: 144
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.metaStructMap
       ByteSize: 8
       GoRuntimeType: 1.299296e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 163
+      ID: 145
       Name: '*map<string,interface {}>'
       ByteSize: 8
-      Pointee: 164 GoSwissMapHeaderType map<string,interface {}>
+      Pointee: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: GoSwissMapHeaderType
-      ID: 164
+      ID: 146
       Name: map<string,interface {}>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 165 PointerType **table<string,interface {}>
+          Type: 147 PointerType **table<string,interface {}>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 300 GoSliceDataType []*table<string,interface {}>.array
-      GroupType: 170 StructureType noalg.map.group[string]interface {}
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '**table<string,interface {}>'
       ByteSize: 8
-      Pointee: 166 PointerType *table<string,interface {}>
+      Pointee: 148 PointerType *table<string,interface {}>
     - __kind: PointerType
-      ID: 166
+      ID: 148
       Name: '*table<string,interface {}>'
       ByteSize: 8
-      Pointee: 167 StructureType table<string,interface {}>
+      Pointee: 149 StructureType table<string,interface {}>
     - __kind: StructureType
-      ID: 167
+      ID: 149
       Name: table<string,interface {}>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 168 GoSwissMapGroupsType groupReference<string,interface {}>
+          Type: 150 GoSwissMapGroupsType groupReference<string,interface {}>
     - __kind: GoSwissMapGroupsType
-      ID: 168
+      ID: 150
       Name: groupReference<string,interface {}>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 169 PointerType *noalg.map.group[string]interface {}
+          Type: 151 PointerType *noalg.map.group[string]interface {}
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 170 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 301 GoSliceDataType []noalg.map.group[string]interface {}.array
+          Type: 17 BaseType uint64
+      GroupType: 152 StructureType noalg.map.group[string]interface {}
+      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
-      ID: 169
+      ID: 151
       Name: '*noalg.map.group[string]interface {}'
       ByteSize: 8
-      Pointee: 170 StructureType noalg.map.group[string]interface {}
+      Pointee: 152 StructureType noalg.map.group[string]interface {}
     - __kind: StructureType
-      ID: 170
+      ID: 152
       Name: noalg.map.group[string]interface {}
       ByteSize: 264
       GoRuntimeType: 1.308896e+06
@@ -2426,21 +2244,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 171 ArrayType noalg.[8]struct { key string; elem interface {} }
+          Type: 153 ArrayType noalg.[8]struct { key string; elem interface {} }
     - __kind: ArrayType
-      ID: 171
+      ID: 153
       Name: noalg.[8]struct { key string; elem interface {} }
       ByteSize: 256
       GoRuntimeType: 688576
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 172 StructureType noalg.struct { key string; elem interface {} }
+      Element: 154 StructureType noalg.struct { key string; elem interface {} }
     - __kind: StructureType
-      ID: 172
+      ID: 154
       Name: noalg.struct { key string; elem interface {} }
       ByteSize: 32
       GoRuntimeType: 1.308768e+06
@@ -2448,109 +2266,109 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoMapType
-      ID: 173
+      ID: 155
       Name: map[string]float64
       ByteSize: 8
       GoRuntimeType: 1.152928e+06
       GoKind: 21
-      HeaderType: 175 GoSwissMapHeaderType map<string,float64>
+      HeaderType: 157 GoSwissMapHeaderType map<string,float64>
     - __kind: PointerType
-      ID: 174
+      ID: 156
       Name: '*map<string,float64>'
       ByteSize: 8
-      Pointee: 175 GoSwissMapHeaderType map<string,float64>
+      Pointee: 157 GoSwissMapHeaderType map<string,float64>
     - __kind: GoSwissMapHeaderType
-      ID: 175
+      ID: 157
       Name: map<string,float64>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 176 PointerType **table<string,float64>
+          Type: 158 PointerType **table<string,float64>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 290 GoSliceDataType []*table<string,float64>.array
-      GroupType: 181 StructureType noalg.map.group[string]float64
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 270 GoSliceDataType []*table<string,float64>.array
+      GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '**table<string,float64>'
       ByteSize: 8
-      Pointee: 177 PointerType *table<string,float64>
+      Pointee: 159 PointerType *table<string,float64>
     - __kind: PointerType
-      ID: 177
+      ID: 159
       Name: '*table<string,float64>'
       ByteSize: 8
-      Pointee: 178 StructureType table<string,float64>
+      Pointee: 160 StructureType table<string,float64>
     - __kind: StructureType
-      ID: 178
+      ID: 160
       Name: table<string,float64>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 179 GoSwissMapGroupsType groupReference<string,float64>
+          Type: 161 GoSwissMapGroupsType groupReference<string,float64>
     - __kind: GoSwissMapGroupsType
-      ID: 179
+      ID: 161
       Name: groupReference<string,float64>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 180 PointerType *noalg.map.group[string]float64
+          Type: 162 PointerType *noalg.map.group[string]float64
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 181 StructureType noalg.map.group[string]float64
-      GroupSliceType: 291 GoSliceDataType []noalg.map.group[string]float64.array
+          Type: 17 BaseType uint64
+      GroupType: 163 StructureType noalg.map.group[string]float64
+      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
-      ID: 180
+      ID: 162
       Name: '*noalg.map.group[string]float64'
       ByteSize: 8
-      Pointee: 181 StructureType noalg.map.group[string]float64
+      Pointee: 163 StructureType noalg.map.group[string]float64
     - __kind: StructureType
-      ID: 181
+      ID: 163
       Name: noalg.map.group[string]float64
       ByteSize: 200
       GoRuntimeType: 1.326944e+06
@@ -2558,21 +2376,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 182 ArrayType noalg.[8]struct { key string; elem float64 }
+          Type: 164 ArrayType noalg.[8]struct { key string; elem float64 }
     - __kind: ArrayType
-      ID: 182
+      ID: 164
       Name: noalg.[8]struct { key string; elem float64 }
       ByteSize: 192
       GoRuntimeType: 711616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 183 StructureType noalg.struct { key string; elem float64 }
+      Element: 165 StructureType noalg.struct { key string; elem float64 }
     - __kind: StructureType
-      ID: 183
+      ID: 165
       Name: noalg.struct { key string; elem float64 }
       ByteSize: 24
       GoRuntimeType: 1.326816e+06
@@ -2580,18 +2398,18 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
     - __kind: BaseType
-      ID: 184
+      ID: 166
       Name: float64
       ByteSize: 8
       GoRuntimeType: 591136
       GoKind: 14
     - __kind: GoSliceHeaderType
-      ID: 185
+      ID: 167
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 24
       GoRuntimeType: 491392
@@ -2599,23 +2417,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 186 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 168 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+          Type: 8 BaseType int
+      Data: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
-      ID: 186
+      ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
       ByteSize: 8
       GoRuntimeType: 1.210016e+06
       GoKind: 22
-      Pointee: 187 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Pointee: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: StructureType
-      ID: 187
+      ID: 169
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
       ByteSize: 56
       GoRuntimeType: 1.9464e+06
@@ -2623,24 +2441,24 @@ Types:
       RawFields:
         - Name: TraceID
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: TraceIDHigh
           Offset: 8
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: SpanID
           Offset: 16
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: Tracestate
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Flags
           Offset: 48
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
     - __kind: GoSliceHeaderType
-      ID: 188
+      ID: 170
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 24
       GoRuntimeType: 491584
@@ -2648,23 +2466,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 189 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+          Type: 171 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 294 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+          Type: 8 BaseType int
+      Data: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
       ByteSize: 8
       GoRuntimeType: 1.210144e+06
       GoKind: 22
-      Pointee: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Pointee: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
       ByteSize: 40
       GoRuntimeType: 1.781184e+06
@@ -2672,115 +2490,115 @@ Types:
       RawFields:
         - Name: Name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TimeUnixNano
           Offset: 16
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: Attributes
           Offset: 24
-          Type: 191 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 173 GoMapType map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: RawAttributes
           Offset: 32
-          Type: 212 GoMapType map[string]interface {}
+          Type: 194 GoMapType map[string]interface {}
     - __kind: GoMapType
-      ID: 191
+      ID: 173
       Name: map[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 8
       GoRuntimeType: 1.153056e+06
       GoKind: 21
-      HeaderType: 193 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      HeaderType: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 192
+      ID: 174
       Name: '*map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 193 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 175 GoSwissMapHeaderType map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSwissMapHeaderType
-      ID: 193
+      ID: 175
       Name: map<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 194 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 176 PointerType **table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 296 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
-      GroupType: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 276 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 194
+      ID: 176
       Name: '**table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 195 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: PointerType
-      ID: 195
+      ID: 177
       Name: '*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>'
       ByteSize: 8
-      Pointee: 196 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Pointee: 178 StructureType table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: StructureType
-      ID: 196
+      ID: 178
       Name: table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 197 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+          Type: 179 GoSwissMapGroupsType groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSwissMapGroupsType
-      ID: 197
+      ID: 179
       Name: groupReference<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 198 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 180 PointerType *noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 297 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+          Type: 17 BaseType uint64
+      GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      GroupSliceType: 277 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
-      ID: 198
+      ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
-      Pointee: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 199
+      ID: 181
       Name: noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 200
       GoRuntimeType: 1.3272e+06
@@ -2788,21 +2606,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 200 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+          Type: 182 ArrayType noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: ArrayType
-      ID: 200
+      ID: 182
       Name: noalg.[8]struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 192
       GoRuntimeType: 711712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 201 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
+      Element: 183 StructureType noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
     - __kind: StructureType
-      ID: 201
+      ID: 183
       Name: noalg.struct { key string; elem *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute }
       ByteSize: 24
       GoRuntimeType: 1.327072e+06
@@ -2810,19 +2628,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 202 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+          Type: 184 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
-      ID: 202
+      ID: 184
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210912e+06
       GoKind: 22
-      Pointee: 203 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Pointee: 185 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: StructureType
-      ID: 203
+      ID: 185
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
       ByteSize: 56
       GoRuntimeType: 1.946656e+06
@@ -2830,37 +2648,37 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 204 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
+          Type: 186 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
         - Name: ArrayValue
           Offset: 48
-          Type: 205 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+          Type: 187 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: BaseType
-      ID: 204
+      ID: 186
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttributeType
       ByteSize: 4
       GoRuntimeType: 1.001728e+06
       GoKind: 5
     - __kind: PointerType
-      ID: 205
+      ID: 187
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute'
       ByteSize: 8
       GoRuntimeType: 1.210784e+06
       GoKind: 22
-      Pointee: 206 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
+      Pointee: 188 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
     - __kind: StructureType
-      ID: 206
+      ID: 188
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttribute
       ByteSize: 24
       GoRuntimeType: 1.210656e+06
@@ -2868,9 +2686,9 @@ Types:
       RawFields:
         - Name: Values
           Offset: 0
-          Type: 207 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 189 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: GoSliceHeaderType
-      ID: 207
+      ID: 189
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 24
       GoRuntimeType: 491456
@@ -2878,29 +2696,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 208 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+          Type: 190 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 298 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+          Type: 8 BaseType int
+      Data: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
-      ID: 208
+      ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoKind: 22
-      Pointee: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 209
+      ID: 191
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
       ByteSize: 8
       GoRuntimeType: 1.210528e+06
       GoKind: 22
-      Pointee: 210 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Pointee: 192 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: StructureType
-      ID: 210
+      ID: 192
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
       ByteSize: 48
       GoRuntimeType: 1.868992e+06
@@ -2908,41 +2726,41 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 211 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
+          Type: 193 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
         - Name: StringValue
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: BoolValue
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IntValue
           Offset: 32
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: DoubleValue
           Offset: 40
-          Type: 184 BaseType float64
+          Type: 166 BaseType float64
     - __kind: BaseType
-      ID: 211
+      ID: 193
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValueType
       ByteSize: 4
       GoRuntimeType: 1.001824e+06
       GoKind: 5
     - __kind: GoMapType
-      ID: 212
+      ID: 194
       Name: map[string]interface {}
       ByteSize: 8
       GoRuntimeType: 1.146272e+06
       GoKind: 21
-      HeaderType: 164 GoSwissMapHeaderType map<string,interface {}>
+      HeaderType: 146 GoSwissMapHeaderType map<string,interface {}>
     - __kind: PointerType
-      ID: 213
+      ID: 195
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext'
       ByteSize: 8
       GoRuntimeType: 2.045472e+06
       GoKind: 22
-      Pointee: 214 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
+      Pointee: 196 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
     - __kind: StructureType
-      ID: 214
+      ID: 196
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanContext
       ByteSize: 168
       GoRuntimeType: 2.261024e+06
@@ -2950,55 +2768,55 @@ Types:
       RawFields:
         - Name: updated
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: trace
           Offset: 8
-          Type: 215 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+          Type: 197 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
         - Name: span
           Offset: 16
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: errors
           Offset: 24
-          Type: 160 StructureType sync/atomic.Int32
+          Type: 142 StructureType sync/atomic.Int32
         - Name: reparentID
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: isRemote
           Offset: 48
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: traceID
           Offset: 49
-          Type: 221 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
+          Type: 203 ArrayType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
         - Name: spanID
           Offset: 72
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: mu
           Offset: 80
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: baggage
           Offset: 104
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: hasBaggage
           Offset: 112
-          Type: 9 BaseType uint32
+          Type: 141 BaseType uint32
         - Name: origin
           Offset: 120
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: spanLinks
           Offset: 136
-          Type: 185 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+          Type: 167 GoSliceHeaderType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
         - Name: baggageOnly
           Offset: 160
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: PointerType
-      ID: 215
+      ID: 197
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace'
       ByteSize: 8
       GoRuntimeType: 2.269504e+06
       GoKind: 22
-      Pointee: 216 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
+      Pointee: 198 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
     - __kind: StructureType
-      ID: 216
+      ID: 198
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.trace
       ByteSize: 104
       GoRuntimeType: 2.14816e+06
@@ -3006,36 +2824,36 @@ Types:
       RawFields:
         - Name: mu
           Offset: 0
-          Type: 155 StructureType sync.RWMutex
+          Type: 136 StructureType sync.RWMutex
         - Name: spans
           Offset: 24
-          Type: 217 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 199 GoSliceHeaderType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: tags
           Offset: 48
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: propagatingTags
           Offset: 56
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
         - Name: finished
           Offset: 64
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: full
           Offset: 72
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: priority
           Offset: 80
-          Type: 219 PointerType *float64
+          Type: 201 PointerType *float64
         - Name: locked
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: samplingDecision
           Offset: 92
-          Type: 220 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
+          Type: 202 BaseType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
         - Name: root
           Offset: 96
-          Type: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: GoSliceHeaderType
-      ID: 217
+      ID: 199
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 24
       GoRuntimeType: 491840
@@ -3043,57 +2861,57 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 218 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+          Type: 200 PointerType **github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 302 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+          Type: 8 BaseType int
+      Data: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
-      ID: 218
+      ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
       ByteSize: 8
       GoKind: 22
-      Pointee: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Pointee: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 219
+      ID: 201
       Name: '*float64'
       ByteSize: 8
       GoRuntimeType: 402592
       GoKind: 22
-      Pointee: 184 BaseType float64
+      Pointee: 166 BaseType float64
     - __kind: BaseType
-      ID: 220
+      ID: 202
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.samplingDecision
       ByteSize: 4
       GoRuntimeType: 589984
       GoKind: 10
     - __kind: ArrayType
-      ID: 221
+      ID: 203
       Name: github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.traceID
       ByteSize: 16
       GoRuntimeType: 914336
       GoKind: 17
       Count: 16
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: GoSubroutineType
-      ID: 222
+      ID: 204
       Name: func()
       ByteSize: 8
       GoRuntimeType: 481952
       GoKind: 19
     - __kind: PointerType
-      ID: 223
+      ID: 205
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.316032e+06
       GoKind: 22
-      Pointee: 224 StructureType bytes.Buffer
+      Pointee: 206 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 224
+      ID: 206
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.634976e+06
@@ -3101,415 +2919,405 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 225 BaseType bytes.readOp
+          Type: 207 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 225
+      ID: 207
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 589344
       GoKind: 3
     - __kind: StructureType
-      ID: 226
+      ID: 208
       Name: context.backgroundCtx
       GoRuntimeType: 1.826784e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 227 StructureType context.emptyCtx
+          Type: 209 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 227
+      ID: 209
       Name: context.emptyCtx
       GoRuntimeType: 1.61824e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 228
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 229
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 228 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 230
+      ID: 210
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 231
+      ID: 211
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 230 GoStringDataType string.str
+      Pointee: 210 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 212
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 213
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 214
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 235
+      ID: 215
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType []string.array
+      Pointee: 214 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 216
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 217
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 218
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 219
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 220
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 221
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 222
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 68 PointerType *mime/multipart.FileHeader
+      Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 243
+      ID: 223
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 222 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 224
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 225
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 226
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 247
+      ID: 227
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []uint8.array
+      Pointee: 226 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 228
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 76 PointerType *crypto/x509.Certificate
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 249
+      ID: 229
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 228 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 230
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 86 BaseType math/big.Word
+      Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 251
+      ID: 231
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType math/big.nat.array
+      Pointee: 230 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 232
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 253
+      ID: 233
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 234
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 255
+      ID: 235
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 98 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 257
+      ID: 237
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []time.zone.array
+      Pointee: 236 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 238
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 259
+      ID: 239
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []time.zoneTrans.array
+      Pointee: 238 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 261
+      ID: 241
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 263
+      ID: 243
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 244
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 110 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 265
+      ID: 245
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 267
+      ID: 247
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 266 GoSliceDataType []net.IP.array
+      Pointee: 246 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 248
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 269
+      ID: 249
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 268 GoSliceDataType net.IP.array
+      Pointee: 248 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 250
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 271
+      ID: 251
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 270 GoSliceDataType []*net/url.URL.array
+      Pointee: 250 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 252
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 118 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 273
+      ID: 253
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []*net.IPNet.array
+      Pointee: 252 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 254
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 275
+      ID: 255
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType net.IPMask.array
+      Pointee: 254 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 256
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 123 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 277
+      ID: 257
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 276 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 256 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 258
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.PolicyMapping
+      Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 279
+      ID: 259
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 260
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 281
+      ID: 261
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 280 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 262
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType []uint8
+      Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 283
+      ID: 263
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType [][]uint8.array
+      Pointee: 262 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 284
+      ID: 264
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 285
+      ID: 265
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 284 GoSliceDataType []net/http.segment.array
+      Pointee: 264 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 286
+      ID: 266
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 267
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]string
+      Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 288
+      ID: 268
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 289
+      ID: 269
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[string]interface {}
+      Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 290
+      ID: 270
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
-      Element: 177 PointerType *table<string,float64>
+      Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 291
+      ID: 271
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
-      Element: 181 StructureType noalg.map.group[string]float64
+      Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 292
+      ID: 272
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
-      Element: 187 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
+      Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 293
+      ID: 273
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 292 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 294
+      ID: 274
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
-      Element: 190 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
+      Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 295
+      ID: 275
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 294 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 296
+      ID: 276
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
-      Element: 195 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
+      Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 297
+      ID: 277
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
-      Element: 199 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
+      Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 298
+      ID: 278
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
-      Element: 209 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
+      Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 299
+      ID: 279
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 298 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 300
+      ID: 280
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
-      Element: 166 PointerType *table<string,interface {}>
+      Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 301
+      ID: 281
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
-      Element: 170 StructureType noalg.map.group[string]interface {}
+      Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 302
+      ID: 282
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
-      Element: 153 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
+      Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 303
+      ID: 283
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 302 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3526,14 +3334,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3541,11 +3349,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 305
+MaxTypeID: 285
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -3490,3 +3490,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 304
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x13dd6a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 284 EventRootType Probe[main.HandleHTTP]
+          Type: 303 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8a0ca0", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 285 EventRootType Probe[main.LookAtTheRequest]
+          Type: 304 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8a0f9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -224,11 +224,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 211 PointerType *string.str
+          Type: 230 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 210 GoStringDataType string.str
+      Data: 229 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -366,7 +366,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 224 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 243 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -433,7 +433,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 225 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 244 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -490,7 +490,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 214 GoSliceDataType []string.array
+      Data: 233 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 29
       Name: '*string'
@@ -599,7 +599,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 220 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 239 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -648,7 +648,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 221 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -705,7 +705,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 222 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 241 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -770,7 +770,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 226 GoSliceDataType []uint8.array
+      Data: 245 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -849,7 +849,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 228 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 247 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1087,7 +1087,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 230 GoSliceDataType math/big.nat.array
+      Data: 249 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1157,7 +1157,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1194,7 +1194,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1269,7 +1269,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 236 GoSliceDataType []time.zone.array
+      Data: 255 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1309,7 +1309,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 238 GoSliceDataType []time.zoneTrans.array
+      Data: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1358,7 +1358,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1398,7 +1398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1422,7 +1422,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1452,7 +1452,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 246 GoSliceDataType []net.IP.array
+      Data: 265 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1476,7 +1476,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 248 GoSliceDataType net.IP.array
+      Data: 267 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1493,7 +1493,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 250 GoSliceDataType []*net/url.URL.array
+      Data: 269 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1515,7 +1515,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 252 GoSliceDataType []*net.IPNet.array
+      Data: 271 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1558,7 +1558,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 254 GoSliceDataType net.IPMask.array
+      Data: 273 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1575,7 +1575,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 256 GoSliceDataType []crypto/x509.OID.array
+      Data: 275 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1609,7 +1609,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1646,7 +1646,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1669,7 +1669,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 262 GoSliceDataType [][]uint8.array
+      Data: 281 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1808,7 +1808,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 264 GoSliceDataType []net/http.segment.array
+      Data: 283 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1874,7 +1874,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 266 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 285 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1923,7 +1923,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 267 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 286 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2180,7 +2180,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 280 GoSliceDataType []*table<string,interface {}>.array
+      TablePtrSliceType: 299 GoSliceDataType []*table<string,interface {}>.array
       GroupType: 152 StructureType noalg.map.group[string]interface {}
     - __kind: PointerType
       ID: 147
@@ -2229,7 +2229,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 152 StructureType noalg.map.group[string]interface {}
-      GroupSliceType: 281 GoSliceDataType []noalg.map.group[string]interface {}.array
+      GroupSliceType: 300 GoSliceDataType []noalg.map.group[string]interface {}.array
     - __kind: PointerType
       ID: 151
       Name: '*noalg.map.group[string]interface {}'
@@ -2312,7 +2312,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 270 GoSliceDataType []*table<string,float64>.array
+      TablePtrSliceType: 289 GoSliceDataType []*table<string,float64>.array
       GroupType: 163 StructureType noalg.map.group[string]float64
     - __kind: PointerType
       ID: 158
@@ -2361,7 +2361,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 163 StructureType noalg.map.group[string]float64
-      GroupSliceType: 271 GoSliceDataType []noalg.map.group[string]float64.array
+      GroupSliceType: 290 GoSliceDataType []noalg.map.group[string]float64.array
     - __kind: PointerType
       ID: 162
       Name: '*noalg.map.group[string]float64'
@@ -2424,7 +2424,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Data: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: PointerType
       ID: 168
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink'
@@ -2473,7 +2473,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Data: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: PointerType
       ID: 171
       Name: '*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent'
@@ -2542,7 +2542,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 276 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
+      TablePtrSliceType: 295 GoSliceDataType []*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: PointerType
       ID: 176
@@ -2591,7 +2591,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
-      GroupSliceType: 277 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
+      GroupSliceType: 296 GoSliceDataType []noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array
     - __kind: PointerType
       ID: 180
       Name: '*noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute'
@@ -2703,7 +2703,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Data: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: PointerType
       ID: 190
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue'
@@ -2868,7 +2868,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Data: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: PointerType
       ID: 200
       Name: '**github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span'
@@ -2947,377 +2947,510 @@ Types:
       GoRuntimeType: 1.61824e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 210
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 590816
+      GoKind: 7
+    - __kind: PointerType
+      ID: 211
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 402656
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: GoInterfaceType
+      ID: 212
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.049312e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 213
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 590240
+      GoKind: 3
+    - __kind: BaseType
+      ID: 214
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 591072
+      GoKind: 13
+    - __kind: PointerType
+      ID: 215
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 402336
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: PointerType
+      ID: 216
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 401952
+      GoKind: 22
+      Pointee: 140 BaseType int32
+    - __kind: PointerType
+      ID: 217
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 402016
+      GoKind: 22
+      Pointee: 141 BaseType uint32
+    - __kind: BaseType
+      ID: 218
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 590368
+      GoKind: 4
+    - __kind: BaseType
+      ID: 219
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 590944
+      GoKind: 15
+    - __kind: BaseType
+      ID: 220
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 591008
+      GoKind: 16
+    - __kind: PointerType
+      ID: 221
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 402080
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 222
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 402144
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 223
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 401888
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 224
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 401824
+      GoKind: 22
+      Pointee: 218 BaseType int16
+    - __kind: PointerType
+      ID: 225
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 401696
+      GoKind: 22
+      Pointee: 213 BaseType int8
+    - __kind: PointerType
+      ID: 226
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 401568
+      GoKind: 22
+      Pointee: 212 GoInterfaceType error
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 402272
+      GoKind: 22
+      Pointee: 210 BaseType uint
+    - __kind: PointerType
+      ID: 228
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 402528
+      GoKind: 22
+      Pointee: 214 BaseType float32
+    - __kind: GoStringDataType
+      ID: 229
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 211
+      ID: 230
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 210 GoStringDataType string.str
+      Pointee: 229 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 231
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 232
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 233
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 215
+      ID: 234
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 214 GoSliceDataType []string.array
+      Pointee: 233 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 235
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 236
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 237
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 219
+      ID: 238
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 239
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 221
+      ID: 240
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 241
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 223
+      ID: 242
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 241 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 243
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 225
+      ID: 244
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 245
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 227
+      ID: 246
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []uint8.array
+      Pointee: 245 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 228
+      ID: 247
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 229
+      ID: 248
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 228 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 247 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 249
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 231
+      ID: 250
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 230 GoSliceDataType math/big.nat.array
+      Pointee: 249 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 251
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 233
+      ID: 252
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 232 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 251 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 253
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 235
+      ID: 254
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 234 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 253 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 255
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 237
+      ID: 256
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 236 GoSliceDataType []time.zone.array
+      Pointee: 255 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 238
+      ID: 257
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 239
+      ID: 258
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 238 GoSliceDataType []time.zoneTrans.array
+      Pointee: 257 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 259
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 241
+      ID: 260
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 240 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 259 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 261
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 243
+      ID: 262
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 242 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 261 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 244
+      ID: 263
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 245
+      ID: 264
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 244 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 263 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 265
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 247
+      ID: 266
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 246 GoSliceDataType []net.IP.array
+      Pointee: 265 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 267
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 249
+      ID: 268
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 248 GoSliceDataType net.IP.array
+      Pointee: 267 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 269
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 251
+      ID: 270
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 250 GoSliceDataType []*net/url.URL.array
+      Pointee: 269 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 271
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 253
+      ID: 272
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 252 GoSliceDataType []*net.IPNet.array
+      Pointee: 271 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 273
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 255
+      ID: 274
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 254 GoSliceDataType net.IPMask.array
+      Pointee: 273 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 275
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 257
+      ID: 276
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 256 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 275 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 258
+      ID: 277
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 259
+      ID: 278
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 258 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 277 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 279
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 261
+      ID: 280
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 260 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 279 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 281
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 263
+      ID: 282
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 262 GoSliceDataType [][]uint8.array
+      Pointee: 281 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 264
+      ID: 283
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 265
+      ID: 284
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 264 GoSliceDataType []net/http.segment.array
+      Pointee: 283 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 285
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 286
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 287
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 288
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 289
       Name: '[]*table<string,float64>.array'
       ByteSize: 8192
       Element: 159 PointerType *table<string,float64>
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 290
       Name: '[]noalg.map.group[string]float64.array'
       ByteSize: 2048
       Element: 163 StructureType noalg.map.group[string]float64
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 291
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 2048
       Element: 169 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink
     - __kind: PointerType
-      ID: 273
+      ID: 292
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array'
       ByteSize: 8
-      Pointee: 272 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
+      Pointee: 291 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.SpanLink.array
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 293
       Name: '[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 2048
       Element: 172 StructureType github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent
     - __kind: PointerType
-      ID: 275
+      ID: 294
       Name: '*[]github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array'
       ByteSize: 8
-      Pointee: 274 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
+      Pointee: 293 GoSliceDataType []github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEvent.array
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 295
       Name: '[]*table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>.array'
       ByteSize: 8192
       Element: 177 PointerType *table<string,*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute>
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 296
       Name: '[]noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute.array'
       ByteSize: 2048
       Element: 181 StructureType noalg.map.group[string]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventAttribute
     - __kind: GoSliceDataType
-      ID: 278
+      ID: 297
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 2048
       Element: 191 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue
     - __kind: PointerType
-      ID: 279
+      ID: 298
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array'
       ByteSize: 8
-      Pointee: 278 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
+      Pointee: 297 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.spanEventArrayAttributeValue.array
     - __kind: GoSliceDataType
-      ID: 280
+      ID: 299
       Name: '[]*table<string,interface {}>.array'
       ByteSize: 8192
       Element: 148 PointerType *table<string,interface {}>
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 300
       Name: '[]noalg.map.group[string]interface {}.array'
       ByteSize: 2048
       Element: 152 StructureType noalg.map.group[string]interface {}
     - __kind: GoSliceDataType
-      ID: 282
+      ID: 301
       Name: '[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 2048
       Element: 134 PointerType *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span
     - __kind: PointerType
-      ID: 283
+      ID: 302
       Name: '*[]*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array'
       ByteSize: 8
-      Pointee: 282 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
+      Pointee: 301 GoSliceDataType []*github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.Span.array
     - __kind: EventRootType
-      ID: 284
+      ID: 303
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3341,7 +3474,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 304
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3355,5 +3488,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 285
+MaxTypeID: 304
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 184 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 185 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -240,11 +240,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 155 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 154 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -385,7 +385,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 144 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -461,7 +461,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 135 GoSliceDataType []string.array
+      Data: 157 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 25
       Name: '*string'
@@ -521,7 +521,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 137 GoSliceDataType []*runtime.bmap.array
+      Data: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 31
       Name: '**runtime.bmap'
@@ -648,7 +648,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 141 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 163 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -696,7 +696,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 142 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 164 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -761,7 +761,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 145 GoSliceDataType []uint8.array
+      Data: 167 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -840,7 +840,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 147 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 169 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1056,7 +1056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 149 GoSliceDataType math/big.nat.array
+      Data: 171 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1126,7 +1126,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1163,7 +1163,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1244,7 +1244,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 155 GoSliceDataType []time.zone.array
+      Data: 177 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1284,7 +1284,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 157 GoSliceDataType []time.zoneTrans.array
+      Data: 179 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1333,7 +1333,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1373,7 +1373,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1397,7 +1397,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1427,7 +1427,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 165 GoSliceDataType []net.IP.array
+      Data: 187 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1451,7 +1451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 167 GoSliceDataType net.IP.array
+      Data: 189 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 169 GoSliceDataType []*net/url.URL.array
+      Data: 191 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1491,7 +1491,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 171 GoSliceDataType []*net.IPNet.array
+      Data: 193 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1534,7 +1534,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 173 GoSliceDataType net.IPMask.array
+      Data: 195 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1551,7 +1551,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType []crypto/x509.OID.array
+      Data: 197 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1585,7 +1585,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1608,7 +1608,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType [][]uint8.array
+      Data: 201 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1747,7 +1747,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []net/http.segment.array
+      Data: 203 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1816,7 +1816,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 183 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 205 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -1905,267 +1905,419 @@ Types:
       GoRuntimeType: 1.399456e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 132
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 372640
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 133
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 372320
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: BaseType
+      ID: 134
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 533888
+      GoKind: 5
+    - __kind: BaseType
+      ID: 135
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 533632
+      GoKind: 3
+    - __kind: BaseType
+      ID: 136
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 534208
+      GoKind: 7
+    - __kind: BaseType
+      ID: 137
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 534464
+      GoKind: 13
+    - __kind: BaseType
+      ID: 138
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 534528
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 139
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 987456
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 140
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 371936
+      GoKind: 22
+      Pointee: 134 BaseType int32
+    - __kind: PointerType
+      ID: 141
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 372000
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: BaseType
+      ID: 142
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 534336
+      GoKind: 15
+    - __kind: BaseType
+      ID: 143
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 534400
+      GoKind: 16
+    - __kind: PointerType
+      ID: 144
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 372576
+      GoKind: 22
+      Pointee: 138 BaseType float64
+    - __kind: PointerType
+      ID: 145
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 372064
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 146
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 372128
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 147
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 371872
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 148
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 371808
+      GoKind: 22
+      Pointee: 149 BaseType int16
+    - __kind: BaseType
+      ID: 149
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 533760
+      GoKind: 4
+    - __kind: PointerType
+      ID: 150
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 371680
+      GoKind: 22
+      Pointee: 135 BaseType int8
+    - __kind: PointerType
+      ID: 151
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 371552
+      GoKind: 22
+      Pointee: 139 GoInterfaceType error
+    - __kind: PointerType
+      ID: 152
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 372256
+      GoKind: 22
+      Pointee: 136 BaseType uint
+    - __kind: PointerType
+      ID: 153
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 372512
+      GoKind: 22
+      Pointee: 137 BaseType float32
+    - __kind: GoStringDataType
+      ID: 154
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 133
+      ID: 155
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 154 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 135
+      ID: 157
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 136
+      ID: 158
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 135 GoSliceDataType []string.array
+      Pointee: 157 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 159
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 138
+      ID: 160
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 137 GoSliceDataType []*runtime.bmap.array
+      Pointee: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 161
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 162
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 163
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 164
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 143
+      ID: 165
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 142 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 164 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 166
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 145
+      ID: 167
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 146
+      ID: 168
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 145 GoSliceDataType []uint8.array
+      Pointee: 167 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 169
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 170
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 147 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 169 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 171
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 150
+      ID: 172
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType math/big.nat.array
+      Pointee: 171 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 173
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 152
+      ID: 174
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 175
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 154
+      ID: 176
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 177
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 178
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []time.zone.array
+      Pointee: 177 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 179
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 158
+      ID: 180
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []time.zoneTrans.array
+      Pointee: 179 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 181
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 160
+      ID: 182
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 183
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 162
+      ID: 184
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 185
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 164
+      ID: 186
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 187
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 166
+      ID: 188
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []net.IP.array
+      Pointee: 187 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 189
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 168
+      ID: 190
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType net.IP.array
+      Pointee: 189 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 191
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 170
+      ID: 192
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []*net/url.URL.array
+      Pointee: 191 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 193
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 172
+      ID: 194
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*net.IPNet.array
+      Pointee: 193 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 195
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 174
+      ID: 196
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType net.IPMask.array
+      Pointee: 195 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 197
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 176
+      ID: 198
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 197 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 199
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 178
+      ID: 200
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 201
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 180
+      ID: 202
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType [][]uint8.array
+      Pointee: 201 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 203
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 182
+      ID: 204
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []net/http.segment.array
+      Pointee: 203 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 205
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 184
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2189,7 +2341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2203,5 +2355,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 185
+MaxTypeID: 207
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 204 EventRootType Probe[main.HandleHTTP]
+          Type: 184 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xd289f3", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 205 EventRootType Probe[main.LookAtTheRequest]
+          Type: 185 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xd28d6e", Frameless: false}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0xd289e0..0xd28a56
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 144 PointerType *bytes.Buffer
+          Type: 126 PointerType *bytes.Buffer
           Locations:
             - Range: 0xd28b8f..0xd28bb1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 147 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 129 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xd28a68..0xd28a68
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 148 StructureType context.backgroundCtx
+          Type: 130 StructureType context.backgroundCtx
           Locations:
             - Range: 0xd289e0..0xd28c90
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0xd28d60..0xd28d85
               Pieces:
@@ -126,247 +126,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.098336e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 393440
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.636192e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.059904e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.444448e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 1.988576e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 534272
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 533952
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 536768
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 533696
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 768256
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 785184
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 371744
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 536832
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 536896
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.842048e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 480864
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 150 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 393376
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.304416e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 534144
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.060352e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 625280
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 534656
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.154176e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.189984e+06
@@ -374,84 +155,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 38 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 129 GoChannelType <-chan struct {}
+          Type: 111 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 130 PointerType *net/http.Response
+          Type: 112 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 133 PointerType *net/http.pattern
+          Type: 115 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 533568
@@ -459,20 +240,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 153 PointerType *string.str
+          Type: 133 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 152 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 132 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371744
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533696
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 534144
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.949216e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986272e+06
@@ -480,46 +280,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.114208e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.432736e+06
@@ -527,120 +327,126 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 534592
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.91744e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 16
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 38 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 164 GoSliceDataType []bucket<string,[]string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 144 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 533824
       GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 533952
+      GoKind: 10
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 38
+      ID: 20
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 41 ArrayType []val<[]string>
+          Type: 23 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 37 PointerType *bucket<string,[]string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 42 GoSliceHeaderType []string
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 39
+      ID: 21
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: ArrayType
-      ID: 40
+      ID: 22
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 41
+      ID: 23
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 42 GoSliceHeaderType []string
+      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 42
+      ID: 24
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464704
@@ -648,30 +454,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 43 PointerType *string
+          Type: 25 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 155 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 135 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 25
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 371616
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 534272
+      GoKind: 12
     - __kind: PointerType
-      ID: 44
+      ID: 27
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375520
       GoKind: 22
-      Pointee: 45 StructureType runtime.mapextra
+      Pointee: 28 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 45
+      ID: 28
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.428704e+06
@@ -679,22 +491,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 49 PointerType *runtime.bmap
+          Type: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 46
+      ID: 29
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466432
       GoKind: 22
-      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 30
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466368
@@ -702,28 +514,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **runtime.bmap
+          Type: 31 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 157 GoSliceDataType []*runtime.bmap.array
+          Type: 8 BaseType int
+      Data: 137 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 48
+      ID: 31
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 49 PointerType *runtime.bmap
+      Pointee: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 49
+      ID: 32
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.109856e+06
       GoKind: 22
-      Pointee: 50 StructureType runtime.bmap
+      Pointee: 33 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 50
+      ID: 33
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.109728e+06
@@ -731,42 +543,48 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 34
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067136e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 35
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634112
       GoKind: 19
     - __kind: BaseType
-      ID: 53
+      ID: 36
       Name: int64
       ByteSize: 8
       GoRuntimeType: 534016
       GoKind: 6
     - __kind: GoMapType
-      ID: 54
+      ID: 37
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.670784e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 55
+      ID: 38
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 39 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 56
+      ID: 39
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294336e+06
@@ -774,96 +592,96 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 57 GoMapType map[string][]string
+          Type: 40 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 57
+      ID: 40
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882496
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 58
+      ID: 41
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887296
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 42
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 43
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 141 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
-      ID: 61
+      ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 63
+      ID: 46
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 47
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457376
@@ -871,29 +689,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType **mime/multipart.FileHeader
+          Type: 48 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 142 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 65
+      ID: 48
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 66 PointerType *mime/multipart.FileHeader
+      Pointee: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 66
+      ID: 49
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837376
       GoKind: 22
-      Pointee: 67 StructureType mime/multipart.FileHeader
+      Pointee: 50 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 67
+      ID: 50
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.838016e+06
@@ -901,34 +719,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 68 GoMapType net/textproto.MIMEHeader
+          Type: 51 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: content
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 68
+      ID: 51
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.595904e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 52
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463552
@@ -936,23 +754,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 165 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 145 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 70
+      ID: 53
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 835936
       GoKind: 22
-      Pointee: 71 StructureType crypto/tls.ConnectionState
+      Pointee: 54 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 71
+      ID: 54
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.1e+06
@@ -960,54 +778,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 125 GoSliceHeaderType [][]uint8
+          Type: 107 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 128 BaseType crypto/tls.CurveID
+          Type: 110 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 55
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469536
@@ -1015,28 +833,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **crypto/x509.Certificate
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 147 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 73
+      ID: 56
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 74 PointerType *crypto/x509.Certificate
+      Pointee: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 74
+      ID: 57
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.90528e+06
       GoKind: 22
-      Pointee: 75 StructureType crypto/x509.Certificate
+      Pointee: 58 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 75
+      ID: 58
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.234656e+06
@@ -1044,179 +862,173 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+          Type: 59 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 80 PointerType *math/big.Int
+          Type: 62 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 101 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 110 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 113 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 120 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 76
+      ID: 59
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.070976e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 77
+      ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768448
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 78
+      ID: 61
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785376
       GoKind: 20
-      UnderlyingStructure: 79 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 79
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 80
+      ID: 62
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231104e+06
       GoKind: 22
-      Pointee: 81 StructureType math/big.Int
+      Pointee: 63 StructureType math/big.Int
     - __kind: StructureType
-      ID: 81
+      ID: 63
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308416e+06
@@ -1224,12 +1036,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 82 GoSliceHeaderType math/big.nat
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 64
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.21424e+06
@@ -1237,29 +1049,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType *math/big.Word
+          Type: 65 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 169 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 149 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 83
+      ID: 65
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397856
       GoKind: 22
-      Pointee: 84 BaseType math/big.Word
+      Pointee: 66 BaseType math/big.Word
     - __kind: BaseType
-      ID: 84
+      ID: 66
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537536
       GoKind: 7
     - __kind: StructureType
-      ID: 85
+      ID: 67
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.046944e+06
@@ -1267,39 +1079,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 68
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 481888
@@ -1307,23 +1119,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408800
       GoKind: 22
-      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316256e+06
@@ -1331,12 +1143,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.009856e+06
@@ -1344,23 +1156,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *int
+          Type: 72 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 372192
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215168e+06
@@ -1368,28 +1180,28 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 93 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: BaseType
-      ID: 92
+      ID: 74
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 534080
       GoKind: 11
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421216e+06
       GoKind: 22
-      Pointee: 94 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.833984e+06
@@ -1397,27 +1209,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 95 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 98 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459040
@@ -1425,23 +1237,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 175 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 155 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367072
       GoKind: 22
-      Pointee: 97 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421024e+06
@@ -1449,15 +1261,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459104
@@ -1465,23 +1277,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 177 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 157 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 99
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 100 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623328e+06
@@ -1489,24 +1301,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 101
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537216
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481376
@@ -1514,23 +1326,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 408992
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 104
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.455008e+06
@@ -1538,15 +1350,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481440
@@ -1554,23 +1366,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.009728e+06
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470816
@@ -1578,29 +1390,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395040
       GoKind: 22
-      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 109
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537280
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454048
@@ -1608,23 +1420,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 185 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 165 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 111
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974144e+06
       GoKind: 22
-      Pointee: 112 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.94816e+06
@@ -1632,16 +1444,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 187 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 167 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -1649,22 +1461,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 189 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 169 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 114
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -1672,29 +1484,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 191 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 171 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 117 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 117
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095776e+06
       GoKind: 22
-      Pointee: 118 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 118
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.275936e+06
@@ -1702,12 +1514,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 112 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 119 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 975808
@@ -1715,16 +1527,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 193 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 173 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -1732,23 +1544,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 195 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 175 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717248e+06
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.717472e+06
@@ -1756,9 +1568,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -1766,22 +1578,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *[]*crypto/x509.Certificate
+          Type: 106 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 124
+      ID: 106
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 107
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452832
@@ -1789,47 +1601,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *[]uint8
+          Type: 108 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 199 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 179 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 126
+      ID: 108
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452512
       GoKind: 22
-      Pointee: 69 GoSliceHeaderType []uint8
+      Pointee: 52 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 127
+      ID: 109
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960256
       GoKind: 19
     - __kind: BaseType
-      ID: 128
+      ID: 110
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766048
       GoKind: 9
     - __kind: GoChannelType
-      ID: 129
+      ID: 111
       Name: <-chan struct {}
       GoRuntimeType: 546752
       GoKind: 18
     - __kind: PointerType
-      ID: 130
+      ID: 112
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.590912e+06
       GoKind: 22
-      Pointee: 131 StructureType net/http.Response
+      Pointee: 113 StructureType net/http.Response
     - __kind: StructureType
-      ID: 131
+      ID: 113
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.064832e+06
@@ -1837,62 +1649,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 132
+      ID: 114
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187104e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416224e+06
       GoKind: 22
-      Pointee: 134 StructureType net/http.pattern
+      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.701568e+06
@@ -1900,21 +1718,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 135 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454816
@@ -1922,23 +1740,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 136 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 201 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 181 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 136
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364000
       GoKind: 22
-      Pointee: 137 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416032e+06
@@ -1946,99 +1764,99 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884128
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<string,string>
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<string,string>
+      Pointee: 122 GoHMapHeaderType hash<string,string>
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 122
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<string,string>
-      BucketsType: 203 GoSliceDataType []bucket<string,string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 183 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<string,string>
+      Pointee: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 124
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 143 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 141 PointerType *bucket<string,string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 27 GoStringHeaderType string
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 143
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 144
+      ID: 126
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.114976e+06
       GoKind: 22
-      Pointee: 145 StructureType bytes.Buffer
+      Pointee: 127 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 145
+      ID: 127
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.41392e+06
@@ -2046,312 +1864,308 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 146 BaseType bytes.readOp
+          Type: 128 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 146
+      ID: 128
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532800
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 129
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.295936e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 130
       Name: context.backgroundCtx
       GoRuntimeType: 1.6672e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 149 StructureType context.emptyCtx
+          Type: 131 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 149
+      ID: 131
       Name: context.emptyCtx
       GoRuntimeType: 1.399456e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 150
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 151
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 150 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 152
+      ID: 132
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 153
+      ID: 133
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 152 GoStringDataType string.str
+      Pointee: 132 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 134
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 135
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 156
+      ID: 136
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []string.array
+      Pointee: 135 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 137
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 49 PointerType *runtime.bmap
+      Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 158
+      ID: 138
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []*runtime.bmap.array
+      Pointee: 137 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 139
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 140
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 141
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 142
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 66 PointerType *mime/multipart.FileHeader
+      Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 163
+      ID: 143
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 142 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 144
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 145
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 166
+      ID: 146
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []uint8.array
+      Pointee: 145 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 147
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 PointerType *crypto/x509.Certificate
+      Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 168
+      ID: 148
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 147 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 149
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 84 BaseType math/big.Word
+      Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 170
+      ID: 150
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType math/big.nat.array
+      Pointee: 149 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 151
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 172
+      ID: 152
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 153
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 174
+      ID: 154
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 155
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 97 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 176
+      ID: 156
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zone.array
+      Pointee: 155 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 157
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 100 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 178
+      ID: 158
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+      Pointee: 157 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 159
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 180
+      ID: 160
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 161
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 162
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 163
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 109 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 184
+      ID: 164
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 165
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 112 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 186
+      ID: 166
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []net.IP.array
+      Pointee: 165 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 167
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 188
+      ID: 168
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IP.array
+      Pointee: 167 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 169
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 170
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net/url.URL.array
+      Pointee: 169 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 171
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 117 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 192
+      ID: 172
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net.IPNet.array
+      Pointee: 171 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 173
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 194
+      ID: 174
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType net.IPMask.array
+      Pointee: 173 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 175
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 196
+      ID: 176
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 175 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 198
+      ID: 178
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 179
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 69 GoSliceHeaderType []uint8
+      Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 200
+      ID: 180
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType [][]uint8.array
+      Pointee: 179 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 181
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 137 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []net/http.segment.array
+      Pointee: 181 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 183
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<string,string>
+      Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 204
+      ID: 184
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2368,14 +2182,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 185
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2383,11 +2197,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 205
+MaxTypeID: 185
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.23.11.yaml
@@ -2357,3 +2357,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 207
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x1776bc0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 198 EventRootType Probe[main.HandleHTTP]
+          Type: 221 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 199 EventRootType Probe[main.LookAtTheRequest]
+          Type: 222 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -240,11 +240,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 141 PointerType *string.str
+          Type: 164 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 140 GoStringDataType string.str
+      Data: 163 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -382,7 +382,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 154 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -449,7 +449,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -506,7 +506,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 144 GoSliceDataType []string.array
+      Data: 167 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 29
       Name: '*string'
@@ -615,7 +615,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 150 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -664,7 +664,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 151 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -721,7 +721,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 152 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 175 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -786,7 +786,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 156 GoSliceDataType []uint8.array
+      Data: 179 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -865,7 +865,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 158 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 181 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1103,7 +1103,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 160 GoSliceDataType math/big.nat.array
+      Data: 183 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1173,7 +1173,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1210,7 +1210,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1285,7 +1285,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 166 GoSliceDataType []time.zone.array
+      Data: 189 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1325,7 +1325,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 168 GoSliceDataType []time.zoneTrans.array
+      Data: 191 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1374,7 +1374,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1414,7 +1414,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1438,7 +1438,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 176 GoSliceDataType []net.IP.array
+      Data: 199 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1492,7 +1492,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType net.IP.array
+      Data: 201 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1509,7 +1509,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 180 GoSliceDataType []*net/url.URL.array
+      Data: 203 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1532,7 +1532,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 182 GoSliceDataType []*net.IPNet.array
+      Data: 205 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1575,7 +1575,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 184 GoSliceDataType net.IPMask.array
+      Data: 207 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1592,7 +1592,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509.OID.array
+      Data: 209 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1626,7 +1626,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1663,7 +1663,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1686,7 +1686,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 192 GoSliceDataType [][]uint8.array
+      Data: 215 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1825,7 +1825,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []net/http.segment.array
+      Data: 217 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1891,7 +1891,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 196 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 219 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1940,7 +1940,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 197 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2038,297 +2038,455 @@ Types:
       GoRuntimeType: 1.580704e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 140
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 580032
+      GoKind: 10
+    - __kind: BaseType
+      ID: 141
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 579968
+      GoKind: 5
+    - __kind: PointerType
+      ID: 142
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 397280
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: GoInterfaceType
+      ID: 143
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.023328e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 144
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 579712
+      GoKind: 3
+    - __kind: BaseType
+      ID: 145
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 580288
+      GoKind: 7
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 580544
+      GoKind: 13
+    - __kind: BaseType
+      ID: 147
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 580608
+      GoKind: 14
+    - __kind: PointerType
+      ID: 148
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 396960
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: PointerType
+      ID: 149
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 396576
+      GoKind: 22
+      Pointee: 141 BaseType int32
+    - __kind: PointerType
+      ID: 150
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 396640
+      GoKind: 22
+      Pointee: 140 BaseType uint32
+    - __kind: BaseType
+      ID: 151
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 580416
+      GoKind: 15
+    - __kind: BaseType
+      ID: 152
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 580480
+      GoKind: 16
+    - __kind: PointerType
+      ID: 153
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 397216
+      GoKind: 22
+      Pointee: 147 BaseType float64
+    - __kind: PointerType
+      ID: 154
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 396704
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 155
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 396768
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 156
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 396512
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 157
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 396448
+      GoKind: 22
+      Pointee: 158 BaseType int16
+    - __kind: BaseType
+      ID: 158
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 579840
+      GoKind: 4
+    - __kind: PointerType
+      ID: 159
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 396320
+      GoKind: 22
+      Pointee: 144 BaseType int8
+    - __kind: PointerType
+      ID: 160
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 396192
+      GoKind: 22
+      Pointee: 143 GoInterfaceType error
+    - __kind: PointerType
+      ID: 161
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 396896
+      GoKind: 22
+      Pointee: 145 BaseType uint
+    - __kind: PointerType
+      ID: 162
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 397152
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: GoStringDataType
+      ID: 163
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 141
+      ID: 164
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 140 GoStringDataType string.str
+      Pointee: 163 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 167
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []string.array
+      Pointee: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 169
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 170
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 171
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 172
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 150
+      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 174
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 175
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 153
+      ID: 176
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 152 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 175 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 177
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 178
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 179
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 157
+      ID: 180
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 156 GoSliceDataType []uint8.array
+      Pointee: 179 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 181
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 159
+      ID: 182
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 158 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 181 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 183
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 161
+      ID: 184
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType math/big.nat.array
+      Pointee: 183 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 185
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 163
+      ID: 186
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 187
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 165
+      ID: 188
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 189
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 167
+      ID: 190
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []time.zone.array
+      Pointee: 189 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 191
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 169
+      ID: 192
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType []time.zoneTrans.array
+      Pointee: 191 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 193
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 171
+      ID: 194
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 195
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 173
+      ID: 196
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 197
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 175
+      ID: 198
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 199
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 177
+      ID: 200
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []net.IP.array
+      Pointee: 199 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 201
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 179
+      ID: 202
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType net.IP.array
+      Pointee: 201 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 203
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 181
+      ID: 204
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*net/url.URL.array
+      Pointee: 203 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 205
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 183
+      ID: 206
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*net.IPNet.array
+      Pointee: 205 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 207
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 185
+      ID: 208
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType net.IPMask.array
+      Pointee: 207 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 209
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 187
+      ID: 210
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 209 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 211
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 189
+      ID: 212
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 213
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 191
+      ID: 214
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 215
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 193
+      ID: 216
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType [][]uint8.array
+      Pointee: 215 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 217
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 195
+      ID: 218
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []net/http.segment.array
+      Pointee: 217 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 219
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 220
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 198
+      ID: 221
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2352,7 +2510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 222
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2366,5 +2524,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 199
+MaxTypeID: 222
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 219 EventRootType Probe[main.HandleHTTP]
+          Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0xcfc653", Frameless: false}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 220 EventRootType Probe[main.LookAtTheRequest]
+          Type: 199 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0xcfc9ce", Frameless: false}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0xcfc640..0xcfc6b6
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 153 PointerType *bytes.Buffer
+          Type: 134 PointerType *bytes.Buffer
           Locations:
             - Range: 0xcfc7ee..0xcfc809
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 137 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0xcfc6c8..0xcfc6c8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 157 StructureType context.backgroundCtx
+          Type: 138 StructureType context.backgroundCtx
           Locations:
             - Range: 0xcfc640..0xcfc8f0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0xcfc9c0..0xcfc9e5
               Pieces:
@@ -126,247 +126,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.177056e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 418528
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.7496e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.19088e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.626176e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.115328e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 580352
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 580032
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 582848
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 579776
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 831872
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 847648
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 396384
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 582912
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 582976
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.966944e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 511104
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 159 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 418464
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.478368e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 580224
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.191328e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 678720
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 580736
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.285568e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.322816e+06
@@ -374,84 +155,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 49 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 52 PointerType *mime/multipart.Form
+          Type: 34 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 114 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 115 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 118 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 579648
@@ -459,20 +240,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 162 PointerType *string.str
+          Type: 141 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 161 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 140 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 396384
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 579776
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 580224
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.100096e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.113024e+06
@@ -480,46 +280,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.19216e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.61408e+06
@@ -527,130 +327,136 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 580672
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.088128e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 35
+      ID: 16
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 37 PointerType **table<string,[]string>
+          Type: 19 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 175 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 43 StructureType noalg.map.group[string][]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 580160
       GoKind: 11
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 580352
+      GoKind: 12
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 38 PointerType *table<string,[]string>
+      Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 38
+      ID: 20
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 39 StructureType table<string,[]string>
+      Pointee: 21 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 39
+      ID: 21
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 41 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: BaseType
-      ID: 40
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 579904
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 41
+      ID: 23
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 42 PointerType *noalg.map.group[string][]string
+          Type: 24 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 43 StructureType noalg.map.group[string][]string
-      GroupSliceType: 176 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 42
+      ID: 24
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 43 StructureType noalg.map.group[string][]string
+      Pointee: 25 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 43
+      ID: 25
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.281056e+06
@@ -658,21 +464,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 44 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 44
+      ID: 26
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 684000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 45 StructureType noalg.struct { key string; elem []string }
+      Element: 27 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 45
+      ID: 27
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280928e+06
@@ -680,12 +486,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 46
+      ID: 28
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492832
@@ -693,56 +499,62 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 47 PointerType *string
+          Type: 29 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 165 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 144 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 47
+      ID: 29
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 396256
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 30
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.10128e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 49
+      ID: 31
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687968
       GoKind: 19
     - __kind: BaseType
-      ID: 50
+      ID: 32
       Name: int64
       ByteSize: 8
       GoRuntimeType: 580096
       GoKind: 6
     - __kind: GoMapType
-      ID: 51
+      ID: 33
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.871296e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 52
+      ID: 34
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 903008
       GoKind: 22
-      Pointee: 53 StructureType mime/multipart.Form
+      Pointee: 35 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 53
+      ID: 35
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467968e+06
@@ -750,116 +562,116 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 54 GoMapType map[string][]string
+          Type: 36 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 55 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 54
+      ID: 36
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118688e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 55
+      ID: 37
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.123296e+06
       GoKind: 21
-      HeaderType: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 56
+      ID: 38
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapHeaderType
-      ID: 57
+      ID: 39
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 58 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 171 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 150 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 40
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 41
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 60
+      ID: 42
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 61 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapGroupsType
-      ID: 61
+      ID: 43
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 62 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 172 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 151 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 62
+      ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 63
+      ID: 45
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.290528e+06
@@ -867,21 +679,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 64 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 64
+      ID: 46
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 694016
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 65 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 65
+      ID: 47
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.2904e+06
@@ -889,12 +701,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 66 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 48
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483904
@@ -902,29 +714,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType **mime/multipart.FileHeader
+          Type: 49 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 152 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 67
+      ID: 49
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 68 PointerType *mime/multipart.FileHeader
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 68
+      ID: 50
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902912
       GoKind: 22
-      Pointee: 69 StructureType mime/multipart.FileHeader
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 69
+      ID: 51
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962912e+06
@@ -932,34 +744,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 70 GoMapType net/textproto.MIMEHeader
+          Type: 52 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: content
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 70
+      ID: 52
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808832e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 53
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491680
@@ -967,23 +779,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 177 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 156 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 72
+      ID: 54
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 901472
       GoKind: 22
-      Pointee: 73 StructureType crypto/tls.ConnectionState
+      Pointee: 55 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 73
+      ID: 55
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.232384e+06
@@ -991,54 +803,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 74 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 110 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 113 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 74
+      ID: 56
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498464
@@ -1046,29 +858,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 75 PointerType **crypto/x509.Certificate
+          Type: 57 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 179 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 158 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 75
+      ID: 57
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 PointerType *crypto/x509.Certificate
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 76
+      ID: 58
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.031072e+06
       GoKind: 22
-      Pointee: 77 StructureType crypto/x509.Certificate
+      Pointee: 59 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 77
+      ID: 59
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.377888e+06
@@ -1076,200 +888,194 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 78 BaseType crypto/x509.SignatureAlgorithm
+          Type: 60 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 79 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 82 PointerType *math/big.Int
+          Type: 63 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 102 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 108 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 111 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 114 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 121 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 124 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 78
+      ID: 60
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.105248e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 79
+      ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 832064
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 80
+      ID: 62
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 849280
       GoKind: 20
-      UnderlyingStructure: 81 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 81
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 82
+      ID: 63
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.365472e+06
       GoKind: 22
-      Pointee: 83 StructureType math/big.Int
+      Pointee: 64 StructureType math/big.Int
     - __kind: StructureType
-      ID: 83
+      ID: 64
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483968e+06
@@ -1277,12 +1083,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 84 GoSliceHeaderType math/big.nat
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 65
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.346272e+06
@@ -1290,29 +1096,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *math/big.Word
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 181 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 160 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 85
+      ID: 66
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423200
       GoKind: 22
-      Pointee: 86 BaseType math/big.Word
+      Pointee: 67 BaseType math/big.Word
     - __kind: BaseType
-      ID: 86
+      ID: 67
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583552
       GoKind: 7
     - __kind: StructureType
-      ID: 87
+      ID: 68
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.177504e+06
@@ -1320,39 +1126,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 69
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512576
@@ -1360,23 +1166,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 89
+      ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 434080
       GoKind: 22
-      Pointee: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 90
+      ID: 71
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492608e+06
@@ -1384,12 +1190,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044832e+06
@@ -1397,23 +1203,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *int
+          Type: 73 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 185 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 92
+      ID: 73
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 396832
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 93
+      ID: 74
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.349088e+06
@@ -1421,22 +1227,22 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 94 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: PointerType
-      ID: 94
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.602944e+06
       GoKind: 22
-      Pointee: 95 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 95
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.958592e+06
@@ -1444,27 +1250,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 96 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 99 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485952
@@ -1472,23 +1278,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 187 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 166 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 97
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391776
       GoKind: 22
-      Pointee: 98 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602752e+06
@@ -1496,15 +1302,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 486016
@@ -1512,23 +1318,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 189 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 168 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 100
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391840
       GoKind: 22
-      Pointee: 101 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 101
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.73712e+06
@@ -1536,24 +1342,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 102
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583296
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511808
@@ -1561,23 +1367,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 104
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434272
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 105
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.63616e+06
@@ -1585,15 +1391,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511872
@@ -1601,23 +1407,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 193 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 107
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044704e+06
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499936
@@ -1625,29 +1431,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 195 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 109
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420256
       GoKind: 22
-      Pointee: 110 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 110
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583360
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479648
@@ -1655,23 +1461,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 197 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 176 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 112
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.13488e+06
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109952e+06
@@ -1679,16 +1485,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 199 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511936
@@ -1696,22 +1502,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 201 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 180 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 115
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
       GoKind: 22
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 512000
@@ -1719,29 +1525,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 203 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 117
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 118 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.174624e+06
       GoKind: 22
-      Pointee: 119 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 119
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.449408e+06
@@ -1749,12 +1555,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 113 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 120 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.011424e+06
@@ -1762,16 +1568,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 205 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 512064
@@ -1779,23 +1585,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 207 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 186 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 122
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938912e+06
       GoKind: 22
-      Pointee: 123 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 123
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.939168e+06
@@ -1803,9 +1609,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 105
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 512128
@@ -1813,23 +1619,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.PolicyMapping
+          Type: 106 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 209 GoSliceDataType []crypto/x509.PolicyMapping.array
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 125
+      ID: 106
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420320
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.PolicyMapping
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
     - __kind: StructureType
-      ID: 126
+      ID: 107
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480928e+06
@@ -1837,12 +1643,12 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 108
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498592
@@ -1850,22 +1656,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 109 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 211 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 128
+      ID: 109
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 110
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478688
@@ -1873,47 +1679,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 111 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 213 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 192 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 130
+      ID: 111
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478304
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType []uint8
+      Pointee: 53 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 112
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 995552
       GoKind: 19
     - __kind: BaseType
-      ID: 132
+      ID: 113
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829664
       GoKind: 9
     - __kind: GoChannelType
-      ID: 133
+      ID: 114
       Name: <-chan struct {}
       GoRuntimeType: 592896
       GoKind: 18
     - __kind: PointerType
-      ID: 134
+      ID: 115
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.706048e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 116 StructureType net/http.Response
     - __kind: StructureType
-      ID: 135
+      ID: 116
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.195808e+06
@@ -1921,62 +1727,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 117
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.267616e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 137
+      ID: 118
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597952e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 138
+      ID: 119
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818656e+06
@@ -1984,21 +1796,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 120 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 120
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481280
@@ -2006,23 +1818,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 121 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 215 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 121
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388640
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
-      ID: 141
+      ID: 122
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.59776e+06
@@ -2030,112 +1842,112 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119712e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
-      GroupType: 150 StructureType noalg.map.group[string]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 196 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 145
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 146
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 147 StructureType table<string,string>
+      Pointee: 128 StructureType table<string,string>
     - __kind: StructureType
-      ID: 147
+      ID: 128
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,string>
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
     - __kind: GoSwissMapGroupsType
-      ID: 148
+      ID: 129
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]string
+          Type: 130 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]string
-      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 197 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
-      ID: 149
+      ID: 130
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]string
+      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 150
+      ID: 131
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.28336e+06
@@ -2143,21 +1955,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: ArrayType
-      ID: 151
+      ID: 132
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688160
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem string }
+      Element: 133 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 152
+      ID: 133
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.283232e+06
@@ -2165,19 +1977,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 153
+      ID: 134
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245824e+06
       GoKind: 22
-      Pointee: 154 StructureType bytes.Buffer
+      Pointee: 135 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 154
+      ID: 135
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595648e+06
@@ -2185,342 +1997,338 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 155 BaseType bytes.readOp
+          Type: 136 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 155
+      ID: 136
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578816
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 137
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.469568e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 157
+      ID: 138
       Name: context.backgroundCtx
       GoRuntimeType: 1.781952e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 158 StructureType context.emptyCtx
+          Type: 139 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 158
+      ID: 139
       Name: context.emptyCtx
       GoRuntimeType: 1.580704e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 159
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 160
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 159 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 161
+      ID: 140
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 162
+      ID: 141
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 161 GoStringDataType string.str
+      Pointee: 140 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 142
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 143
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 144
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 166
+      ID: 145
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []string.array
+      Pointee: 144 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 146
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 147
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 148
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 149
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 150
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 151
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 152
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 68 PointerType *mime/multipart.FileHeader
+      Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 174
+      ID: 153
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 152 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 154
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 155
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 156
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 178
+      ID: 157
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []uint8.array
+      Pointee: 156 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 158
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 76 PointerType *crypto/x509.Certificate
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 180
+      ID: 159
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 158 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 160
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 86 BaseType math/big.Word
+      Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 182
+      ID: 161
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType math/big.nat.array
+      Pointee: 160 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 162
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 184
+      ID: 163
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 164
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 166
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 98 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 188
+      ID: 167
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []time.zone.array
+      Pointee: 166 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 168
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 190
+      ID: 169
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []time.zoneTrans.array
+      Pointee: 168 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 192
+      ID: 171
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 172
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 194
+      ID: 173
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 174
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 110 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 196
+      ID: 175
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 176
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 198
+      ID: 177
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []net.IP.array
+      Pointee: 176 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 178
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 200
+      ID: 179
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IP.array
+      Pointee: 178 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 180
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 202
+      ID: 181
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []*net/url.URL.array
+      Pointee: 180 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 182
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 118 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 204
+      ID: 183
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []*net.IPNet.array
+      Pointee: 182 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 184
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 206
+      ID: 185
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType net.IPMask.array
+      Pointee: 184 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 186
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 123 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 208
+      ID: 187
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 186 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 188
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.PolicyMapping
+      Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 210
+      ID: 189
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 190
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 212
+      ID: 191
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 192
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType []uint8
+      Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 214
+      ID: 193
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint8.array
+      Pointee: 192 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 194
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 216
+      ID: 195
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []net/http.segment.array
+      Pointee: 194 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 196
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 197
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]string
+      Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 219
+      ID: 198
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2537,14 +2345,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 220
+      ID: 199
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2552,11 +2360,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 220
+MaxTypeID: 199
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=amd64,toolchain=go1.24.3.yaml
@@ -2526,3 +2526,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 222
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x181b800", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -2356,3 +2356,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 207
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x12ddd40", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 204 EventRootType Probe[main.HandleHTTP]
+          Type: 184 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 205 EventRootType Probe[main.LookAtTheRequest]
+          Type: 185 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0x8ad860..0x8ad8c4
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 144 PointerType *bytes.Buffer
+          Type: 126 PointerType *bytes.Buffer
           Locations:
             - Range: 0x8ad9b4..0x8ad9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 147 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 129 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x8ad8d8..0x8ad8d8
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 148 StructureType context.backgroundCtx
+          Type: 130 StructureType context.backgroundCtx
           Locations:
             - Range: 0x8ad860..0x8adab0
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0x8adb90..0x8adbb4
               Pieces:
@@ -126,247 +126,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.098528e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 393504
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.636736e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.060448e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.4448e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 1.98912e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 534464
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 534144
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 536960
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 533888
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 768352
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 785280
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 371808
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 537024
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 537088
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.842592e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 480992
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 150 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 393440
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.304608e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 534336
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.060896e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 625568
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 534848
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.15472e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.190528e+06
@@ -374,84 +155,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 52 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 35 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 54 GoMapType net/url.Values
+          Type: 37 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 55 PointerType *mime/multipart.Form
+          Type: 38 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 129 GoChannelType <-chan struct {}
+          Type: 111 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 130 PointerType *net/http.Response
+          Type: 112 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 132 GoInterfaceType context.Context
+          Type: 114 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 133 PointerType *net/http.pattern
+          Type: 115 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 138 GoMapType map[string]string
+          Type: 120 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 533760
@@ -459,20 +240,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 153 PointerType *string.str
+          Type: 133 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 152 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 132 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 371808
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 533888
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 534336
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 1.94976e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 1.986816e+06
@@ -480,46 +280,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.1144e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.433088e+06
@@ -527,120 +327,126 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 534784
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 1.917984e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoHMapHeaderType hash<string,[]string>
+      Pointee: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 35
+      ID: 16
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 37 PointerType *bucket<string,[]string>
+          Type: 19 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 38 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 164 GoSliceDataType []bucket<string,[]string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 20 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 144 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 534016
       GoKind: 9
+    - __kind: BaseType
+      ID: 18
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 534144
+      GoKind: 10
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 38 GoHMapBucketType bucket<string,[]string>
+      Pointee: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 38
+      ID: 20
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 41 ArrayType []val<[]string>
+          Type: 23 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 37 PointerType *bucket<string,[]string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 42 GoSliceHeaderType []string
+          Type: 19 PointerType *bucket<string,[]string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 24 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 39
+      ID: 21
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 621920
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: ArrayType
-      ID: 40
+      ID: 22
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 41
+      ID: 23
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 42 GoSliceHeaderType []string
+      Element: 24 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 42
+      ID: 24
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 464768
@@ -648,30 +454,36 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 43 PointerType *string
+          Type: 25 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 155 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 135 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 43
+      ID: 25
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 371680
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
+    - __kind: BaseType
+      ID: 26
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 534464
+      GoKind: 12
     - __kind: PointerType
-      ID: 44
+      ID: 27
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 375584
       GoKind: 22
-      Pointee: 45 StructureType runtime.mapextra
+      Pointee: 28 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 45
+      ID: 28
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.429056e+06
@@ -679,22 +491,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 46 PointerType *[]*runtime.bmap
+          Type: 29 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 49 PointerType *runtime.bmap
+          Type: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 46
+      ID: 29
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 466496
       GoKind: 22
-      Pointee: 47 GoSliceHeaderType []*runtime.bmap
+      Pointee: 30 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 47
+      ID: 30
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 466432
@@ -702,28 +514,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 48 PointerType **runtime.bmap
+          Type: 31 PointerType **runtime.bmap
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 157 GoSliceDataType []*runtime.bmap.array
+          Type: 8 BaseType int
+      Data: 137 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 48
+      ID: 31
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 49 PointerType *runtime.bmap
+      Pointee: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 49
+      ID: 32
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.110048e+06
       GoKind: 22
-      Pointee: 50 StructureType runtime.bmap
+      Pointee: 33 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 50
+      ID: 33
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10992e+06
@@ -731,42 +543,48 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
     - __kind: GoInterfaceType
-      ID: 51
+      ID: 34
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.067328e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 52
+      ID: 35
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 634400
       GoKind: 19
     - __kind: BaseType
-      ID: 53
+      ID: 36
       Name: int64
       ByteSize: 8
       GoRuntimeType: 534208
       GoKind: 6
     - __kind: GoMapType
-      ID: 54
+      ID: 37
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.671328e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 55
+      ID: 38
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 837568
       GoKind: 22
-      Pointee: 56 StructureType mime/multipart.Form
+      Pointee: 39 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 56
+      ID: 39
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.294528e+06
@@ -774,96 +592,96 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 57 GoMapType map[string][]string
+          Type: 40 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 58 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 41 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 57
+      ID: 40
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 882592
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoMapType
-      ID: 58
+      ID: 41
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 887392
       GoKind: 21
-      HeaderType: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      HeaderType: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 42
       Name: '*hash<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
+      Pointee: 43 GoHMapHeaderType hash<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapHeaderType
-      ID: 60
+      ID: 43
       Name: hash<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: oldbuckets
           Offset: 24
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 161 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      BucketsType: 141 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
-      ID: 61
+      ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Pointee: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoHMapBucketType
-      ID: 62
+      ID: 45
       Name: bucket<string,[]*mime/multipart.FileHeader>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 63 ArrayType []val<[]*mime/multipart.FileHeader>
+          Type: 46 ArrayType []val<[]*mime/multipart.FileHeader>
         - Name: overflow
           Offset: 328
-          Type: 61 PointerType *bucket<string,[]*mime/multipart.FileHeader>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 44 PointerType *bucket<string,[]*mime/multipart.FileHeader>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: ArrayType
-      ID: 63
+      ID: 46
       Name: '[]val<[]*mime/multipart.FileHeader>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 64 GoSliceHeaderType []*mime/multipart.FileHeader
+      Element: 47 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 64
+      ID: 47
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 457504
@@ -871,29 +689,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 65 PointerType **mime/multipart.FileHeader
+          Type: 48 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 142 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 65
+      ID: 48
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 66 PointerType *mime/multipart.FileHeader
+      Pointee: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 66
+      ID: 49
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 837472
       GoKind: 22
-      Pointee: 67 StructureType mime/multipart.FileHeader
+      Pointee: 50 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 67
+      ID: 50
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.83856e+06
@@ -901,34 +719,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 68 GoMapType net/textproto.MIMEHeader
+          Type: 51 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: content
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 68
+      ID: 51
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.596448e+06
       GoKind: 21
-      HeaderType: 35 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 16 GoHMapHeaderType hash<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 69
+      ID: 52
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 463616
@@ -936,23 +754,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 165 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 145 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 70
+      ID: 53
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 836032
       GoKind: 22
-      Pointee: 71 StructureType crypto/tls.ConnectionState
+      Pointee: 54 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 71
+      ID: 54
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.100544e+06
@@ -960,54 +778,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 72 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 55 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 123 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 105 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 125 GoSliceHeaderType [][]uint8
+          Type: 107 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 127 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 109 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 128 BaseType crypto/tls.CurveID
+          Type: 110 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 72
+      ID: 55
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469664
@@ -1015,28 +833,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 73 PointerType **crypto/x509.Certificate
+          Type: 56 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 167 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 147 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 73
+      ID: 56
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
-      Pointee: 74 PointerType *crypto/x509.Certificate
+      Pointee: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 74
+      ID: 57
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 1.905824e+06
       GoKind: 22
-      Pointee: 75 StructureType crypto/x509.Certificate
+      Pointee: 58 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 75
+      ID: 58
       Name: crypto/x509.Certificate
       ByteSize: 1352
       GoRuntimeType: 2.2352e+06
@@ -1044,179 +862,173 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 76 BaseType crypto/x509.SignatureAlgorithm
+          Type: 59 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 77 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 60 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 80 PointerType *math/big.Int
+          Type: 62 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 85 StructureType crypto/x509/pkix.Name
+          Type: 67 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 91 StructureType time.Time
+          Type: 73 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 101 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 102 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 107 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 110 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 113 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 115 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 105 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 120 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
     - __kind: BaseType
-      ID: 76
+      ID: 59
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.071168e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 77
+      ID: 60
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 768544
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 78
+      ID: 61
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 785472
       GoKind: 20
-      UnderlyingStructure: 79 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 79
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 80
+      ID: 62
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.231648e+06
       GoKind: 22
-      Pointee: 81 StructureType math/big.Int
+      Pointee: 63 StructureType math/big.Int
     - __kind: StructureType
-      ID: 81
+      ID: 63
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.308608e+06
@@ -1224,12 +1036,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 82 GoSliceHeaderType math/big.nat
+          Type: 64 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 82
+      ID: 64
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.214784e+06
@@ -1237,29 +1049,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 83 PointerType *math/big.Word
+          Type: 65 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 169 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 149 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 83
+      ID: 65
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 397920
       GoKind: 22
-      Pointee: 84 BaseType math/big.Word
+      Pointee: 66 BaseType math/big.Word
     - __kind: BaseType
-      ID: 84
+      ID: 66
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 537728
       GoKind: 7
     - __kind: StructureType
-      ID: 85
+      ID: 67
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.047488e+06
@@ -1267,39 +1079,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 86 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 68 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 86
+      ID: 68
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 482016
@@ -1307,23 +1119,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 87 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 408928
       GoKind: 22
-      Pointee: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.316608e+06
@@ -1331,12 +1143,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 78 GoEmptyInterfaceType interface {}
+          Type: 61 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 89
+      ID: 71
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.010048e+06
@@ -1344,23 +1156,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 90 PointerType *int
+          Type: 72 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 372256
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.215712e+06
@@ -1368,28 +1180,28 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 92 BaseType uint64
+          Type: 74 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 93 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: BaseType
-      ID: 92
+      ID: 74
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 534272
       GoKind: 11
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.421568e+06
       GoKind: 22
-      Pointee: 94 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.834528e+06
@@ -1397,27 +1209,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 95 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 98 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 95
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 459168
@@ -1425,23 +1237,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 96 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 175 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 155 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 367136
       GoKind: 22
-      Pointee: 97 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.421376e+06
@@ -1449,15 +1261,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 98
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 459232
@@ -1465,23 +1277,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 99 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 177 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 157 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 99
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 367200
       GoKind: 22
-      Pointee: 100 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.623872e+06
@@ -1489,24 +1301,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 101
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 537408
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 102
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 481504
@@ -1514,23 +1326,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 103 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 409120
       GoKind: 22
-      Pointee: 104 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 104
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.45536e+06
@@ -1538,15 +1350,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 105
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 481568
@@ -1554,23 +1366,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 106 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.00992e+06
       GoKind: 22
-      Pointee: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 107
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 470944
@@ -1578,29 +1390,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 108 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 395104
       GoKind: 22
-      Pointee: 109 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 109
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 537472
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 110
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 454176
@@ -1608,23 +1420,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 111 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 185 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 165 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 111
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 1.974688e+06
       GoKind: 22
-      Pointee: 112 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 112
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 1.948704e+06
@@ -1632,16 +1444,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 187 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 167 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 481632
@@ -1649,21 +1461,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 114 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 189 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 169 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 114
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 115
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 481696
@@ -1671,29 +1483,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 116 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 191 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 171 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 117 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 117
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.095968e+06
       GoKind: 22
-      Pointee: 118 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 118
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.276128e+06
@@ -1701,12 +1513,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 112 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 119 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 119
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 976000
@@ -1714,16 +1526,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 193 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 173 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 481760
@@ -1731,23 +1543,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 121 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 195 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 175 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.717792e+06
       GoKind: 22
-      Pointee: 122 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.718016e+06
@@ -1755,9 +1567,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 469792
@@ -1765,22 +1577,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 124 PointerType *[]*crypto/x509.Certificate
+          Type: 106 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 124
+      ID: 106
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 125
+      ID: 107
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 452960
@@ -1788,47 +1600,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 126 PointerType *[]uint8
+          Type: 108 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 199 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 179 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 126
+      ID: 108
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 452640
       GoKind: 22
-      Pointee: 69 GoSliceHeaderType []uint8
+      Pointee: 52 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 127
+      ID: 109
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 960448
       GoKind: 19
     - __kind: BaseType
-      ID: 128
+      ID: 110
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 766144
       GoKind: 9
     - __kind: GoChannelType
-      ID: 129
+      ID: 111
       Name: <-chan struct {}
       GoRuntimeType: 546944
       GoKind: 18
     - __kind: PointerType
-      ID: 130
+      ID: 112
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.591456e+06
       GoKind: 22
-      Pointee: 131 StructureType net/http.Response
+      Pointee: 113 StructureType net/http.Response
     - __kind: StructureType
-      ID: 131
+      ID: 113
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.065376e+06
@@ -1836,62 +1648,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 51 GoInterfaceType io.ReadCloser
+          Type: 34 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 53 BaseType int64
+          Type: 36 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 42 GoSliceHeaderType []string
+          Type: 24 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 70 PointerType *crypto/tls.ConnectionState
+          Type: 53 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 132
+      ID: 114
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.187296e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.416576e+06
       GoKind: 22
-      Pointee: 134 StructureType net/http.pattern
+      Pointee: 116 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.702112e+06
@@ -1899,21 +1717,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 135 GoSliceHeaderType []net/http.segment
+          Type: 117 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 135
+      ID: 117
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 454944
@@ -1921,23 +1739,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 136 PointerType *net/http.segment
+          Type: 118 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 201 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 181 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 136
+      ID: 118
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 364064
       GoKind: 22
-      Pointee: 137 StructureType net/http.segment
+      Pointee: 119 StructureType net/http.segment
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.416384e+06
@@ -1945,99 +1763,99 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 884224
       GoKind: 21
-      HeaderType: 140 GoHMapHeaderType hash<string,string>
+      HeaderType: 122 GoHMapHeaderType hash<string,string>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*hash<string,string>'
       ByteSize: 8
-      Pointee: 140 GoHMapHeaderType hash<string,string>
+      Pointee: 122 GoHMapHeaderType hash<string,string>
     - __kind: GoHMapHeaderType
-      ID: 140
+      ID: 122
       Name: hash<string,string>
       ByteSize: 48
       RawFields:
         - Name: count
           Offset: 0
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: flags
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: B
           Offset: 9
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: noverflow
           Offset: 10
-          Type: 36 BaseType uint16
+          Type: 17 BaseType uint16
         - Name: hash0
           Offset: 12
-          Type: 9 BaseType uint32
+          Type: 18 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: oldbuckets
           Offset: 24
-          Type: 141 PointerType *bucket<string,string>
+          Type: 123 PointerType *bucket<string,string>
         - Name: nevacuate
           Offset: 32
-          Type: 8 BaseType uintptr
+          Type: 26 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 44 PointerType *runtime.mapextra
-      BucketType: 142 GoHMapBucketType bucket<string,string>
-      BucketsType: 203 GoSliceDataType []bucket<string,string>.array
+          Type: 27 PointerType *runtime.mapextra
+      BucketType: 124 GoHMapBucketType bucket<string,string>
+      BucketsType: 183 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '*bucket<string,string>'
       ByteSize: 8
-      Pointee: 142 GoHMapBucketType bucket<string,string>
+      Pointee: 124 GoHMapBucketType bucket<string,string>
     - __kind: GoHMapBucketType
-      ID: 142
+      ID: 124
       Name: bucket<string,string>
       ByteSize: 272
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 39 ArrayType [8]uint8
+          Type: 21 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 40 ArrayType []key<string>
+          Type: 22 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 143 ArrayType []val<string>
+          Type: 125 ArrayType []val<string>
         - Name: overflow
           Offset: 264
-          Type: 141 PointerType *bucket<string,string>
-      KeyType: 27 GoStringHeaderType string
-      ValueType: 27 GoStringHeaderType string
+          Type: 123 PointerType *bucket<string,string>
+      KeyType: 5 GoStringHeaderType string
+      ValueType: 5 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 143
+      ID: 125
       Name: '[]val<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 144
+      ID: 126
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.11552e+06
       GoKind: 22
-      Pointee: 145 StructureType bytes.Buffer
+      Pointee: 127 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 145
+      ID: 127
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.414272e+06
@@ -2045,312 +1863,308 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 69 GoSliceHeaderType []uint8
+          Type: 52 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 146 BaseType bytes.readOp
+          Type: 128 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 146
+      ID: 128
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 532992
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 147
+      ID: 129
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.296128e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 148
+      ID: 130
       Name: context.backgroundCtx
       GoRuntimeType: 1.667744e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 149 StructureType context.emptyCtx
+          Type: 131 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 149
+      ID: 131
       Name: context.emptyCtx
       GoRuntimeType: 1.399808e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 150
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 151
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 150 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 152
+      ID: 132
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 153
+      ID: 133
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 152 GoStringDataType string.str
+      Pointee: 132 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 134
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 135
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 156
+      ID: 136
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []string.array
+      Pointee: 135 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 137
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 49 PointerType *runtime.bmap
+      Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 158
+      ID: 138
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []*runtime.bmap.array
+      Pointee: 137 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 139
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 140
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 141
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
-      Element: 62 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
+      Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 142
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 66 PointerType *mime/multipart.FileHeader
+      Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 163
+      ID: 143
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 142 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 144
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 38 GoHMapBucketType bucket<string,[]string>
+      Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 145
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 166
+      ID: 146
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []uint8.array
+      Pointee: 145 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 147
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 PointerType *crypto/x509.Certificate
+      Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 168
+      ID: 148
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 147 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 149
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 84 BaseType math/big.Word
+      Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 170
+      ID: 150
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType math/big.nat.array
+      Pointee: 149 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 151
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 88 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 172
+      ID: 152
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 153
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 174
+      ID: 154
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 155
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 97 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 176
+      ID: 156
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []time.zone.array
+      Pointee: 155 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 157
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 100 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 178
+      ID: 158
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []time.zoneTrans.array
+      Pointee: 157 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 159
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 104 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 180
+      ID: 160
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 161
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 89 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 182
+      ID: 162
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 163
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 109 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 184
+      ID: 164
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 165
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 112 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 186
+      ID: 166
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType []net.IP.array
+      Pointee: 165 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 167
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 188
+      ID: 168
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType net.IP.array
+      Pointee: 167 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 169
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 190
+      ID: 170
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []*net/url.URL.array
+      Pointee: 169 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 171
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 117 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 192
+      ID: 172
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []*net.IPNet.array
+      Pointee: 171 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 173
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 194
+      ID: 174
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType net.IPMask.array
+      Pointee: 173 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 175
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 122 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 196
+      ID: 176
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 175 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 177
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 72 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 198
+      ID: 178
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 179
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 69 GoSliceHeaderType []uint8
+      Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 200
+      ID: 180
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType [][]uint8.array
+      Pointee: 179 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 181
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 137 StructureType net/http.segment
+      Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 202
+      ID: 182
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []net/http.segment.array
+      Pointee: 181 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 183
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
-      Element: 142 GoHMapBucketType bucket<string,string>
+      Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 204
+      ID: 184
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2367,14 +2181,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 185
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2382,11 +2196,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 205
+MaxTypeID: 185
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.23.11.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 184 EventRootType Probe[main.HandleHTTP]
+          Type: 206 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x8ad870", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 185 EventRootType Probe[main.LookAtTheRequest]
+          Type: 207 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x8adb9c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -240,11 +240,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 155 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 154 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -385,7 +385,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 20 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 144 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 166 GoSliceDataType []bucket<string,[]string>.array
     - __kind: BaseType
       ID: 17
       Name: uint16
@@ -461,7 +461,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 135 GoSliceDataType []string.array
+      Data: 157 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 25
       Name: '*string'
@@ -521,7 +521,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 137 GoSliceDataType []*runtime.bmap.array
+      Data: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 31
       Name: '**runtime.bmap'
@@ -648,7 +648,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
-      BucketsType: 141 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
+      BucketsType: 163 GoSliceDataType []bucket<string,[]*mime/multipart.FileHeader>.array
     - __kind: PointerType
       ID: 44
       Name: '*bucket<string,[]*mime/multipart.FileHeader>'
@@ -696,7 +696,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 142 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 164 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 48
       Name: '**mime/multipart.FileHeader'
@@ -761,7 +761,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 145 GoSliceDataType []uint8.array
+      Data: 167 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 53
       Name: '*crypto/tls.ConnectionState'
@@ -840,7 +840,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 147 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 169 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 56
       Name: '**crypto/x509.Certificate'
@@ -1056,7 +1056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 149 GoSliceDataType math/big.nat.array
+      Data: 171 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 65
       Name: '*math/big.Word'
@@ -1126,7 +1126,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 69
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1163,7 +1163,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 72
       Name: '*int'
@@ -1244,7 +1244,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 155 GoSliceDataType []time.zone.array
+      Data: 177 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1284,7 +1284,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 157 GoSliceDataType []time.zoneTrans.array
+      Data: 179 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1333,7 +1333,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1373,7 +1373,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1397,7 +1397,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1427,7 +1427,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 165 GoSliceDataType []net.IP.array
+      Data: 187 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1451,7 +1451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 167 GoSliceDataType net.IP.array
+      Data: 189 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 169 GoSliceDataType []*net/url.URL.array
+      Data: 191 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1490,7 +1490,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 171 GoSliceDataType []*net.IPNet.array
+      Data: 193 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1533,7 +1533,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 173 GoSliceDataType net.IPMask.array
+      Data: 195 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1550,7 +1550,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 175 GoSliceDataType []crypto/x509.OID.array
+      Data: 197 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1584,7 +1584,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 106
       Name: '*[]*crypto/x509.Certificate'
@@ -1607,7 +1607,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 179 GoSliceDataType [][]uint8.array
+      Data: 201 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 108
       Name: '*[]uint8'
@@ -1746,7 +1746,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 181 GoSliceDataType []net/http.segment.array
+      Data: 203 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 118
       Name: '*net/http.segment'
@@ -1815,7 +1815,7 @@ Types:
           Offset: 40
           Type: 27 PointerType *runtime.mapextra
       BucketType: 124 GoHMapBucketType bucket<string,string>
-      BucketsType: 183 GoSliceDataType []bucket<string,string>.array
+      BucketsType: 205 GoSliceDataType []bucket<string,string>.array
     - __kind: PointerType
       ID: 123
       Name: '*bucket<string,string>'
@@ -1904,267 +1904,419 @@ Types:
       GoRuntimeType: 1.399808e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 132
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 372704
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: PointerType
+      ID: 133
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 372384
+      GoKind: 22
+      Pointee: 26 BaseType uintptr
+    - __kind: BaseType
+      ID: 134
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 534400
+      GoKind: 7
+    - __kind: BaseType
+      ID: 135
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 534080
+      GoKind: 5
+    - __kind: BaseType
+      ID: 136
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 533824
+      GoKind: 3
+    - __kind: BaseType
+      ID: 137
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 534656
+      GoKind: 13
+    - __kind: BaseType
+      ID: 138
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 534720
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 139
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 987648
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: PointerType
+      ID: 140
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 372000
+      GoKind: 22
+      Pointee: 135 BaseType int32
+    - __kind: PointerType
+      ID: 141
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 372064
+      GoKind: 22
+      Pointee: 18 BaseType uint32
+    - __kind: BaseType
+      ID: 142
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 533952
+      GoKind: 4
+    - __kind: BaseType
+      ID: 143
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 534528
+      GoKind: 15
+    - __kind: BaseType
+      ID: 144
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 534592
+      GoKind: 16
+    - __kind: PointerType
+      ID: 145
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 372640
+      GoKind: 22
+      Pointee: 138 BaseType float64
+    - __kind: PointerType
+      ID: 146
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 372128
+      GoKind: 22
+      Pointee: 36 BaseType int64
+    - __kind: PointerType
+      ID: 147
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 372192
+      GoKind: 22
+      Pointee: 74 BaseType uint64
+    - __kind: PointerType
+      ID: 148
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 371936
+      GoKind: 22
+      Pointee: 17 BaseType uint16
+    - __kind: PointerType
+      ID: 149
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 371872
+      GoKind: 22
+      Pointee: 142 BaseType int16
+    - __kind: PointerType
+      ID: 150
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 371744
+      GoKind: 22
+      Pointee: 136 BaseType int8
+    - __kind: PointerType
+      ID: 151
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 371616
+      GoKind: 22
+      Pointee: 139 GoInterfaceType error
+    - __kind: PointerType
+      ID: 152
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 372320
+      GoKind: 22
+      Pointee: 134 BaseType uint
+    - __kind: PointerType
+      ID: 153
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 372576
+      GoKind: 22
+      Pointee: 137 BaseType float32
+    - __kind: GoStringDataType
+      ID: 154
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 133
+      ID: 155
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 154 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 156
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 135
+      ID: 157
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 136
+      ID: 158
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 135 GoSliceDataType []string.array
+      Pointee: 157 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 137
+      ID: 159
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 32 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 138
+      ID: 160
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 137 GoSliceDataType []*runtime.bmap.array
+      Pointee: 159 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 161
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 162
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 163
       Name: '[]bucket<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 2048
       Element: 45 GoHMapBucketType bucket<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 164
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 49 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 143
+      ID: 165
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 142 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 164 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 166
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 20 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 145
+      ID: 167
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 146
+      ID: 168
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 145 GoSliceDataType []uint8.array
+      Pointee: 167 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 169
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 57 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 148
+      ID: 170
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 147 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 169 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 171
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 66 BaseType math/big.Word
     - __kind: PointerType
-      ID: 150
+      ID: 172
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 149 GoSliceDataType math/big.nat.array
+      Pointee: 171 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 173
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 70 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 152
+      ID: 174
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 151 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 173 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 153
+      ID: 175
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 154
+      ID: 176
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 153 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 175 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 177
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 156
+      ID: 178
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 155 GoSliceDataType []time.zone.array
+      Pointee: 177 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 179
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 158
+      ID: 180
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 157 GoSliceDataType []time.zoneTrans.array
+      Pointee: 179 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 159
+      ID: 181
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 160
+      ID: 182
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 159 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 181 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 183
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 71 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 162
+      ID: 184
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 161 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 183 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 185
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 164
+      ID: 186
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 163 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 185 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 187
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 166
+      ID: 188
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []net.IP.array
+      Pointee: 187 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 189
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 168
+      ID: 190
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 167 GoSliceDataType net.IP.array
+      Pointee: 189 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 191
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 170
+      ID: 192
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 169 GoSliceDataType []*net/url.URL.array
+      Pointee: 191 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 193
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 172
+      ID: 194
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 171 GoSliceDataType []*net.IPNet.array
+      Pointee: 193 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 195
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 174
+      ID: 196
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType net.IPMask.array
+      Pointee: 195 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 197
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 176
+      ID: 198
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 175 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 197 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 199
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 55 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 178
+      ID: 200
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 199 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 201
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 52 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 180
+      ID: 202
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType [][]uint8.array
+      Pointee: 201 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 203
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 119 StructureType net/http.segment
     - __kind: PointerType
-      ID: 182
+      ID: 204
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType []net/http.segment.array
+      Pointee: 203 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 205
       Name: '[]bucket<string,string>.array'
       ByteSize: 2048
       Element: 124 GoHMapBucketType bucket<string,string>
     - __kind: EventRootType
-      ID: 184
+      ID: 206
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2188,7 +2340,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 207
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2202,5 +2354,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 185
+MaxTypeID: 207
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 219 EventRootType Probe[main.HandleHTTP]
+          Type: 198 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 220 EventRootType Probe[main.LookAtTheRequest]
+          Type: 199 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -56,7 +56,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: r
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
           Locations:
             - Range: 0x86c100..0x86c164
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
@@ -65,7 +65,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: '&buf'
-          Type: 153 PointerType *bytes.Buffer
+          Type: 134 PointerType *bytes.Buffer
           Locations:
             - Range: 0x86c254..0x86c268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -74,7 +74,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: span
-          Type: 156 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
+          Type: 137 GoInterfaceType gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
           Locations:
             - Range: 0x86c178..0x86c178
               Pieces:
@@ -97,7 +97,7 @@ Subprograms:
           IsParameter: false
           IsReturn: false
         - Name: .autotmp_14
-          Type: 157 StructureType context.backgroundCtx
+          Type: 138 StructureType context.backgroundCtx
           Locations:
             - Range: 0x86c100..0x86c340
               Pieces: [{Size: 0, Op: {CfaOffset: 0}}]
@@ -109,7 +109,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: path
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
           Locations:
             - Range: 0x86c410..0x86c434
               Pieces:
@@ -126,247 +126,28 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.176352e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 2
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 3 PointerType *internal/abi.ITab
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 3
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 418432
-      GoKind: 22
-      Pointee: 4 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 4
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.749056e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 5 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 22 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 23 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 5
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.190112e+06
-      GoKind: 22
-      Pointee: 6 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 6
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.625632e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 7 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 17 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 18 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 7
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.11456e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 8 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 8 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 9 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 10 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 11 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 11 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 12 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 13 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 14 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 8
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 580128
-      GoKind: 12
-    - __kind: BaseType
-      ID: 9
-      Name: uint32
-      ByteSize: 4
-      GoRuntimeType: 579808
-      GoKind: 10
-    - __kind: BaseType
-      ID: 10
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 582624
-      GoKind: 8
-    - __kind: BaseType
-      ID: 11
-      Name: uint8
-      ByteSize: 1
-      GoRuntimeType: 579552
-      GoKind: 8
-    - __kind: BaseType
-      ID: 12
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 831264
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 13
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 847040
-      GoKind: 19
-    - __kind: PointerType
-      ID: 14
-      Name: '*uint8'
-      ByteSize: 8
-      GoRuntimeType: 396288
-      GoKind: 22
-      Pointee: 11 BaseType uint8
-    - __kind: BaseType
-      ID: 15
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 582688
-      GoKind: 5
-    - __kind: BaseType
-      ID: 16
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 582752
-      GoKind: 5
-    - __kind: StructureType
-      ID: 17
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.966176e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 14 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 18
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 510944
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 19 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 21 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 21 BaseType int
-      Data: 159 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 19
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 418368
-      GoKind: 22
-      Pointee: 20 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 20
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.477664e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 15 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 16 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 21
-      Name: int
-      ByteSize: 8
-      GoRuntimeType: 580000
-      GoKind: 2
-    - __kind: PointerType
-      ID: 22
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.19056e+06
-      GoKind: 22
-      Pointee: 7 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 23
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 678592
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 8 BaseType uintptr
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 24
+      ID: 2
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 580512
       GoKind: 26
     - __kind: PointerType
-      ID: 25
+      ID: 3
       Name: '*net/http.Request'
       ByteSize: 8
       GoRuntimeType: 2.2848e+06
       GoKind: 22
-      Pointee: 26 StructureType net/http.Request
+      Pointee: 4 StructureType net/http.Request
     - __kind: StructureType
-      ID: 26
+      ID: 4
       Name: net/http.Request
       ByteSize: 304
       GoRuntimeType: 2.322048e+06
@@ -374,84 +155,84 @@ Types:
       RawFields:
         - Name: Method
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: URL
           Offset: 16
-          Type: 28 PointerType *net/url.URL
+          Type: 9 PointerType *net/url.URL
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: GetBody
           Offset: 80
-          Type: 49 GoSubroutineType func() (io.ReadCloser, error)
+          Type: 31 GoSubroutineType func() (io.ReadCloser, error)
         - Name: ContentLength
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 120
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Host
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Form
           Offset: 144
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: PostForm
           Offset: 152
-          Type: 51 GoMapType net/url.Values
+          Type: 33 GoMapType net/url.Values
         - Name: MultipartForm
           Offset: 160
-          Type: 52 PointerType *mime/multipart.Form
+          Type: 34 PointerType *mime/multipart.Form
         - Name: Trailer
           Offset: 168
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: RemoteAddr
           Offset: 176
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RequestURI
           Offset: 192
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: TLS
           Offset: 208
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
         - Name: Cancel
           Offset: 216
-          Type: 133 GoChannelType <-chan struct {}
+          Type: 114 GoChannelType <-chan struct {}
         - Name: Response
           Offset: 224
-          Type: 134 PointerType *net/http.Response
+          Type: 115 PointerType *net/http.Response
         - Name: Pattern
           Offset: 232
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ctx
           Offset: 248
-          Type: 136 GoInterfaceType context.Context
+          Type: 117 GoInterfaceType context.Context
         - Name: pat
           Offset: 264
-          Type: 137 PointerType *net/http.pattern
+          Type: 118 PointerType *net/http.pattern
         - Name: matches
           Offset: 272
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: otherValues
           Offset: 296
-          Type: 142 GoMapType map[string]string
+          Type: 123 GoMapType map[string]string
     - __kind: GoStringHeaderType
-      ID: 27
+      ID: 5
       Name: string
       ByteSize: 16
       GoRuntimeType: 579424
@@ -459,20 +240,39 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 162 PointerType *string.str
+          Type: 141 PointerType *string.str
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
-      Data: 161 GoStringDataType string.str
+          Type: 8 BaseType int
+      Data: 140 GoStringDataType string.str
     - __kind: PointerType
-      ID: 28
+      ID: 6
+      Name: '*uint8'
+      ByteSize: 8
+      GoRuntimeType: 396288
+      GoKind: 22
+      Pointee: 7 BaseType uint8
+    - __kind: BaseType
+      ID: 7
+      Name: uint8
+      ByteSize: 1
+      GoRuntimeType: 579552
+      GoKind: 8
+    - __kind: BaseType
+      ID: 8
+      Name: int
+      ByteSize: 8
+      GoRuntimeType: 580000
+      GoKind: 2
+    - __kind: PointerType
+      ID: 9
       Name: '*net/url.URL'
       ByteSize: 8
       GoRuntimeType: 2.099328e+06
       GoKind: 22
-      Pointee: 29 StructureType net/url.URL
+      Pointee: 10 StructureType net/url.URL
     - __kind: StructureType
-      ID: 29
+      ID: 10
       Name: net/url.URL
       ByteSize: 144
       GoRuntimeType: 2.112256e+06
@@ -480,46 +280,46 @@ Types:
       RawFields:
         - Name: Scheme
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Opaque
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: User
           Offset: 32
-          Type: 30 PointerType *net/url.Userinfo
+          Type: 11 PointerType *net/url.Userinfo
         - Name: Host
           Offset: 40
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Path
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawPath
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: OmitHost
           Offset: 88
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ForceQuery
           Offset: 89
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RawQuery
           Offset: 96
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Fragment
           Offset: 112
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: RawFragment
           Offset: 128
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 30
+      ID: 11
       Name: '*net/url.Userinfo'
       ByteSize: 8
       GoRuntimeType: 1.191456e+06
       GoKind: 22
-      Pointee: 31 StructureType net/url.Userinfo
+      Pointee: 12 StructureType net/url.Userinfo
     - __kind: StructureType
-      ID: 31
+      ID: 12
       Name: net/url.Userinfo
       ByteSize: 40
       GoRuntimeType: 1.613536e+06
@@ -527,130 +327,136 @@ Types:
       RawFields:
         - Name: username
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: password
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: passwordSet
           Offset: 32
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 32
+      ID: 13
       Name: bool
       ByteSize: 1
       GoRuntimeType: 580448
       GoKind: 1
     - __kind: GoMapType
-      ID: 33
+      ID: 14
       Name: net/http.Header
       ByteSize: 8
       GoRuntimeType: 2.08736e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 34
+      ID: 15
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 35 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 35
+      ID: 16
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 37 PointerType **table<string,[]string>
+          Type: 19 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 175 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 43 StructureType noalg.map.group[string][]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
-      ID: 36
+      ID: 17
       Name: uint64
       ByteSize: 8
       GoRuntimeType: 579936
       GoKind: 11
+    - __kind: BaseType
+      ID: 18
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 580128
+      GoKind: 12
     - __kind: PointerType
-      ID: 37
+      ID: 19
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 38 PointerType *table<string,[]string>
+      Pointee: 20 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 38
+      ID: 20
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 39 StructureType table<string,[]string>
+      Pointee: 21 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 39
+      ID: 21
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 41 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 23 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: BaseType
-      ID: 40
+      ID: 22
       Name: uint16
       ByteSize: 2
       GoRuntimeType: 579680
       GoKind: 9
     - __kind: GoSwissMapGroupsType
-      ID: 41
+      ID: 23
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 42 PointerType *noalg.map.group[string][]string
+          Type: 24 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 43 StructureType noalg.map.group[string][]string
-      GroupSliceType: 176 GoSliceDataType []noalg.map.group[string][]string.array
+          Type: 17 BaseType uint64
+      GroupType: 25 StructureType noalg.map.group[string][]string
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 42
+      ID: 24
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 43 StructureType noalg.map.group[string][]string
+      Pointee: 25 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 43
+      ID: 25
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.280352e+06
@@ -658,21 +464,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 44 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 26 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 44
+      ID: 26
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 683872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 45 StructureType noalg.struct { key string; elem []string }
+      Element: 27 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 45
+      ID: 27
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.280224e+06
@@ -680,12 +486,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 46
+      ID: 28
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 492672
@@ -693,56 +499,62 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 47 PointerType *string
+          Type: 29 PointerType *string
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 165 GoSliceDataType []string.array
+          Type: 8 BaseType int
+      Data: 144 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 47
+      ID: 29
       Name: '*string'
       ByteSize: 8
       GoRuntimeType: 396160
       GoKind: 22
-      Pointee: 27 GoStringHeaderType string
+      Pointee: 5 GoStringHeaderType string
     - __kind: GoInterfaceType
-      ID: 48
+      ID: 30
       Name: io.ReadCloser
       ByteSize: 16
       GoRuntimeType: 1.100576e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 49
+      ID: 31
       Name: func() (io.ReadCloser, error)
       ByteSize: 8
       GoRuntimeType: 687840
       GoKind: 19
     - __kind: BaseType
-      ID: 50
+      ID: 32
       Name: int64
       ByteSize: 8
       GoRuntimeType: 579872
       GoKind: 6
     - __kind: GoMapType
-      ID: 51
+      ID: 33
       Name: net/url.Values
       ByteSize: 8
       GoRuntimeType: 1.870528e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 52
+      ID: 34
       Name: '*mime/multipart.Form'
       ByteSize: 8
       GoRuntimeType: 902400
       GoKind: 22
-      Pointee: 53 StructureType mime/multipart.Form
+      Pointee: 35 StructureType mime/multipart.Form
     - __kind: StructureType
-      ID: 53
+      ID: 35
       Name: mime/multipart.Form
       ByteSize: 16
       GoRuntimeType: 1.467264e+06
@@ -750,116 +562,116 @@ Types:
       RawFields:
         - Name: Value
           Offset: 0
-          Type: 54 GoMapType map[string][]string
+          Type: 36 GoMapType map[string][]string
         - Name: File
           Offset: 8
-          Type: 55 GoMapType map[string][]*mime/multipart.FileHeader
+          Type: 37 GoMapType map[string][]*mime/multipart.FileHeader
     - __kind: GoMapType
-      ID: 54
+      ID: 36
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117984e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoMapType
-      ID: 55
+      ID: 37
       Name: map[string][]*mime/multipart.FileHeader
       ByteSize: 8
       GoRuntimeType: 1.122592e+06
       GoKind: 21
-      HeaderType: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      HeaderType: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 56
+      ID: 38
       Name: '*map<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 57 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
+      Pointee: 39 GoSwissMapHeaderType map<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapHeaderType
-      ID: 57
+      ID: 39
       Name: map<string,[]*mime/multipart.FileHeader>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 58 PointerType **table<string,[]*mime/multipart.FileHeader>
+          Type: 40 PointerType **table<string,[]*mime/multipart.FileHeader>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 171 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 150 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 58
+      ID: 40
       Name: '**table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Pointee: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: PointerType
-      ID: 59
+      ID: 41
       Name: '*table<string,[]*mime/multipart.FileHeader>'
       ByteSize: 8
-      Pointee: 60 StructureType table<string,[]*mime/multipart.FileHeader>
+      Pointee: 42 StructureType table<string,[]*mime/multipart.FileHeader>
     - __kind: StructureType
-      ID: 60
+      ID: 42
       Name: table<string,[]*mime/multipart.FileHeader>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 61 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
+          Type: 43 GoSwissMapGroupsType groupReference<string,[]*mime/multipart.FileHeader>
     - __kind: GoSwissMapGroupsType
-      ID: 61
+      ID: 43
       Name: groupReference<string,[]*mime/multipart.FileHeader>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 62 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
+          Type: 44 PointerType *noalg.map.group[string][]*mime/multipart.FileHeader
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 172 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+          Type: 17 BaseType uint64
+      GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      GroupSliceType: 151 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 62
+      ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
       ByteSize: 8
-      Pointee: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Pointee: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 63
+      ID: 45
       Name: noalg.map.group[string][]*mime/multipart.FileHeader
       ByteSize: 328
       GoRuntimeType: 1.289824e+06
@@ -867,21 +679,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 64 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
+          Type: 46 ArrayType noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: ArrayType
-      ID: 64
+      ID: 46
       Name: noalg.[8]struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 320
       GoRuntimeType: 693888
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 65 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
+      Element: 47 StructureType noalg.struct { key string; elem []*mime/multipart.FileHeader }
     - __kind: StructureType
-      ID: 65
+      ID: 47
       Name: noalg.struct { key string; elem []*mime/multipart.FileHeader }
       ByteSize: 40
       GoRuntimeType: 1.289696e+06
@@ -889,12 +701,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 66 GoSliceHeaderType []*mime/multipart.FileHeader
+          Type: 48 GoSliceHeaderType []*mime/multipart.FileHeader
     - __kind: GoSliceHeaderType
-      ID: 66
+      ID: 48
       Name: '[]*mime/multipart.FileHeader'
       ByteSize: 24
       GoRuntimeType: 483744
@@ -902,29 +714,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 67 PointerType **mime/multipart.FileHeader
+          Type: 49 PointerType **mime/multipart.FileHeader
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+          Type: 8 BaseType int
+      Data: 152 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
-      ID: 67
+      ID: 49
       Name: '**mime/multipart.FileHeader'
       ByteSize: 8
       GoKind: 22
-      Pointee: 68 PointerType *mime/multipart.FileHeader
+      Pointee: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 68
+      ID: 50
       Name: '*mime/multipart.FileHeader'
       ByteSize: 8
       GoRuntimeType: 902304
       GoKind: 22
-      Pointee: 69 StructureType mime/multipart.FileHeader
+      Pointee: 51 StructureType mime/multipart.FileHeader
     - __kind: StructureType
-      ID: 69
+      ID: 51
       Name: mime/multipart.FileHeader
       ByteSize: 88
       GoRuntimeType: 1.962144e+06
@@ -932,34 +744,34 @@ Types:
       RawFields:
         - Name: Filename
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Header
           Offset: 16
-          Type: 70 GoMapType net/textproto.MIMEHeader
+          Type: 52 GoMapType net/textproto.MIMEHeader
         - Name: Size
           Offset: 24
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: content
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: tmpfile
           Offset: 56
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: tmpoff
           Offset: 72
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: tmpshared
           Offset: 80
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 70
+      ID: 52
       Name: net/textproto.MIMEHeader
       ByteSize: 8
       GoRuntimeType: 1.808288e+06
       GoKind: 21
-      HeaderType: 35 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 16 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSliceHeaderType
-      ID: 71
+      ID: 53
       Name: '[]uint8'
       ByteSize: 24
       GoRuntimeType: 491520
@@ -967,23 +779,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 177 GoSliceDataType []uint8.array
+          Type: 8 BaseType int
+      Data: 156 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 72
+      ID: 54
       Name: '*crypto/tls.ConnectionState'
       ByteSize: 8
       GoRuntimeType: 900864
       GoKind: 22
-      Pointee: 73 StructureType crypto/tls.ConnectionState
+      Pointee: 55 StructureType crypto/tls.ConnectionState
     - __kind: StructureType
-      ID: 73
+      ID: 55
       Name: crypto/tls.ConnectionState
       ByteSize: 192
       GoRuntimeType: 2.231616e+06
@@ -991,54 +803,54 @@ Types:
       RawFields:
         - Name: Version
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: HandshakeComplete
           Offset: 2
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: DidResume
           Offset: 3
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: CipherSuite
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: NegotiatedProtocol
           Offset: 8
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: NegotiatedProtocolIsMutual
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ServerName
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: PeerCertificates
           Offset: 48
-          Type: 74 GoSliceHeaderType []*crypto/x509.Certificate
+          Type: 56 GoSliceHeaderType []*crypto/x509.Certificate
         - Name: VerifiedChains
           Offset: 72
-          Type: 127 GoSliceHeaderType [][]*crypto/x509.Certificate
+          Type: 108 GoSliceHeaderType [][]*crypto/x509.Certificate
         - Name: SignedCertificateTimestamps
           Offset: 96
-          Type: 129 GoSliceHeaderType [][]uint8
+          Type: 110 GoSliceHeaderType [][]uint8
         - Name: OCSPResponse
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: TLSUnique
           Offset: 144
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: ECHAccepted
           Offset: 168
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: ekm
           Offset: 176
-          Type: 131 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
+          Type: 112 GoSubroutineType func(string, []uint8, int) ([]uint8, error)
         - Name: testingOnlyDidHRR
           Offset: 184
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: testingOnlyCurveID
           Offset: 186
-          Type: 132 BaseType crypto/tls.CurveID
+          Type: 113 BaseType crypto/tls.CurveID
     - __kind: GoSliceHeaderType
-      ID: 74
+      ID: 56
       Name: '[]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498304
@@ -1046,29 +858,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 75 PointerType **crypto/x509.Certificate
+          Type: 57 PointerType **crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 179 GoSliceDataType []*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 158 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 75
+      ID: 57
       Name: '**crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 76 PointerType *crypto/x509.Certificate
+      Pointee: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 76
+      ID: 58
       Name: '*crypto/x509.Certificate'
       ByteSize: 8
       GoRuntimeType: 2.030304e+06
       GoKind: 22
-      Pointee: 77 StructureType crypto/x509.Certificate
+      Pointee: 59 StructureType crypto/x509.Certificate
     - __kind: StructureType
-      ID: 77
+      ID: 59
       Name: crypto/x509.Certificate
       ByteSize: 1424
       GoRuntimeType: 2.37712e+06
@@ -1076,200 +888,194 @@ Types:
       RawFields:
         - Name: Raw
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawTBSCertificate
           Offset: 24
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubjectPublicKeyInfo
           Offset: 48
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawSubject
           Offset: 72
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: RawIssuer
           Offset: 96
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: Signature
           Offset: 120
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: SignatureAlgorithm
           Offset: 144
-          Type: 78 BaseType crypto/x509.SignatureAlgorithm
+          Type: 60 BaseType crypto/x509.SignatureAlgorithm
         - Name: PublicKeyAlgorithm
           Offset: 152
-          Type: 79 BaseType crypto/x509.PublicKeyAlgorithm
+          Type: 61 BaseType crypto/x509.PublicKeyAlgorithm
         - Name: PublicKey
           Offset: 160
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
         - Name: Version
           Offset: 176
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: SerialNumber
           Offset: 184
-          Type: 82 PointerType *math/big.Int
+          Type: 63 PointerType *math/big.Int
         - Name: Issuer
           Offset: 192
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: Subject
           Offset: 440
-          Type: 87 StructureType crypto/x509/pkix.Name
+          Type: 68 StructureType crypto/x509/pkix.Name
         - Name: NotBefore
           Offset: 688
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: NotAfter
           Offset: 712
-          Type: 93 StructureType time.Time
+          Type: 74 StructureType time.Time
         - Name: KeyUsage
           Offset: 736
-          Type: 102 BaseType crypto/x509.KeyUsage
+          Type: 83 BaseType crypto/x509.KeyUsage
         - Name: Extensions
           Offset: 744
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: ExtraExtensions
           Offset: 768
-          Type: 103 GoSliceHeaderType []crypto/x509/pkix.Extension
+          Type: 84 GoSliceHeaderType []crypto/x509/pkix.Extension
         - Name: UnhandledCriticalExtensions
           Offset: 792
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: ExtKeyUsage
           Offset: 816
-          Type: 108 GoSliceHeaderType []crypto/x509.ExtKeyUsage
+          Type: 89 GoSliceHeaderType []crypto/x509.ExtKeyUsage
         - Name: UnknownExtKeyUsage
           Offset: 840
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: BasicConstraintsValid
           Offset: 864
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: IsCA
           Offset: 865
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: MaxPathLen
           Offset: 872
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: MaxPathLenZero
           Offset: 880
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: SubjectKeyId
           Offset: 888
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: AuthorityKeyId
           Offset: 912
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: OCSPServer
           Offset: 936
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IssuingCertificateURL
           Offset: 960
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: DNSNames
           Offset: 984
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: EmailAddresses
           Offset: 1008
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: IPAddresses
           Offset: 1032
-          Type: 111 GoSliceHeaderType []net.IP
+          Type: 92 GoSliceHeaderType []net.IP
         - Name: URIs
           Offset: 1056
-          Type: 114 GoSliceHeaderType []*net/url.URL
+          Type: 95 GoSliceHeaderType []*net/url.URL
         - Name: PermittedDNSDomainsCritical
           Offset: 1080
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PermittedDNSDomains
           Offset: 1088
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedDNSDomains
           Offset: 1112
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedIPRanges
           Offset: 1136
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: ExcludedIPRanges
           Offset: 1160
-          Type: 116 GoSliceHeaderType []*net.IPNet
+          Type: 97 GoSliceHeaderType []*net.IPNet
         - Name: PermittedEmailAddresses
           Offset: 1184
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedEmailAddresses
           Offset: 1208
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PermittedURIDomains
           Offset: 1232
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: ExcludedURIDomains
           Offset: 1256
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: CRLDistributionPoints
           Offset: 1280
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PolicyIdentifiers
           Offset: 1304
-          Type: 106 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
+          Type: 87 GoSliceHeaderType []encoding/asn1.ObjectIdentifier
         - Name: Policies
           Offset: 1328
-          Type: 121 GoSliceHeaderType []crypto/x509.OID
+          Type: 102 GoSliceHeaderType []crypto/x509.OID
         - Name: InhibitAnyPolicy
           Offset: 1352
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitAnyPolicyZero
           Offset: 1360
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: InhibitPolicyMapping
           Offset: 1368
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: InhibitPolicyMappingZero
           Offset: 1376
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: RequireExplicitPolicy
           Offset: 1384
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: RequireExplicitPolicyZero
           Offset: 1392
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: PolicyMappings
           Offset: 1400
-          Type: 124 GoSliceHeaderType []crypto/x509.PolicyMapping
+          Type: 105 GoSliceHeaderType []crypto/x509.PolicyMapping
     - __kind: BaseType
-      ID: 78
+      ID: 60
       Name: crypto/x509.SignatureAlgorithm
       ByteSize: 8
       GoRuntimeType: 1.104544e+06
       GoKind: 2
     - __kind: BaseType
-      ID: 79
+      ID: 61
       Name: crypto/x509.PublicKeyAlgorithm
       ByteSize: 8
       GoRuntimeType: 831456
       GoKind: 2
     - __kind: GoEmptyInterfaceType
-      ID: 80
+      ID: 62
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 848672
       GoKind: 20
-      UnderlyingStructure: 81 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 81
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 22 PointerType *internal/abi.Type
+          Type: 2 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 24 VoidPointerType unsafe.Pointer
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 82
+      ID: 63
       Name: '*math/big.Int'
       ByteSize: 8
       GoRuntimeType: 2.364704e+06
       GoKind: 22
-      Pointee: 83 StructureType math/big.Int
+      Pointee: 64 StructureType math/big.Int
     - __kind: StructureType
-      ID: 83
+      ID: 64
       Name: math/big.Int
       ByteSize: 32
       GoRuntimeType: 1.483264e+06
@@ -1277,12 +1083,12 @@ Types:
       RawFields:
         - Name: neg
           Offset: 0
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: abs
           Offset: 8
-          Type: 84 GoSliceHeaderType math/big.nat
+          Type: 65 GoSliceHeaderType math/big.nat
     - __kind: GoSliceHeaderType
-      ID: 84
+      ID: 65
       Name: math/big.nat
       ByteSize: 24
       GoRuntimeType: 2.345504e+06
@@ -1290,29 +1096,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 85 PointerType *math/big.Word
+          Type: 66 PointerType *math/big.Word
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 181 GoSliceDataType math/big.nat.array
+          Type: 8 BaseType int
+      Data: 160 GoSliceDataType math/big.nat.array
     - __kind: PointerType
-      ID: 85
+      ID: 66
       Name: '*math/big.Word'
       ByteSize: 8
       GoRuntimeType: 423040
       GoKind: 22
-      Pointee: 86 BaseType math/big.Word
+      Pointee: 67 BaseType math/big.Word
     - __kind: BaseType
-      ID: 86
+      ID: 67
       Name: math/big.Word
       ByteSize: 8
       GoRuntimeType: 583328
       GoKind: 7
     - __kind: StructureType
-      ID: 87
+      ID: 68
       Name: crypto/x509/pkix.Name
       ByteSize: 248
       GoRuntimeType: 2.176736e+06
@@ -1320,39 +1126,39 @@ Types:
       RawFields:
         - Name: Country
           Offset: 0
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Organization
           Offset: 24
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: OrganizationalUnit
           Offset: 48
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Locality
           Offset: 72
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Province
           Offset: 96
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: StreetAddress
           Offset: 120
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: PostalCode
           Offset: 144
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: SerialNumber
           Offset: 168
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: CommonName
           Offset: 184
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: Names
           Offset: 200
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
         - Name: ExtraNames
           Offset: 224
-          Type: 88 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
+          Type: 69 GoSliceHeaderType []crypto/x509/pkix.AttributeTypeAndValue
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 69
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 24
       GoRuntimeType: 512416
@@ -1360,23 +1166,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType *crypto/x509/pkix.AttributeTypeAndValue
+          Type: 70 PointerType *crypto/x509/pkix.AttributeTypeAndValue
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+          Type: 8 BaseType int
+      Data: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
-      ID: 89
+      ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
       ByteSize: 8
       GoRuntimeType: 433984
       GoKind: 22
-      Pointee: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Pointee: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: StructureType
-      ID: 90
+      ID: 71
       Name: crypto/x509/pkix.AttributeTypeAndValue
       ByteSize: 40
       GoRuntimeType: 1.492064e+06
@@ -1384,12 +1190,12 @@ Types:
       RawFields:
         - Name: Type
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Value
           Offset: 24
-          Type: 80 GoEmptyInterfaceType interface {}
+          Type: 62 GoEmptyInterfaceType interface {}
     - __kind: GoSliceHeaderType
-      ID: 91
+      ID: 72
       Name: encoding/asn1.ObjectIdentifier
       ByteSize: 24
       GoRuntimeType: 1.044128e+06
@@ -1397,23 +1203,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 92 PointerType *int
+          Type: 73 PointerType *int
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 185 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 92
+      ID: 73
       Name: '*int'
       ByteSize: 8
       GoRuntimeType: 396736
       GoKind: 22
-      Pointee: 21 BaseType int
+      Pointee: 8 BaseType int
     - __kind: StructureType
-      ID: 93
+      ID: 74
       Name: time.Time
       ByteSize: 24
       GoRuntimeType: 2.34832e+06
@@ -1421,22 +1227,22 @@ Types:
       RawFields:
         - Name: wall
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: ext
           Offset: 8
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: loc
           Offset: 16
-          Type: 94 PointerType *time.Location
+          Type: 75 PointerType *time.Location
     - __kind: PointerType
-      ID: 94
+      ID: 75
       Name: '*time.Location'
       ByteSize: 8
       GoRuntimeType: 1.6024e+06
       GoKind: 22
-      Pointee: 95 StructureType time.Location
+      Pointee: 76 StructureType time.Location
     - __kind: StructureType
-      ID: 95
+      ID: 76
       Name: time.Location
       ByteSize: 104
       GoRuntimeType: 1.957824e+06
@@ -1444,27 +1250,27 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: zone
           Offset: 16
-          Type: 96 GoSliceHeaderType []time.zone
+          Type: 77 GoSliceHeaderType []time.zone
         - Name: tx
           Offset: 40
-          Type: 99 GoSliceHeaderType []time.zoneTrans
+          Type: 80 GoSliceHeaderType []time.zoneTrans
         - Name: extend
           Offset: 64
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: cacheStart
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheEnd
           Offset: 88
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: cacheZone
           Offset: 96
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
     - __kind: GoSliceHeaderType
-      ID: 96
+      ID: 77
       Name: '[]time.zone'
       ByteSize: 24
       GoRuntimeType: 485792
@@ -1472,23 +1278,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 97 PointerType *time.zone
+          Type: 78 PointerType *time.zone
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 187 GoSliceDataType []time.zone.array
+          Type: 8 BaseType int
+      Data: 166 GoSliceDataType []time.zone.array
     - __kind: PointerType
-      ID: 97
+      ID: 78
       Name: '*time.zone'
       ByteSize: 8
       GoRuntimeType: 391680
       GoKind: 22
-      Pointee: 98 StructureType time.zone
+      Pointee: 79 StructureType time.zone
     - __kind: StructureType
-      ID: 98
+      ID: 79
       Name: time.zone
       ByteSize: 32
       GoRuntimeType: 1.602208e+06
@@ -1496,15 +1302,15 @@ Types:
       RawFields:
         - Name: name
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: offset
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: isDST
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 99
+      ID: 80
       Name: '[]time.zoneTrans'
       ByteSize: 24
       GoRuntimeType: 485856
@@ -1512,23 +1318,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 100 PointerType *time.zoneTrans
+          Type: 81 PointerType *time.zoneTrans
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 189 GoSliceDataType []time.zoneTrans.array
+          Type: 8 BaseType int
+      Data: 168 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
-      ID: 100
+      ID: 81
       Name: '*time.zoneTrans'
       ByteSize: 8
       GoRuntimeType: 391744
       GoKind: 22
-      Pointee: 101 StructureType time.zoneTrans
+      Pointee: 82 StructureType time.zoneTrans
     - __kind: StructureType
-      ID: 101
+      ID: 82
       Name: time.zoneTrans
       ByteSize: 16
       GoRuntimeType: 1.736576e+06
@@ -1536,24 +1342,24 @@ Types:
       RawFields:
         - Name: when
           Offset: 0
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: index
           Offset: 8
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: isstd
           Offset: 9
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: isutc
           Offset: 10
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: BaseType
-      ID: 102
+      ID: 83
       Name: crypto/x509.KeyUsage
       ByteSize: 8
       GoRuntimeType: 583072
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 103
+      ID: 84
       Name: '[]crypto/x509/pkix.Extension'
       ByteSize: 24
       GoRuntimeType: 511648
@@ -1561,23 +1367,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 104 PointerType *crypto/x509/pkix.Extension
+          Type: 85 PointerType *crypto/x509/pkix.Extension
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 191 GoSliceDataType []crypto/x509/pkix.Extension.array
+          Type: 8 BaseType int
+      Data: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
-      ID: 104
+      ID: 85
       Name: '*crypto/x509/pkix.Extension'
       ByteSize: 8
       GoRuntimeType: 434176
       GoKind: 22
-      Pointee: 105 StructureType crypto/x509/pkix.Extension
+      Pointee: 86 StructureType crypto/x509/pkix.Extension
     - __kind: StructureType
-      ID: 105
+      ID: 86
       Name: crypto/x509/pkix.Extension
       ByteSize: 56
       GoRuntimeType: 1.635616e+06
@@ -1585,15 +1391,15 @@ Types:
       RawFields:
         - Name: Id
           Offset: 0
-          Type: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+          Type: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
         - Name: Critical
           Offset: 24
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Value
           Offset: 32
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 106
+      ID: 87
       Name: '[]encoding/asn1.ObjectIdentifier'
       ByteSize: 24
       GoRuntimeType: 511712
@@ -1601,23 +1407,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 107 PointerType *encoding/asn1.ObjectIdentifier
+          Type: 88 PointerType *encoding/asn1.ObjectIdentifier
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 193 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+          Type: 8 BaseType int
+      Data: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
-      ID: 107
+      ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
       ByteSize: 8
       GoRuntimeType: 1.044e+06
       GoKind: 22
-      Pointee: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Pointee: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: GoSliceHeaderType
-      ID: 108
+      ID: 89
       Name: '[]crypto/x509.ExtKeyUsage'
       ByteSize: 24
       GoRuntimeType: 499776
@@ -1625,29 +1431,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 109 PointerType *crypto/x509.ExtKeyUsage
+          Type: 90 PointerType *crypto/x509.ExtKeyUsage
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 195 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+          Type: 8 BaseType int
+      Data: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
-      ID: 109
+      ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
       ByteSize: 8
       GoRuntimeType: 420160
       GoKind: 22
-      Pointee: 110 BaseType crypto/x509.ExtKeyUsage
+      Pointee: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: BaseType
-      ID: 110
+      ID: 91
       Name: crypto/x509.ExtKeyUsage
       ByteSize: 8
       GoRuntimeType: 583136
       GoKind: 2
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 92
       Name: '[]net.IP'
       ByteSize: 24
       GoRuntimeType: 479488
@@ -1655,23 +1461,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 112 PointerType *net.IP
+          Type: 93 PointerType *net.IP
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 197 GoSliceDataType []net.IP.array
+          Type: 8 BaseType int
+      Data: 176 GoSliceDataType []net.IP.array
     - __kind: PointerType
-      ID: 112
+      ID: 93
       Name: '*net.IP'
       ByteSize: 8
       GoRuntimeType: 2.134112e+06
       GoKind: 22
-      Pointee: 113 GoSliceHeaderType net.IP
+      Pointee: 94 GoSliceHeaderType net.IP
     - __kind: GoSliceHeaderType
-      ID: 113
+      ID: 94
       Name: net.IP
       ByteSize: 24
       GoRuntimeType: 2.109184e+06
@@ -1679,16 +1485,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 199 GoSliceDataType net.IP.array
+          Type: 8 BaseType int
+      Data: 178 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
-      ID: 114
+      ID: 95
       Name: '[]*net/url.URL'
       ByteSize: 24
       GoRuntimeType: 511776
@@ -1696,21 +1502,21 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 115 PointerType **net/url.URL
+          Type: 96 PointerType **net/url.URL
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 201 GoSliceDataType []*net/url.URL.array
+          Type: 8 BaseType int
+      Data: 180 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
-      ID: 115
+      ID: 96
       Name: '**net/url.URL'
       ByteSize: 8
-      Pointee: 28 PointerType *net/url.URL
+      Pointee: 9 PointerType *net/url.URL
     - __kind: GoSliceHeaderType
-      ID: 116
+      ID: 97
       Name: '[]*net.IPNet'
       ByteSize: 24
       GoRuntimeType: 511840
@@ -1718,29 +1524,29 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 117 PointerType **net.IPNet
+          Type: 98 PointerType **net.IPNet
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 203 GoSliceDataType []*net.IPNet.array
+          Type: 8 BaseType int
+      Data: 182 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
-      ID: 117
+      ID: 98
       Name: '**net.IPNet'
       ByteSize: 8
       GoKind: 22
-      Pointee: 118 PointerType *net.IPNet
+      Pointee: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 118
+      ID: 99
       Name: '*net.IPNet'
       ByteSize: 8
       GoRuntimeType: 1.17392e+06
       GoKind: 22
-      Pointee: 119 StructureType net.IPNet
+      Pointee: 100 StructureType net.IPNet
     - __kind: StructureType
-      ID: 119
+      ID: 100
       Name: net.IPNet
       ByteSize: 48
       GoRuntimeType: 1.448704e+06
@@ -1748,12 +1554,12 @@ Types:
       RawFields:
         - Name: IP
           Offset: 0
-          Type: 113 GoSliceHeaderType net.IP
+          Type: 94 GoSliceHeaderType net.IP
         - Name: Mask
           Offset: 24
-          Type: 120 GoSliceHeaderType net.IPMask
+          Type: 101 GoSliceHeaderType net.IPMask
     - __kind: GoSliceHeaderType
-      ID: 120
+      ID: 101
       Name: net.IPMask
       ByteSize: 24
       GoRuntimeType: 1.01072e+06
@@ -1761,16 +1567,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 14 PointerType *uint8
+          Type: 6 PointerType *uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 205 GoSliceDataType net.IPMask.array
+          Type: 8 BaseType int
+      Data: 184 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
-      ID: 121
+      ID: 102
       Name: '[]crypto/x509.OID'
       ByteSize: 24
       GoRuntimeType: 511904
@@ -1778,23 +1584,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 122 PointerType *crypto/x509.OID
+          Type: 103 PointerType *crypto/x509.OID
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 207 GoSliceDataType []crypto/x509.OID.array
+          Type: 8 BaseType int
+      Data: 186 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
-      ID: 122
+      ID: 103
       Name: '*crypto/x509.OID'
       ByteSize: 8
       GoRuntimeType: 1.938144e+06
       GoKind: 22
-      Pointee: 123 StructureType crypto/x509.OID
+      Pointee: 104 StructureType crypto/x509.OID
     - __kind: StructureType
-      ID: 123
+      ID: 104
       Name: crypto/x509.OID
       ByteSize: 24
       GoRuntimeType: 1.9384e+06
@@ -1802,9 +1608,9 @@ Types:
       RawFields:
         - Name: der
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
     - __kind: GoSliceHeaderType
-      ID: 124
+      ID: 105
       Name: '[]crypto/x509.PolicyMapping'
       ByteSize: 24
       GoRuntimeType: 511968
@@ -1812,23 +1618,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 125 PointerType *crypto/x509.PolicyMapping
+          Type: 106 PointerType *crypto/x509.PolicyMapping
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 209 GoSliceDataType []crypto/x509.PolicyMapping.array
+          Type: 8 BaseType int
+      Data: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
-      ID: 125
+      ID: 106
       Name: '*crypto/x509.PolicyMapping'
       ByteSize: 8
       GoRuntimeType: 420224
       GoKind: 22
-      Pointee: 126 StructureType crypto/x509.PolicyMapping
+      Pointee: 107 StructureType crypto/x509.PolicyMapping
     - __kind: StructureType
-      ID: 126
+      ID: 107
       Name: crypto/x509.PolicyMapping
       ByteSize: 48
       GoRuntimeType: 1.480224e+06
@@ -1836,12 +1642,12 @@ Types:
       RawFields:
         - Name: IssuerDomainPolicy
           Offset: 0
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
         - Name: SubjectDomainPolicy
           Offset: 24
-          Type: 123 StructureType crypto/x509.OID
+          Type: 104 StructureType crypto/x509.OID
     - __kind: GoSliceHeaderType
-      ID: 127
+      ID: 108
       Name: '[][]*crypto/x509.Certificate'
       ByteSize: 24
       GoRuntimeType: 498432
@@ -1849,22 +1655,22 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 128 PointerType *[]*crypto/x509.Certificate
+          Type: 109 PointerType *[]*crypto/x509.Certificate
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 211 GoSliceDataType [][]*crypto/x509.Certificate.array
+          Type: 8 BaseType int
+      Data: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
-      ID: 128
+      ID: 109
       Name: '*[]*crypto/x509.Certificate'
       ByteSize: 8
       GoKind: 22
-      Pointee: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Pointee: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: GoSliceHeaderType
-      ID: 129
+      ID: 110
       Name: '[][]uint8'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -1872,47 +1678,47 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 130 PointerType *[]uint8
+          Type: 111 PointerType *[]uint8
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 213 GoSliceDataType [][]uint8.array
+          Type: 8 BaseType int
+      Data: 192 GoSliceDataType [][]uint8.array
     - __kind: PointerType
-      ID: 130
+      ID: 111
       Name: '*[]uint8'
       ByteSize: 8
       GoRuntimeType: 478144
       GoKind: 22
-      Pointee: 71 GoSliceHeaderType []uint8
+      Pointee: 53 GoSliceHeaderType []uint8
     - __kind: GoSubroutineType
-      ID: 131
+      ID: 112
       Name: func(string, []uint8, int) ([]uint8, error)
       ByteSize: 8
       GoRuntimeType: 994848
       GoKind: 19
     - __kind: BaseType
-      ID: 132
+      ID: 113
       Name: crypto/tls.CurveID
       ByteSize: 2
       GoRuntimeType: 829056
       GoKind: 9
     - __kind: GoChannelType
-      ID: 133
+      ID: 114
       Name: <-chan struct {}
       GoRuntimeType: 592672
       GoKind: 18
     - __kind: PointerType
-      ID: 134
+      ID: 115
       Name: '*net/http.Response'
       ByteSize: 8
       GoRuntimeType: 1.705504e+06
       GoKind: 22
-      Pointee: 135 StructureType net/http.Response
+      Pointee: 116 StructureType net/http.Response
     - __kind: StructureType
-      ID: 135
+      ID: 116
       Name: net/http.Response
       ByteSize: 144
       GoRuntimeType: 2.19504e+06
@@ -1920,62 +1726,68 @@ Types:
       RawFields:
         - Name: Status
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: StatusCode
           Offset: 16
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Proto
           Offset: 24
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: ProtoMajor
           Offset: 40
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: ProtoMinor
           Offset: 48
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: Header
           Offset: 56
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Body
           Offset: 64
-          Type: 48 GoInterfaceType io.ReadCloser
+          Type: 30 GoInterfaceType io.ReadCloser
         - Name: ContentLength
           Offset: 80
-          Type: 50 BaseType int64
+          Type: 32 BaseType int64
         - Name: TransferEncoding
           Offset: 88
-          Type: 46 GoSliceHeaderType []string
+          Type: 28 GoSliceHeaderType []string
         - Name: Close
           Offset: 112
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Uncompressed
           Offset: 113
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: Trailer
           Offset: 120
-          Type: 33 GoMapType net/http.Header
+          Type: 14 GoMapType net/http.Header
         - Name: Request
           Offset: 128
-          Type: 25 PointerType *net/http.Request
+          Type: 3 PointerType *net/http.Request
         - Name: TLS
           Offset: 136
-          Type: 72 PointerType *crypto/tls.ConnectionState
+          Type: 54 PointerType *crypto/tls.ConnectionState
     - __kind: GoInterfaceType
-      ID: 136
+      ID: 117
       Name: context.Context
       ByteSize: 16
       GoRuntimeType: 1.266912e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: PointerType
-      ID: 137
+      ID: 118
       Name: '*net/http.pattern'
       ByteSize: 8
       GoRuntimeType: 1.597408e+06
       GoKind: 22
-      Pointee: 138 StructureType net/http.pattern
+      Pointee: 119 StructureType net/http.pattern
     - __kind: StructureType
-      ID: 138
+      ID: 119
       Name: net/http.pattern
       ByteSize: 88
       GoRuntimeType: 1.818112e+06
@@ -1983,21 +1795,21 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: method
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: host
           Offset: 32
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: segments
           Offset: 48
-          Type: 139 GoSliceHeaderType []net/http.segment
+          Type: 120 GoSliceHeaderType []net/http.segment
         - Name: loc
           Offset: 72
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: GoSliceHeaderType
-      ID: 139
+      ID: 120
       Name: '[]net/http.segment'
       ByteSize: 24
       GoRuntimeType: 481120
@@ -2005,23 +1817,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 140 PointerType *net/http.segment
+          Type: 121 PointerType *net/http.segment
         - Name: len
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: cap
           Offset: 16
-          Type: 21 BaseType int
-      Data: 215 GoSliceDataType []net/http.segment.array
+          Type: 8 BaseType int
+      Data: 194 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
-      ID: 140
+      ID: 121
       Name: '*net/http.segment'
       ByteSize: 8
       GoRuntimeType: 388544
       GoKind: 22
-      Pointee: 141 StructureType net/http.segment
+      Pointee: 122 StructureType net/http.segment
     - __kind: StructureType
-      ID: 141
+      ID: 122
       Name: net/http.segment
       ByteSize: 24
       GoRuntimeType: 1.597216e+06
@@ -2029,112 +1841,112 @@ Types:
       RawFields:
         - Name: s
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: wild
           Offset: 16
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
         - Name: multi
           Offset: 17
-          Type: 32 BaseType bool
+          Type: 13 BaseType bool
     - __kind: GoMapType
-      ID: 142
+      ID: 123
       Name: map[string]string
       ByteSize: 8
       GoRuntimeType: 1.119008e+06
       GoKind: 21
-      HeaderType: 144 GoSwissMapHeaderType map<string,string>
+      HeaderType: 125 GoSwissMapHeaderType map<string,string>
     - __kind: PointerType
-      ID: 143
+      ID: 124
       Name: '*map<string,string>'
       ByteSize: 8
-      Pointee: 144 GoSwissMapHeaderType map<string,string>
+      Pointee: 125 GoSwissMapHeaderType map<string,string>
     - __kind: GoSwissMapHeaderType
-      ID: 144
+      ID: 125
       Name: map<string,string>
       ByteSize: 48
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 8 BaseType uintptr
+          Type: 18 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 145 PointerType **table<string,string>
+          Type: 126 PointerType **table<string,string>
         - Name: dirLen
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: globalDepth
           Offset: 32
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: globalShift
           Offset: 33
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: writing
           Offset: 34
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: clearSeq
           Offset: 40
-          Type: 36 BaseType uint64
-      TablePtrSliceType: 217 GoSliceDataType []*table<string,string>.array
-      GroupType: 150 StructureType noalg.map.group[string]string
+          Type: 17 BaseType uint64
+      TablePtrSliceType: 196 GoSliceDataType []*table<string,string>.array
+      GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
-      ID: 145
+      ID: 126
       Name: '**table<string,string>'
       ByteSize: 8
-      Pointee: 146 PointerType *table<string,string>
+      Pointee: 127 PointerType *table<string,string>
     - __kind: PointerType
-      ID: 146
+      ID: 127
       Name: '*table<string,string>'
       ByteSize: 8
-      Pointee: 147 StructureType table<string,string>
+      Pointee: 128 StructureType table<string,string>
     - __kind: StructureType
-      ID: 147
+      ID: 128
       Name: table<string,string>
       ByteSize: 32
       GoKind: 25
       RawFields:
         - Name: used
           Offset: 0
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: capacity
           Offset: 2
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: growthLeft
           Offset: 4
-          Type: 40 BaseType uint16
+          Type: 22 BaseType uint16
         - Name: localDepth
           Offset: 6
-          Type: 11 BaseType uint8
+          Type: 7 BaseType uint8
         - Name: index
           Offset: 8
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: groups
           Offset: 16
-          Type: 148 GoSwissMapGroupsType groupReference<string,string>
+          Type: 129 GoSwissMapGroupsType groupReference<string,string>
     - __kind: GoSwissMapGroupsType
-      ID: 148
+      ID: 129
       Name: groupReference<string,string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 149 PointerType *noalg.map.group[string]string
+          Type: 130 PointerType *noalg.map.group[string]string
         - Name: lengthMask
           Offset: 8
-          Type: 36 BaseType uint64
-      GroupType: 150 StructureType noalg.map.group[string]string
-      GroupSliceType: 218 GoSliceDataType []noalg.map.group[string]string.array
+          Type: 17 BaseType uint64
+      GroupType: 131 StructureType noalg.map.group[string]string
+      GroupSliceType: 197 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
-      ID: 149
+      ID: 130
       Name: '*noalg.map.group[string]string'
       ByteSize: 8
-      Pointee: 150 StructureType noalg.map.group[string]string
+      Pointee: 131 StructureType noalg.map.group[string]string
     - __kind: StructureType
-      ID: 150
+      ID: 131
       Name: noalg.map.group[string]string
       ByteSize: 264
       GoRuntimeType: 1.282656e+06
@@ -2142,21 +1954,21 @@ Types:
       RawFields:
         - Name: ctrl
           Offset: 0
-          Type: 36 BaseType uint64
+          Type: 17 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 151 ArrayType noalg.[8]struct { key string; elem string }
+          Type: 132 ArrayType noalg.[8]struct { key string; elem string }
     - __kind: ArrayType
-      ID: 151
+      ID: 132
       Name: noalg.[8]struct { key string; elem string }
       ByteSize: 256
       GoRuntimeType: 688032
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 152 StructureType noalg.struct { key string; elem string }
+      Element: 133 StructureType noalg.struct { key string; elem string }
     - __kind: StructureType
-      ID: 152
+      ID: 133
       Name: noalg.struct { key string; elem string }
       ByteSize: 32
       GoRuntimeType: 1.282528e+06
@@ -2164,19 +1976,19 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 27 GoStringHeaderType string
+          Type: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 153
+      ID: 134
       Name: '*bytes.Buffer'
       ByteSize: 8
       GoRuntimeType: 2.245056e+06
       GoKind: 22
-      Pointee: 154 StructureType bytes.Buffer
+      Pointee: 135 StructureType bytes.Buffer
     - __kind: StructureType
-      ID: 154
+      ID: 135
       Name: bytes.Buffer
       ByteSize: 40
       GoRuntimeType: 1.595104e+06
@@ -2184,342 +1996,338 @@ Types:
       RawFields:
         - Name: buf
           Offset: 0
-          Type: 71 GoSliceHeaderType []uint8
+          Type: 53 GoSliceHeaderType []uint8
         - Name: off
           Offset: 24
-          Type: 21 BaseType int
+          Type: 8 BaseType int
         - Name: lastRead
           Offset: 32
-          Type: 155 BaseType bytes.readOp
+          Type: 136 BaseType bytes.readOp
     - __kind: BaseType
-      ID: 155
+      ID: 136
       Name: bytes.readOp
       ByteSize: 1
       GoRuntimeType: 578592
       GoKind: 3
     - __kind: GoInterfaceType
-      ID: 156
+      ID: 137
       Name: gopkg.in/DataDog/dd-trace-go.v1/ddtrace.Span
       ByteSize: 16
       GoRuntimeType: 1.468864e+06
       GoKind: 20
-      UnderlyingStructure: 2 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 157
+      ID: 138
       Name: context.backgroundCtx
       GoRuntimeType: 1.781408e+06
       GoKind: 25
       RawFields:
         - Name: emptyCtx
           Offset: 0
-          Type: 158 StructureType context.emptyCtx
+          Type: 139 StructureType context.emptyCtx
     - __kind: StructureType
-      ID: 158
+      ID: 139
       Name: context.emptyCtx
       GoRuntimeType: 1.58016e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoSliceDataType
-      ID: 159
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 20 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 160
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 159 GoSliceDataType []internal/abi.Imethod.array
     - __kind: GoStringDataType
-      ID: 161
+      ID: 140
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 162
+      ID: 141
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 161 GoStringDataType string.str
+      Pointee: 140 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 163
+      ID: 142
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 143
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 165
+      ID: 144
       Name: '[]string.array'
       ByteSize: 2048
-      Element: 27 GoStringHeaderType string
+      Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 166
+      ID: 145
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 165 GoSliceDataType []string.array
+      Pointee: 144 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 146
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 147
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 148
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 149
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 171
+      ID: 150
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
-      Element: 59 PointerType *table<string,[]*mime/multipart.FileHeader>
+      Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 151
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 63 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
+      Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 173
+      ID: 152
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
-      Element: 68 PointerType *mime/multipart.FileHeader
+      Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 174
+      ID: 153
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 173 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 152 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 154
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 38 PointerType *table<string,[]string>
+      Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 155
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 43 StructureType noalg.map.group[string][]string
+      Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 177
+      ID: 156
       Name: '[]uint8.array'
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 178
+      ID: 157
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 177 GoSliceDataType []uint8.array
+      Pointee: 156 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 158
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 76 PointerType *crypto/x509.Certificate
+      Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 180
+      ID: 159
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 158 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 160
       Name: math/big.nat.array
       ByteSize: 2048
-      Element: 86 BaseType math/big.Word
+      Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 182
+      ID: 161
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 181 GoSliceDataType math/big.nat.array
+      Pointee: 160 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 162
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
-      Element: 90 StructureType crypto/x509/pkix.AttributeTypeAndValue
+      Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 184
+      ID: 163
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 183 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 185
+      ID: 164
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
-      Element: 21 BaseType int
+      Element: 8 BaseType int
     - __kind: PointerType
-      ID: 186
+      ID: 165
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 185 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 166
       Name: '[]time.zone.array'
       ByteSize: 2048
-      Element: 98 StructureType time.zone
+      Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 188
+      ID: 167
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 187 GoSliceDataType []time.zone.array
+      Pointee: 166 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 168
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
-      Element: 101 StructureType time.zoneTrans
+      Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 190
+      ID: 169
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 189 GoSliceDataType []time.zoneTrans.array
+      Pointee: 168 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 170
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
-      Element: 105 StructureType crypto/x509/pkix.Extension
+      Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 192
+      ID: 171
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 191 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 172
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
-      Element: 91 GoSliceHeaderType encoding/asn1.ObjectIdentifier
+      Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 194
+      ID: 173
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 193 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 174
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
-      Element: 110 BaseType crypto/x509.ExtKeyUsage
+      Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 196
+      ID: 175
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 195 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 176
       Name: '[]net.IP.array'
       ByteSize: 2048
-      Element: 113 GoSliceHeaderType net.IP
+      Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 198
+      ID: 177
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 197 GoSliceDataType []net.IP.array
+      Pointee: 176 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 178
       Name: net.IP.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 200
+      ID: 179
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType net.IP.array
+      Pointee: 178 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 180
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
-      Element: 28 PointerType *net/url.URL
+      Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 202
+      ID: 181
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 201 GoSliceDataType []*net/url.URL.array
+      Pointee: 180 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 182
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
-      Element: 118 PointerType *net.IPNet
+      Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 204
+      ID: 183
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 203 GoSliceDataType []*net.IPNet.array
+      Pointee: 182 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 205
+      ID: 184
       Name: net.IPMask.array
       ByteSize: 2048
-      Element: 11 BaseType uint8
+      Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 206
+      ID: 185
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 205 GoSliceDataType net.IPMask.array
+      Pointee: 184 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 186
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
-      Element: 123 StructureType crypto/x509.OID
+      Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 208
+      ID: 187
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 207 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 186 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 209
+      ID: 188
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
-      Element: 126 StructureType crypto/x509.PolicyMapping
+      Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 210
+      ID: 189
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 209 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 190
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
-      Element: 74 GoSliceHeaderType []*crypto/x509.Certificate
+      Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 212
+      ID: 191
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 211 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 192
       Name: '[][]uint8.array'
       ByteSize: 2048
-      Element: 71 GoSliceHeaderType []uint8
+      Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 214
+      ID: 193
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 213 GoSliceDataType [][]uint8.array
+      Pointee: 192 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 194
       Name: '[]net/http.segment.array'
       ByteSize: 2048
-      Element: 141 StructureType net/http.segment
+      Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 216
+      ID: 195
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 215 GoSliceDataType []net/http.segment.array
+      Pointee: 194 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 217
+      ID: 196
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
-      Element: 146 PointerType *table<string,string>
+      Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 197
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
-      Element: 150 StructureType noalg.map.group[string]string
+      Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 219
+      ID: 198
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2536,14 +2344,14 @@ Types:
         - Name: r
           Offset: 17
           Expression:
-            Type: 25 PointerType *net/http.Request
+            Type: 3 PointerType *net/http.Request
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 1, index: 1, name: r}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 220
+      ID: 199
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2551,11 +2359,11 @@ Types:
         - Name: path
           Offset: 1
           Expression:
-            Type: 27 GoStringHeaderType string
+            Type: 5 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 220
+MaxTypeID: 199
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -10,7 +10,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 1
-          Type: 198 EventRootType Probe[main.HandleHTTP]
+          Type: 221 EventRootType Probe[main.HandleHTTP]
           InjectionPoints: [{PC: "0x86c110", Frameless: true}]
           Condition: null
     - id: look_at_the_request
@@ -23,7 +23,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 2
-          Type: 199 EventRootType Probe[main.LookAtTheRequest]
+          Type: 222 EventRootType Probe[main.LookAtTheRequest]
           InjectionPoints: [{PC: "0x86c41c", Frameless: true}]
           Condition: null
 Subprograms:
@@ -240,11 +240,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 141 PointerType *string.str
+          Type: 164 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 8 BaseType int
-      Data: 140 GoStringDataType string.str
+      Data: 163 GoStringDataType string.str
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
@@ -382,7 +382,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 154 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 177 GoSliceDataType []*table<string,[]string>.array
       GroupType: 25 StructureType noalg.map.group[string][]string
     - __kind: BaseType
       ID: 17
@@ -449,7 +449,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 25 StructureType noalg.map.group[string][]string
-      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 24
       Name: '*noalg.map.group[string][]string'
@@ -506,7 +506,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 144 GoSliceDataType []string.array
+      Data: 167 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 29
       Name: '*string'
@@ -615,7 +615,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 150 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
+      TablePtrSliceType: 173 GoSliceDataType []*table<string,[]*mime/multipart.FileHeader>.array
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: PointerType
       ID: 40
@@ -664,7 +664,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
-      GroupSliceType: 151 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
+      GroupSliceType: 174 GoSliceDataType []noalg.map.group[string][]*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 44
       Name: '*noalg.map.group[string][]*mime/multipart.FileHeader'
@@ -721,7 +721,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 152 GoSliceDataType []*mime/multipart.FileHeader.array
+      Data: 175 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: PointerType
       ID: 49
       Name: '**mime/multipart.FileHeader'
@@ -786,7 +786,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 156 GoSliceDataType []uint8.array
+      Data: 179 GoSliceDataType []uint8.array
     - __kind: PointerType
       ID: 54
       Name: '*crypto/tls.ConnectionState'
@@ -865,7 +865,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 158 GoSliceDataType []*crypto/x509.Certificate.array
+      Data: 181 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 57
       Name: '**crypto/x509.Certificate'
@@ -1103,7 +1103,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 160 GoSliceDataType math/big.nat.array
+      Data: 183 GoSliceDataType math/big.nat.array
     - __kind: PointerType
       ID: 66
       Name: '*math/big.Word'
@@ -1173,7 +1173,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Data: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: PointerType
       ID: 70
       Name: '*crypto/x509/pkix.AttributeTypeAndValue'
@@ -1210,7 +1210,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Data: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 73
       Name: '*int'
@@ -1285,7 +1285,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 166 GoSliceDataType []time.zone.array
+      Data: 189 GoSliceDataType []time.zone.array
     - __kind: PointerType
       ID: 78
       Name: '*time.zone'
@@ -1325,7 +1325,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 168 GoSliceDataType []time.zoneTrans.array
+      Data: 191 GoSliceDataType []time.zoneTrans.array
     - __kind: PointerType
       ID: 81
       Name: '*time.zoneTrans'
@@ -1374,7 +1374,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Data: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: PointerType
       ID: 85
       Name: '*crypto/x509/pkix.Extension'
@@ -1414,7 +1414,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Data: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: PointerType
       ID: 88
       Name: '*encoding/asn1.ObjectIdentifier'
@@ -1438,7 +1438,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Data: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: PointerType
       ID: 90
       Name: '*crypto/x509.ExtKeyUsage'
@@ -1468,7 +1468,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 176 GoSliceDataType []net.IP.array
+      Data: 199 GoSliceDataType []net.IP.array
     - __kind: PointerType
       ID: 93
       Name: '*net.IP'
@@ -1492,7 +1492,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 178 GoSliceDataType net.IP.array
+      Data: 201 GoSliceDataType net.IP.array
     - __kind: GoSliceHeaderType
       ID: 95
       Name: '[]*net/url.URL'
@@ -1509,7 +1509,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 180 GoSliceDataType []*net/url.URL.array
+      Data: 203 GoSliceDataType []*net/url.URL.array
     - __kind: PointerType
       ID: 96
       Name: '**net/url.URL'
@@ -1531,7 +1531,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 182 GoSliceDataType []*net.IPNet.array
+      Data: 205 GoSliceDataType []*net.IPNet.array
     - __kind: PointerType
       ID: 98
       Name: '**net.IPNet'
@@ -1574,7 +1574,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 184 GoSliceDataType net.IPMask.array
+      Data: 207 GoSliceDataType net.IPMask.array
     - __kind: GoSliceHeaderType
       ID: 102
       Name: '[]crypto/x509.OID'
@@ -1591,7 +1591,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 186 GoSliceDataType []crypto/x509.OID.array
+      Data: 209 GoSliceDataType []crypto/x509.OID.array
     - __kind: PointerType
       ID: 103
       Name: '*crypto/x509.OID'
@@ -1625,7 +1625,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Data: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: PointerType
       ID: 106
       Name: '*crypto/x509.PolicyMapping'
@@ -1662,7 +1662,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Data: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: PointerType
       ID: 109
       Name: '*[]*crypto/x509.Certificate'
@@ -1685,7 +1685,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 192 GoSliceDataType [][]uint8.array
+      Data: 215 GoSliceDataType [][]uint8.array
     - __kind: PointerType
       ID: 111
       Name: '*[]uint8'
@@ -1824,7 +1824,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 8 BaseType int
-      Data: 194 GoSliceDataType []net/http.segment.array
+      Data: 217 GoSliceDataType []net/http.segment.array
     - __kind: PointerType
       ID: 121
       Name: '*net/http.segment'
@@ -1890,7 +1890,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 17 BaseType uint64
-      TablePtrSliceType: 196 GoSliceDataType []*table<string,string>.array
+      TablePtrSliceType: 219 GoSliceDataType []*table<string,string>.array
       GroupType: 131 StructureType noalg.map.group[string]string
     - __kind: PointerType
       ID: 126
@@ -1939,7 +1939,7 @@ Types:
           Offset: 8
           Type: 17 BaseType uint64
       GroupType: 131 StructureType noalg.map.group[string]string
-      GroupSliceType: 197 GoSliceDataType []noalg.map.group[string]string.array
+      GroupSliceType: 220 GoSliceDataType []noalg.map.group[string]string.array
     - __kind: PointerType
       ID: 130
       Name: '*noalg.map.group[string]string'
@@ -2037,297 +2037,455 @@ Types:
       GoRuntimeType: 1.58016e+06
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 140
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 579808
+      GoKind: 10
+    - __kind: BaseType
+      ID: 141
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 580064
+      GoKind: 7
+    - __kind: PointerType
+      ID: 142
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 397184
+      GoKind: 22
+      Pointee: 13 BaseType bool
+    - __kind: BaseType
+      ID: 143
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 579744
+      GoKind: 5
+    - __kind: GoInterfaceType
+      ID: 144
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 1.022624e+06
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 2 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 2 VoidPointerType unsafe.Pointer
+    - __kind: BaseType
+      ID: 145
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 579488
+      GoKind: 3
+    - __kind: BaseType
+      ID: 146
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 580320
+      GoKind: 13
+    - __kind: BaseType
+      ID: 147
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 580384
+      GoKind: 14
+    - __kind: PointerType
+      ID: 148
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 396864
+      GoKind: 22
+      Pointee: 18 BaseType uintptr
+    - __kind: PointerType
+      ID: 149
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 396480
+      GoKind: 22
+      Pointee: 143 BaseType int32
+    - __kind: PointerType
+      ID: 150
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 396544
+      GoKind: 22
+      Pointee: 140 BaseType uint32
+    - __kind: BaseType
+      ID: 151
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 579616
+      GoKind: 4
+    - __kind: BaseType
+      ID: 152
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 580192
+      GoKind: 15
+    - __kind: BaseType
+      ID: 153
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 580256
+      GoKind: 16
+    - __kind: PointerType
+      ID: 154
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 397120
+      GoKind: 22
+      Pointee: 147 BaseType float64
+    - __kind: PointerType
+      ID: 155
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 396608
+      GoKind: 22
+      Pointee: 32 BaseType int64
+    - __kind: PointerType
+      ID: 156
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 396672
+      GoKind: 22
+      Pointee: 17 BaseType uint64
+    - __kind: PointerType
+      ID: 157
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 396416
+      GoKind: 22
+      Pointee: 22 BaseType uint16
+    - __kind: PointerType
+      ID: 158
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 396352
+      GoKind: 22
+      Pointee: 151 BaseType int16
+    - __kind: PointerType
+      ID: 159
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 396224
+      GoKind: 22
+      Pointee: 145 BaseType int8
+    - __kind: PointerType
+      ID: 160
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 396096
+      GoKind: 22
+      Pointee: 144 GoInterfaceType error
+    - __kind: PointerType
+      ID: 161
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 396800
+      GoKind: 22
+      Pointee: 141 BaseType uint
+    - __kind: PointerType
+      ID: 162
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 397056
+      GoKind: 22
+      Pointee: 146 BaseType float32
+    - __kind: GoStringDataType
+      ID: 163
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 141
+      ID: 164
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 140 GoStringDataType string.str
+      Pointee: 163 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 142
+      ID: 165
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 166
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 167
       Name: '[]string.array'
       ByteSize: 2048
       Element: 5 GoStringHeaderType string
     - __kind: PointerType
-      ID: 145
+      ID: 168
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []string.array
+      Pointee: 167 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 169
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 170
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 171
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 172
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 150
+      ID: 173
       Name: '[]*table<string,[]*mime/multipart.FileHeader>.array'
       ByteSize: 8192
       Element: 41 PointerType *table<string,[]*mime/multipart.FileHeader>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 174
       Name: '[]noalg.map.group[string][]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 45 StructureType noalg.map.group[string][]*mime/multipart.FileHeader
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 175
       Name: '[]*mime/multipart.FileHeader.array'
       ByteSize: 2048
       Element: 50 PointerType *mime/multipart.FileHeader
     - __kind: PointerType
-      ID: 153
+      ID: 176
       Name: '*[]*mime/multipart.FileHeader.array'
       ByteSize: 8
-      Pointee: 152 GoSliceDataType []*mime/multipart.FileHeader.array
+      Pointee: 175 GoSliceDataType []*mime/multipart.FileHeader.array
     - __kind: GoSliceDataType
-      ID: 154
+      ID: 177
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 20 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 155
+      ID: 178
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 25 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 179
       Name: '[]uint8.array'
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 157
+      ID: 180
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 156 GoSliceDataType []uint8.array
+      Pointee: 179 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 181
       Name: '[]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 58 PointerType *crypto/x509.Certificate
     - __kind: PointerType
-      ID: 159
+      ID: 182
       Name: '*[]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 158 GoSliceDataType []*crypto/x509.Certificate.array
+      Pointee: 181 GoSliceDataType []*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 160
+      ID: 183
       Name: math/big.nat.array
       ByteSize: 2048
       Element: 67 BaseType math/big.Word
     - __kind: PointerType
-      ID: 161
+      ID: 184
       Name: '*math/big.nat.array'
       ByteSize: 8
-      Pointee: 160 GoSliceDataType math/big.nat.array
+      Pointee: 183 GoSliceDataType math/big.nat.array
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 185
       Name: '[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 2048
       Element: 71 StructureType crypto/x509/pkix.AttributeTypeAndValue
     - __kind: PointerType
-      ID: 163
+      ID: 186
       Name: '*[]crypto/x509/pkix.AttributeTypeAndValue.array'
       ByteSize: 8
-      Pointee: 162 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
+      Pointee: 185 GoSliceDataType []crypto/x509/pkix.AttributeTypeAndValue.array
     - __kind: GoSliceDataType
-      ID: 164
+      ID: 187
       Name: encoding/asn1.ObjectIdentifier.array
       ByteSize: 2048
       Element: 8 BaseType int
     - __kind: PointerType
-      ID: 165
+      ID: 188
       Name: '*encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 164 GoSliceDataType encoding/asn1.ObjectIdentifier.array
+      Pointee: 187 GoSliceDataType encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 189
       Name: '[]time.zone.array'
       ByteSize: 2048
       Element: 79 StructureType time.zone
     - __kind: PointerType
-      ID: 167
+      ID: 190
       Name: '*[]time.zone.array'
       ByteSize: 8
-      Pointee: 166 GoSliceDataType []time.zone.array
+      Pointee: 189 GoSliceDataType []time.zone.array
     - __kind: GoSliceDataType
-      ID: 168
+      ID: 191
       Name: '[]time.zoneTrans.array'
       ByteSize: 2048
       Element: 82 StructureType time.zoneTrans
     - __kind: PointerType
-      ID: 169
+      ID: 192
       Name: '*[]time.zoneTrans.array'
       ByteSize: 8
-      Pointee: 168 GoSliceDataType []time.zoneTrans.array
+      Pointee: 191 GoSliceDataType []time.zoneTrans.array
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 193
       Name: '[]crypto/x509/pkix.Extension.array'
       ByteSize: 2048
       Element: 86 StructureType crypto/x509/pkix.Extension
     - __kind: PointerType
-      ID: 171
+      ID: 194
       Name: '*[]crypto/x509/pkix.Extension.array'
       ByteSize: 8
-      Pointee: 170 GoSliceDataType []crypto/x509/pkix.Extension.array
+      Pointee: 193 GoSliceDataType []crypto/x509/pkix.Extension.array
     - __kind: GoSliceDataType
-      ID: 172
+      ID: 195
       Name: '[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 2048
       Element: 72 GoSliceHeaderType encoding/asn1.ObjectIdentifier
     - __kind: PointerType
-      ID: 173
+      ID: 196
       Name: '*[]encoding/asn1.ObjectIdentifier.array'
       ByteSize: 8
-      Pointee: 172 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
+      Pointee: 195 GoSliceDataType []encoding/asn1.ObjectIdentifier.array
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 197
       Name: '[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 2048
       Element: 91 BaseType crypto/x509.ExtKeyUsage
     - __kind: PointerType
-      ID: 175
+      ID: 198
       Name: '*[]crypto/x509.ExtKeyUsage.array'
       ByteSize: 8
-      Pointee: 174 GoSliceDataType []crypto/x509.ExtKeyUsage.array
+      Pointee: 197 GoSliceDataType []crypto/x509.ExtKeyUsage.array
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 199
       Name: '[]net.IP.array'
       ByteSize: 2048
       Element: 94 GoSliceHeaderType net.IP
     - __kind: PointerType
-      ID: 177
+      ID: 200
       Name: '*[]net.IP.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []net.IP.array
+      Pointee: 199 GoSliceDataType []net.IP.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 201
       Name: net.IP.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 179
+      ID: 202
       Name: '*net.IP.array'
       ByteSize: 8
-      Pointee: 178 GoSliceDataType net.IP.array
+      Pointee: 201 GoSliceDataType net.IP.array
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 203
       Name: '[]*net/url.URL.array'
       ByteSize: 2048
       Element: 9 PointerType *net/url.URL
     - __kind: PointerType
-      ID: 181
+      ID: 204
       Name: '*[]*net/url.URL.array'
       ByteSize: 8
-      Pointee: 180 GoSliceDataType []*net/url.URL.array
+      Pointee: 203 GoSliceDataType []*net/url.URL.array
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 205
       Name: '[]*net.IPNet.array'
       ByteSize: 2048
       Element: 99 PointerType *net.IPNet
     - __kind: PointerType
-      ID: 183
+      ID: 206
       Name: '*[]*net.IPNet.array'
       ByteSize: 8
-      Pointee: 182 GoSliceDataType []*net.IPNet.array
+      Pointee: 205 GoSliceDataType []*net.IPNet.array
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 207
       Name: net.IPMask.array
       ByteSize: 2048
       Element: 7 BaseType uint8
     - __kind: PointerType
-      ID: 185
+      ID: 208
       Name: '*net.IPMask.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType net.IPMask.array
+      Pointee: 207 GoSliceDataType net.IPMask.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 209
       Name: '[]crypto/x509.OID.array'
       ByteSize: 2048
       Element: 104 StructureType crypto/x509.OID
     - __kind: PointerType
-      ID: 187
+      ID: 210
       Name: '*[]crypto/x509.OID.array'
       ByteSize: 8
-      Pointee: 186 GoSliceDataType []crypto/x509.OID.array
+      Pointee: 209 GoSliceDataType []crypto/x509.OID.array
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 211
       Name: '[]crypto/x509.PolicyMapping.array'
       ByteSize: 2048
       Element: 107 StructureType crypto/x509.PolicyMapping
     - __kind: PointerType
-      ID: 189
+      ID: 212
       Name: '*[]crypto/x509.PolicyMapping.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []crypto/x509.PolicyMapping.array
+      Pointee: 211 GoSliceDataType []crypto/x509.PolicyMapping.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 213
       Name: '[][]*crypto/x509.Certificate.array'
       ByteSize: 2048
       Element: 56 GoSliceHeaderType []*crypto/x509.Certificate
     - __kind: PointerType
-      ID: 191
+      ID: 214
       Name: '*[][]*crypto/x509.Certificate.array'
       ByteSize: 8
-      Pointee: 190 GoSliceDataType [][]*crypto/x509.Certificate.array
+      Pointee: 213 GoSliceDataType [][]*crypto/x509.Certificate.array
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 215
       Name: '[][]uint8.array'
       ByteSize: 2048
       Element: 53 GoSliceHeaderType []uint8
     - __kind: PointerType
-      ID: 193
+      ID: 216
       Name: '*[][]uint8.array'
       ByteSize: 8
-      Pointee: 192 GoSliceDataType [][]uint8.array
+      Pointee: 215 GoSliceDataType [][]uint8.array
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 217
       Name: '[]net/http.segment.array'
       ByteSize: 2048
       Element: 122 StructureType net/http.segment
     - __kind: PointerType
-      ID: 195
+      ID: 218
       Name: '*[]net/http.segment.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []net/http.segment.array
+      Pointee: 217 GoSliceDataType []net/http.segment.array
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 219
       Name: '[]*table<string,string>.array'
       ByteSize: 8192
       Element: 127 PointerType *table<string,string>
     - __kind: GoSliceDataType
-      ID: 197
+      ID: 220
       Name: '[]noalg.map.group[string]string.array'
       ByteSize: 2048
       Element: 131 StructureType noalg.map.group[string]string
     - __kind: EventRootType
-      ID: 198
+      ID: 221
       Name: Probe[main.HandleHTTP]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -2351,7 +2509,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 199
+      ID: 222
       Name: Probe[main.LookAtTheRequest]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2365,5 +2523,5 @@ Types:
                   Variable: {subprogram: 2, index: 0, name: path}
                   Offset: 0
                   ByteSize: 16
-MaxTypeID: 199
+MaxTypeID: 222
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/rc_tester_v1.arch=arm64,toolchain=go1.24.3.yaml
@@ -2525,3 +2525,4 @@ Types:
                   ByteSize: 16
 MaxTypeID: 222
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x133d7c0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,11 +8,25 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 87
-          Type: 314 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd06eca", Frameless: false}]
+        - ID: 88
+          Type: 315 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd06f2a", Frameless: false}]
+          Condition: null
+    - id: testAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAny}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 272 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xd0410a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -26,7 +40,7 @@ Probes:
       events:
         - ID: 15
           Type: 242 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -40,7 +54,7 @@ Probes:
       events:
         - ID: 17
           Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -50,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 52
-          Type: 279 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xd04640", Frameless: true}]
+        - ID: 53
+          Type: 280 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -68,7 +82,7 @@ Probes:
       events:
         - ID: 16
           Type: 243 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -82,7 +96,7 @@ Probes:
       events:
         - ID: 35
           Type: 262 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0xd03240", Frameless: true}]
+          InjectionPoints: [{PC: "0xd032a0", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -96,7 +110,7 @@ Probes:
       events:
         - ID: 4
           Type: 231 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0xd02980", Frameless: true}]
+          InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -110,7 +124,7 @@ Probes:
       events:
         - ID: 1
           Type: 228 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0xd02920", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02980", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -120,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 68
-          Type: 295 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd06180", Frameless: true}]
+        - ID: 69
+          Type: 296 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd061e0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 66
-          Type: 293 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xd05da0", Frameless: true}]
+        - ID: 67
+          Type: 294 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xd05e00", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 76
-          Type: 303 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd06540", Frameless: true}]
+        - ID: 77
+          Type: 304 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 78
-          Type: 305 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd06a80", Frameless: true}]
+        - ID: 79
+          Type: 306 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 81
-          Type: 308 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
+        - ID: 82
+          Type: 309 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 95
-          Type: 322 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd07000", Frameless: true}]
+        - ID: 96
+          Type: 323 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 97
-          Type: 324 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd07400", Frameless: true}]
+        - ID: 98
+          Type: 325 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd07460", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +232,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 45
-          Type: 272 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xd042e0", Frameless: true}]
+        - ID: 46
+          Type: 273 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xd04180", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -236,7 +250,7 @@ Probes:
       events:
         - ID: 37
           Type: 264 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xd035ea", Frameless: false}]
+          InjectionPoints: [{PC: "0xd0364a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -250,7 +264,7 @@ Probes:
       events:
         - ID: 36
           Type: 263 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xd034ce", Frameless: false}]
+          InjectionPoints: [{PC: "0xd0352e", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -264,7 +278,7 @@ Probes:
       events:
         - ID: 42
           Type: 269 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xd03d40", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -278,7 +292,7 @@ Probes:
       events:
         - ID: 43
           Type: 270 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xd03d64", Frameless: false}]
+          InjectionPoints: [{PC: "0xd03dc4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -292,7 +306,7 @@ Probes:
       events:
         - ID: 38
           Type: 265 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xd03a2a", Frameless: false}]
+          InjectionPoints: [{PC: "0xd03a8a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -306,7 +320,7 @@ Probes:
       events:
         - ID: 39
           Type: 266 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xd03ace", Frameless: false}]
+          InjectionPoints: [{PC: "0xd03b2e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -320,7 +334,7 @@ Probes:
       events:
         - ID: 40
           Type: 267 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xd03baa", Frameless: false}]
+          InjectionPoints: [{PC: "0xd03c0a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -332,9 +346,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 99
-          Type: 326 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xd03b26", Frameless: false}]
+        - ID: 100
+          Type: 327 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xd03b86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -348,7 +362,7 @@ Probes:
       events:
         - ID: 41
           Type: 268 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xd03c2e", Frameless: false}]
+          InjectionPoints: [{PC: "0xd03c8e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -360,9 +374,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 100
-          Type: 327 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xd03c33", Frameless: false}]
+        - ID: 101
+          Type: 328 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -374,9 +388,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 101
-          Type: 328 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xd03ce6", Frameless: false}]
+        - ID: 102
+          Type: 329 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xd03d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -389,18 +403,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 98
-          Type: 325 EventRootType Probe[main.testInlinedPrint]
+        - ID: 99
+          Type: 326 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xd0388a"
+            - PC: "0xd038ea"
               Frameless: false
-            - PC: "0xd03911"
+            - PC: "0xd03971"
               Frameless: false
-            - PC: "0xd03a52"
+            - PC: "0xd03ab2"
               Frameless: false
-            - PC: "0xd03adc"
+            - PC: "0xd03b3c"
               Frameless: false
-            - PC: "0xd03baf"
+            - PC: "0xd03c0f"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -413,9 +427,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 102
-          Type: 329 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xd03d41", Frameless: true}]
+        - ID: 103
+          Type: 330 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xd03da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -428,12 +442,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 103
-          Type: 330 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 104
+          Type: 331 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xd03d85"
+            - PC: "0xd03de5"
               Frameless: false
-            - PC: "0xd03e25"
+            - PC: "0xd03e85"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -448,7 +462,7 @@ Probes:
       events:
         - ID: 7
           Type: 234 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -462,7 +476,7 @@ Probes:
       events:
         - ID: 8
           Type: 235 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -476,7 +490,7 @@ Probes:
       events:
         - ID: 9
           Type: 236 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -490,7 +504,7 @@ Probes:
       events:
         - ID: 6
           Type: 233 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -504,13 +518,13 @@ Probes:
       events:
         - ID: 5
           Type: 232 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInterface}
-      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
@@ -518,7 +532,7 @@ Probes:
       events:
         - ID: 44
           Type: 271 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xd04053", Frameless: false}]
+          InjectionPoints: [{PC: "0xd040aa", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -528,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 70
-          Type: 297 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd06360", Frameless: true}]
+        - ID: 71
+          Type: 298 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd063c0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -542,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 50
-          Type: 277 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xd04600", Frameless: true}]
+        - ID: 51
+          Type: 278 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xd04660", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -556,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 56
-          Type: 283 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
+        - ID: 57
+          Type: 284 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xd04720", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -570,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 54
-          Type: 281 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xd04680", Frameless: true}]
+        - ID: 55
+          Type: 282 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -584,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 65
-          Type: 292 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
+        - ID: 66
+          Type: 293 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xd04840", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -598,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 64
-          Type: 291 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
+        - ID: 65
+          Type: 292 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -612,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 55
-          Type: 282 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
+        - ID: 56
+          Type: 283 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xd04700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -626,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 63
-          Type: 290 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
+        - ID: 64
+          Type: 291 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xd04800", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -640,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 62
-          Type: 289 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xd04780", Frameless: true}]
+        - ID: 63
+          Type: 290 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -654,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 48
-          Type: 275 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xd045c0", Frameless: true}]
+        - ID: 49
+          Type: 276 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xd04620", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -668,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 49
-          Type: 276 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
+        - ID: 50
+          Type: 277 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xd04640", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -682,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 47
-          Type: 274 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xd045a0", Frameless: true}]
+        - ID: 48
+          Type: 275 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xd04600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -696,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 57
-          Type: 284 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
+        - ID: 58
+          Type: 285 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xd04740", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -710,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 60
-          Type: 287 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xd04740", Frameless: true}]
+        - ID: 61
+          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -724,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 61
-          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xd04760", Frameless: true}]
+        - ID: 62
+          Type: 289 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -738,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 58
-          Type: 285 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xd04700", Frameless: true}]
+        - ID: 59
+          Type: 286 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xd04760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -752,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 59
-          Type: 286 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xd04720", Frameless: true}]
+        - ID: 60
+          Type: 287 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xd04780", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -766,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 93
-          Type: 320 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
+        - ID: 94
+          Type: 321 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd07020", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -780,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 67
-          Type: 294 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xd05f60", Frameless: true}]
+        - ID: 68
+          Type: 295 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -794,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 75
-          Type: 302 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd06500", Frameless: true}]
+        - ID: 76
+          Type: 303 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd06560", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -808,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 85
-          Type: 312 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
+        - ID: 86
+          Type: 313 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -822,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 82
-          Type: 309 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
+        - ID: 83
+          Type: 310 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -836,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 84
-          Type: 311 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
+        - ID: 85
+          Type: 312 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -850,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 92
-          Type: 319 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
+        - ID: 93
+          Type: 320 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd07000", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -864,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 71
-          Type: 298 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd06380", Frameless: true}]
+        - ID: 72
+          Type: 299 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -878,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 53
-          Type: 280 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xd04660", Frameless: true}]
+        - ID: 54
+          Type: 281 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -892,11 +906,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 69
-          Type: 296 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd06340", Frameless: true}]
+        - ID: 70
+          Type: 297 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -910,7 +924,7 @@ Probes:
       events:
         - ID: 2
           Type: 229 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0xd02940", Frameless: true}]
+          InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -924,7 +938,7 @@ Probes:
       events:
         - ID: 21
           Type: 248 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0xd02f40", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -938,7 +952,7 @@ Probes:
       events:
         - ID: 19
           Type: 246 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0xd02f00", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -952,7 +966,7 @@ Probes:
       events:
         - ID: 32
           Type: 259 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03100", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -966,7 +980,7 @@ Probes:
       events:
         - ID: 33
           Type: 260 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03120", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -980,7 +994,7 @@ Probes:
       events:
         - ID: 22
           Type: 249 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -994,7 +1008,7 @@ Probes:
       events:
         - ID: 24
           Type: 251 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1008,7 +1022,7 @@ Probes:
       events:
         - ID: 25
           Type: 252 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1022,7 +1036,7 @@ Probes:
       events:
         - ID: 26
           Type: 253 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1036,7 +1050,7 @@ Probes:
       events:
         - ID: 23
           Type: 250 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1050,7 +1064,7 @@ Probes:
       events:
         - ID: 20
           Type: 247 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0xd02f20", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1060,11 +1074,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 88
-          Type: 315 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd06f20", Frameless: true}]
+        - ID: 89
+          Type: 316 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1078,7 +1092,7 @@ Probes:
       events:
         - ID: 27
           Type: 254 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0xd03000", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03060", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1092,7 +1106,7 @@ Probes:
       events:
         - ID: 29
           Type: 256 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0xd03040", Frameless: true}]
+          InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1106,7 +1120,7 @@ Probes:
       events:
         - ID: 30
           Type: 257 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0xd03060", Frameless: true}]
+          InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1120,7 +1134,7 @@ Probes:
       events:
         - ID: 31
           Type: 258 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0xd03080", Frameless: true}]
+          InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1134,7 +1148,7 @@ Probes:
       events:
         - ID: 28
           Type: 255 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0xd03020", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1144,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 79
-          Type: 306 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd06aa0", Frameless: true}]
+        - ID: 80
+          Type: 307 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1158,11 +1172,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 51
-          Type: 278 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xd04620", Frameless: true}]
+        - ID: 52
+          Type: 279 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xd04680", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1176,7 +1190,7 @@ Probes:
       events:
         - ID: 3
           Type: 230 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0xd02960", Frameless: true}]
+          InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1186,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 74
-          Type: 301 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd064c0", Frameless: true}]
+        - ID: 75
+          Type: 302 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd06520", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1200,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 83
-          Type: 310 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
+        - ID: 84
+          Type: 311 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1214,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 96
-          Type: 323 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd07280", Frameless: true}]
+        - ID: 97
+          Type: 324 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1228,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 80
-          Type: 307 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
+        - ID: 81
+          Type: 308 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1242,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 46
-          Type: 273 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xd04580", Frameless: true}]
+        - ID: 47
+          Type: 274 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1256,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 89
-          Type: 316 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd06f40", Frameless: true}]
+        - ID: 90
+          Type: 317 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1270,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 90
-          Type: 317 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd06f60", Frameless: true}]
+        - ID: 91
+          Type: 318 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1284,11 +1298,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 91
-          Type: 318 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+        - ID: 92
+          Type: 319 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1302,7 +1316,7 @@ Probes:
       events:
         - ID: 34
           Type: 261 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd03140", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1316,7 +1330,7 @@ Probes:
       events:
         - ID: 12
           Type: 239 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1330,7 +1344,7 @@ Probes:
       events:
         - ID: 13
           Type: 240 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1344,7 +1358,7 @@ Probes:
       events:
         - ID: 14
           Type: 241 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1358,7 +1372,7 @@ Probes:
       events:
         - ID: 11
           Type: 238 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1372,7 +1386,7 @@ Probes:
       events:
         - ID: 10
           Type: 237 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1382,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 73
-          Type: 300 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
+        - ID: 74
+          Type: 301 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd06440", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1396,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 77
-          Type: 304 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd06a60", Frameless: true}]
+        - ID: 78
+          Type: 305 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1410,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 94
-          Type: 321 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
+        - ID: 95
+          Type: 322 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1424,11 +1438,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 72
-          Type: 299 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
+        - ID: 73
+          Type: 300 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd06400", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1442,7 +1456,7 @@ Probes:
       events:
         - ID: 18
           Type: 245 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
+          InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1452,430 +1466,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 86
-          Type: 313 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
+        - ID: 87
+          Type: 314 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xd02920..0xd02921]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 3 ArrayType [2]uint8
-          Locations:
-            - Range: 0xd02920..0xd02921
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 8
-      Name: main.testRuneArray
-      OutOfLinePCRanges: [0xd02940..0xd02941]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 5 ArrayType [2]int32
-          Locations:
-            - Range: 0xd02940..0xd02941
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 9
-      Name: main.testStringArray
-      OutOfLinePCRanges: [0xd02960..0xd02961]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 ArrayType [2]string
-          Locations:
-            - Range: 0xd02960..0xd02961
-              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 10
-      Name: main.testBoolArray
       OutOfLinePCRanges: [0xd02980..0xd02981]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0xd02980..0xd02981
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
-      Name: main.testIntArray
+    - ID: 8
+      Name: main.testRuneArray
       OutOfLinePCRanges: [0xd029a0..0xd029a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 ArrayType [2]int
-          Locations:
-            - Range: 0xd029a0..0xd029a1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 12
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xd029c0..0xd029c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 ArrayType [2]int8
-          Locations:
-            - Range: 0xd029c0..0xd029c1
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 13
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xd029e0..0xd029e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 ArrayType [2]int16
-          Locations:
-            - Range: 0xd029e0..0xd029e1
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 14
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xd02a00..0xd02a01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
+            - Range: 0xd029a0..0xd029a1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.testStringArray
+      OutOfLinePCRanges: [0xd029c0..0xd029c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0xd029c0..0xd029c1
+              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.testBoolArray
+      OutOfLinePCRanges: [0xd029e0..0xd029e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 ArrayType [2]bool
+          Locations:
+            - Range: 0xd029e0..0xd029e1
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.testIntArray
+      OutOfLinePCRanges: [0xd02a00..0xd02a01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 ArrayType [2]int
+          Locations:
             - Range: 0xd02a00..0xd02a01
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xd02a20..0xd02a21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 13 ArrayType [2]int8
+          Locations:
+            - Range: 0xd02a20..0xd02a21
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xd02a40..0xd02a41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 ArrayType [2]int16
+          Locations:
+            - Range: 0xd02a40..0xd02a41
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 14
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xd02a60..0xd02a61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0xd02a60..0xd02a61
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xd02a20..0xd02a21]
+      OutOfLinePCRanges: [0xd02a80..0xd02a81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 ArrayType [2]int64
           Locations:
-            - Range: 0xd02a20..0xd02a21
+            - Range: 0xd02a80..0xd02a81
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xd02a40..0xd02a41]
+      OutOfLinePCRanges: [0xd02aa0..0xd02aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 ArrayType [2]uint
           Locations:
-            - Range: 0xd02a40..0xd02a41
+            - Range: 0xd02aa0..0xd02aa1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xd02a60..0xd02a61]
+      OutOfLinePCRanges: [0xd02ac0..0xd02ac1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0xd02a60..0xd02a61
+            - Range: 0xd02ac0..0xd02ac1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xd02a80..0xd02a81]
+      OutOfLinePCRanges: [0xd02ae0..0xd02ae1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 ArrayType [2]uint16
           Locations:
-            - Range: 0xd02a80..0xd02a81
+            - Range: 0xd02ae0..0xd02ae1
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xd02aa0..0xd02aa1]
+      OutOfLinePCRanges: [0xd02b00..0xd02b01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 ArrayType [2]uint32
           Locations:
-            - Range: 0xd02aa0..0xd02aa1
+            - Range: 0xd02b00..0xd02b01
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xd02ac0..0xd02ac1]
+      OutOfLinePCRanges: [0xd02b20..0xd02b21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 25 ArrayType [2]uint64
           Locations:
-            - Range: 0xd02ac0..0xd02ac1
+            - Range: 0xd02b20..0xd02b21
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xd02ae0..0xd02ae1]
+      OutOfLinePCRanges: [0xd02b40..0xd02b41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 27 ArrayType [2][2]int
           Locations:
-            - Range: 0xd02ae0..0xd02ae1
+            - Range: 0xd02b40..0xd02b41
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xd02b00..0xd02b01]
+      OutOfLinePCRanges: [0xd02b60..0xd02b61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0xd02b00..0xd02b01
+            - Range: 0xd02b60..0xd02b61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xd02b20..0xd02b21]
+      OutOfLinePCRanges: [0xd02b80..0xd02b81]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 28 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xd02b20..0xd02b21
+            - Range: 0xd02b80..0xd02b81
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xd02b80..0xd02b81]
+      OutOfLinePCRanges: [0xd02be0..0xd02be1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 29 ArrayType [100]uint
           Locations:
-            - Range: 0xd02b80..0xd02b81
+            - Range: 0xd02be0..0xd02be1
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xd02f00..0xd02f01]
+      OutOfLinePCRanges: [0xd02f60..0xd02f61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd02f00..0xd02f01
+            - Range: 0xd02f60..0xd02f61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xd02f20..0xd02f21]
+      OutOfLinePCRanges: [0xd02f80..0xd02f81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xd02f20..0xd02f21
+            - Range: 0xd02f80..0xd02f81
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xd02f40..0xd02f41]
+      OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType bool
           Locations:
-            - Range: 0xd02f40..0xd02f41
+            - Range: 0xd02fa0..0xd02fa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xd02f60..0xd02f61]
+      OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd02f60..0xd02f61
+            - Range: 0xd02fc0..0xd02fc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xd02f80..0xd02f81]
+      OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd02f80..0xd02f81
+            - Range: 0xd02fe0..0xd02fe1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xd02fa0..0xd02fa1]
+      OutOfLinePCRanges: [0xd03000..0xd03001]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int16
           Locations:
-            - Range: 0xd02fa0..0xd02fa1
+            - Range: 0xd03000..0xd03001
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xd02fc0..0xd02fc1]
+      OutOfLinePCRanges: [0xd03020..0xd03021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xd02fc0..0xd02fc1
+            - Range: 0xd03020..0xd03021
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xd02fe0..0xd02fe1]
+      OutOfLinePCRanges: [0xd03040..0xd03041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int64
           Locations:
-            - Range: 0xd02fe0..0xd02fe1
+            - Range: 0xd03040..0xd03041
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xd03000..0xd03001]
+      OutOfLinePCRanges: [0xd03060..0xd03061]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xd03000..0xd03001
+            - Range: 0xd03060..0xd03061
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xd03020..0xd03021]
+      OutOfLinePCRanges: [0xd03080..0xd03081]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd03020..0xd03021
+            - Range: 0xd03080..0xd03081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xd03040..0xd03041]
+      OutOfLinePCRanges: [0xd030a0..0xd030a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 22 BaseType uint16
           Locations:
-            - Range: 0xd03040..0xd03041
+            - Range: 0xd030a0..0xd030a1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 36
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xd03060..0xd03061]
+      OutOfLinePCRanges: [0xd030c0..0xd030c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 24 BaseType uint32
           Locations:
-            - Range: 0xd03060..0xd03061
+            - Range: 0xd030c0..0xd030c1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 37
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xd03080..0xd03081]
+      OutOfLinePCRanges: [0xd030e0..0xd030e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 26 BaseType uint64
           Locations:
-            - Range: 0xd03080..0xd03081
+            - Range: 0xd030e0..0xd030e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 38
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xd030a0..0xd030a1]
+      OutOfLinePCRanges: [0xd03100..0xd03101]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 30 BaseType float32
           Locations:
-            - Range: 0xd030a0..0xd030a1
+            - Range: 0xd03100..0xd03101
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 39
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xd030c0..0xd030c1]
+      OutOfLinePCRanges: [0xd03120..0xd03121]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType float64
           Locations:
-            - Range: 0xd030c0..0xd030c1
+            - Range: 0xd03120..0xd03121
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 40
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xd030e0..0xd030e1]
+      OutOfLinePCRanges: [0xd03140..0xd03141]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 32 BaseType main.typeAlias
           Locations:
-            - Range: 0xd030e0..0xd030e1
+            - Range: 0xd03140..0xd03141
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 41
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xd03240..0xd0325f]
+      OutOfLinePCRanges: [0xd032a0..0xd032bf]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 33 StructureType main.bigStruct
           Locations:
-            - Range: 0xd03240..0xd0325f
+            - Range: 0xd032a0..0xd032bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1893,13 +1907,13 @@ Subprograms:
           IsReturn: false
     - ID: 42
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xd034c0..0xd035c5]
+      OutOfLinePCRanges: [0xd03520..0xd03625]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 57 StructureType main.esotericStack
           Locations:
-            - Range: 0xd034c0..0xd03513
+            - Range: 0xd03520..0xd03573
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1919,7 +1933,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03513..0xd03518
+            - Range: 0xd03573..0xd03578
               Pieces:
                 - Size: 4
                   Op: null
@@ -1939,7 +1953,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xd03518..0xd0351d
+            - Range: 0xd03578..0xd0357d
               Pieces:
                 - Size: 4
                   Op: null
@@ -1963,144 +1977,144 @@ Subprograms:
           IsReturn: false
     - ID: 43
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xd035e0..0xd03643]
+      OutOfLinePCRanges: [0xd03640..0xd036a3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 63 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xd035e0..0xd0360d
+            - Range: 0xd03640..0xd0366d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 44
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xd03a20..0xd03aa8]
+      OutOfLinePCRanges: [0xd03a80..0xd03b08]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03a20..0xd03a35
+            - Range: 0xd03a80..0xd03a95
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 45
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xd03ac0..0xd03b85]
+      OutOfLinePCRanges: [0xd03b20..0xd03be5]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03ac0..0xd03ad6
+            - Range: 0xd03b20..0xd03b36
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03ac0..0xd03ae7
+            - Range: 0xd03b20..0xd03b47
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03ad6..0xd03ae7
+            - Range: 0xd03b36..0xd03b47
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03ae7..0xd03b85
+            - Range: 0xd03b47..0xd03be5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
     - ID: 46
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xd03ba0..0xd03c02]
+      OutOfLinePCRanges: [0xd03c00..0xd03c62]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03ba0..0xd03bba
+            - Range: 0xd03c00..0xd03c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xd03c20..0xd03d2e]
+      OutOfLinePCRanges: [0xd03c80..0xd03d8e]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03c7b..0xd03c85
+            - Range: 0xd03cdb..0xd03ce5
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd03c85..0xd03ca0
+            - Range: 0xd03ce5..0xd03d00
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xd03ca0..0xd03cb4
+            - Range: 0xd03d00..0xd03d14
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03c76..0xd03c80
+            - Range: 0xd03cd6..0xd03ce0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd03c80..0xd03ca0
+            - Range: 0xd03ce0..0xd03d00
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xd03ca0..0xd03caf
+            - Range: 0xd03d00..0xd03d0f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
     - ID: 48
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xd03d40..0xd03d46]
+      OutOfLinePCRanges: [0xd03da0..0xd03da6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03d40..0xd03d45
+            - Range: 0xd03da0..0xd03da5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0xd03d40..0xd03d46, Pieces: []}]
+          Locations: [{Range: 0xd03da0..0xd03da6, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 49
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xd03d60..0xd03da3]
+      OutOfLinePCRanges: [0xd03dc0..0xd03e03]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0xd03d60..0xd03da3
+            - Range: 0xd03dc0..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0xd03d60..0xd03da3, Pieces: []}]
+          Locations: [{Range: 0xd03dc0..0xd03e03, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0xd04040..0xd042cd]
+      OutOfLinePCRanges: [0xd040a0..0xd040e3]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 74 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd04040..0xd0407e
+            - Range: 0xd040a0..0xd040bf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0407e..0xd04085
+            - Range: 0xd040bf..0xd040c2
               Pieces:
                 - Size: 8
                   Op: null
@@ -2110,134 +2124,45 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0xd04040..0xd042cd, Pieces: []}]
+          Locations: [{Range: 0xd040a0..0xd040e3, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: hash
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xd040bd..0xd040c2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd040c2..0xd040de
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd040de..0xd040e5
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-            - Range: 0xd040e5..0xd042cd
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-          IsParameter: false
-          IsReturn: false
-        - Name: inter
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0411d..0xd04122
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd04122..0xd0413f
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0413f..0xd04145
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-            - Range: 0xd04145..0xd042cd
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-          IsParameter: false
-          IsReturn: false
-        - Name: iType
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0417d..0xd04182
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd04182..0xd0419f
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0419f..0xd041a5
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-            - Range: 0xd041a5..0xd042cd
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-          IsParameter: false
-          IsReturn: false
-        - Name: iFun
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xd041dd..0xd041e2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xd041e2..0xd0420a
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0420a..0xd0420f
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-            - Range: 0xd0420f..0xd042cd
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-          IsParameter: false
-          IsReturn: false
     - ID: 51
+      Name: main.testAny
+      OutOfLinePCRanges: [0xd04100..0xd04166]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xd04100..0xd04129
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xd04129..0xd0412e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xd04100..0xd04166, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 52
       Name: main.testError
-      OutOfLinePCRanges: [0xd042e0..0xd042e1]
+      OutOfLinePCRanges: [0xd04180..0xd04181]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 75 GoInterfaceType error
           Locations:
-            - Range: 0xd042e0..0xd042e1
+            - Range: 0xd04180..0xd04181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2245,68 +2170,32 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 52
+    - ID: 53
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xd04580..0xd04581]
+      OutOfLinePCRanges: [0xd045e0..0xd045e1]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 76 StructureType main.structWithMap
           Locations:
-            - Range: 0xd04580..0xd04581
+            - Range: 0xd045e0..0xd045e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xd045a0..0xd045a1]
+      OutOfLinePCRanges: [0xd04600..0xd04601]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 92 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xd045a0..0xd045a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xd045c0..0xd045c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0xd045c0..0xd045c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xd045e0..0xd045e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0xd045e0..0xd045e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xd04600..0xd04601]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
-          Locations:
             - Range: 0xd04600..0xd04601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
-      Name: main.testSmallMap
+    - ID: 55
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xd04620..0xd04621]
       InlinePCRanges: []
       Variables:
@@ -2317,237 +2206,273 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
-      Name: main.testArrayOfMaps
+    - ID: 56
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xd04640..0xd04641]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 ArrayType [2]map[string]int
+          Type: 105 GoMapType map[string][]string
           Locations:
             - Range: 0xd04640..0xd04641
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
-      Name: main.testPointerToMap
+    - ID: 57
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xd04660..0xd04661]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 PointerType *map[string]int
+          Type: 112 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd04660..0xd04661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
-      Name: main.testMapIntToInt
+    - ID: 58
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xd04680..0xd04681]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 77 GoMapType map[int]int
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0xd04680..0xd04681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
-      Name: main.testMapMassive
+    - ID: 59
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xd046a0..0xd046a1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 122 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 120 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd046a0..0xd046a1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
+    - ID: 60
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xd046c0..0xd046c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[string][]main.structWithMap
+          Type: 121 PointerType *map[string]int
           Locations:
             - Range: 0xd046c0..0xd046c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
+    - ID: 61
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xd046e0..0xd046e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 130 GoMapType map[bool]main.node
+          Type: 77 GoMapType map[int]int
           Locations:
             - Range: 0xd046e0..0xd046e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
+    - ID: 62
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xd04700..0xd04701]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 139 GoMapType map[int]uint8
+        - Name: redactMyEntries
+          Type: 122 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04700..0xd04701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
+    - ID: 63
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xd04720..0xd04721]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 139 GoMapType map[int]uint8
+        - Name: m
+          Type: 122 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04720..0xd04721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 64
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xd04740..0xd04741]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 130 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd04740..0xd04741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 65
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xd04760..0xd04761]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 139 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04760..0xd04761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
+    - ID: 66
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xd04780..0xd04781]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 139 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04780..0xd04781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xd047a0..0xd047a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[uint8][4]int
+          Type: 145 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047a0..0xd047a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 68
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xd047c0..0xd047c1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 158 GoMapType map[[4]int]uint8
+          Type: 145 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047c0..0xd047c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 69
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xd047e0..0xd047e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[[4]int][4]int
+          Type: 145 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047e0..0xd047e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 70
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xd04800..0xd04801]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 151 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xd04800..0xd04801
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xd04820..0xd04821]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 158 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xd04820..0xd04821
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xd04840..0xd04841]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xd04840..0xd04841
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xd05da0..0xd05da1]
+      OutOfLinePCRanges: [0xd05e00..0xd05e01]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd05da0..0xd05da1
+            - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd05da0..0xd05da1
+            - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0xd05da0..0xd05da1
+            - Range: 0xd05e00..0xd05e01
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 74
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xd05f60..0xd05f61]
+      OutOfLinePCRanges: [0xd05fc0..0xd05fc1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0xd05f60..0xd05f61
+            - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xd05f60..0xd05f61
+            - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xd05f60..0xd05f61
+            - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xd05f60..0xd05f61
+            - Range: 0xd05fc0..0xd05fc1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd05f60..0xd05f61
+            - Range: 0xd05fc0..0xd05fc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2555,39 +2480,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 75
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd06180..0xd06181]
+      OutOfLinePCRanges: [0xd061e0..0xd061e1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 169 GoChannelType chan bool
           Locations:
-            - Range: 0xd06180..0xd06181
+            - Range: 0xd061e0..0xd061e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd06340..0xd06341]
+      OutOfLinePCRanges: [0xd063a0..0xd063a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd06340..0xd06341
+            - Range: 0xd063a0..0xd063a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd06360..0xd06361]
+      OutOfLinePCRanges: [0xd063c0..0xd063c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.node
           Locations:
-            - Range: 0xd06360..0xd06361
+            - Range: 0xd063c0..0xd063c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2595,112 +2520,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd06380..0xd06381]
+      OutOfLinePCRanges: [0xd063e0..0xd063e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 PointerType *main.node
           Locations:
-            - Range: 0xd06380..0xd06381
+            - Range: 0xd063e0..0xd063e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd063a0..0xd063a1]
+      OutOfLinePCRanges: [0xd06400..0xd06401]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd063a0..0xd063a1
+            - Range: 0xd06400..0xd06401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd063e0..0xd063e1]
+      OutOfLinePCRanges: [0xd06440..0xd06441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 172 PointerType *uint
           Locations:
-            - Range: 0xd063e0..0xd063e1
+            - Range: 0xd06440..0xd06441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd064c0..0xd064c1]
+      OutOfLinePCRanges: [0xd06520..0xd06521]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0xd064c0..0xd064c1
+            - Range: 0xd06520..0xd06521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd06500..0xd06501]
+      OutOfLinePCRanges: [0xd06560..0xd06561]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 173 PointerType *bool
           Locations:
-            - Range: 0xd06500..0xd06501
+            - Range: 0xd06560..0xd06561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xd06500..0xd06501
+            - Range: 0xd06560..0xd06561
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd06540..0xd06541]
+      OutOfLinePCRanges: [0xd065a0..0xd065a1]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 174 PointerType *main.t
           Locations:
-            - Range: 0xd06540..0xd06541
+            - Range: 0xd065a0..0xd065a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd06a60..0xd06a61]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 177 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd06a60..0xd06a61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 84
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd06a80..0xd06a81]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xd06ac0..0xd06ac1]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 177 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd06a80..0xd06a81
+            - Range: 0xd06ac0..0xd06ac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2711,14 +2618,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 85
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xd06aa0..0xd06aa1]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xd06ae0..0xd06ae1]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 178 GoSliceHeaderType [][]uint
+          Type: 177 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd06aa0..0xd06aa1
+            - Range: 0xd06ae0..0xd06ae1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2729,62 +2636,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 86
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xd06ac0..0xd06ac1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd06ac0..0xd06ac1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xd06ac0..0xd06ac1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xd06ae0..0xd06ae1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xd06ae0..0xd06ae1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xd06ae0..0xd06ae1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 88
-      Name: main.testNilSliceOfStructs
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd06b00..0xd06b01]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 178 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd06b00..0xd06b01
               Pieces:
@@ -2796,20 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xd06b00..0xd06b01
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testStringSlice
+    - ID: 87
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xd06b20..0xd06b21]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 111 GoSliceHeaderType []string
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b20..0xd06b21
               Pieces:
@@ -2821,22 +2671,97 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06b20..0xd06b21
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd06b40..0xd06b41]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd06b40..0xd06b41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06b40..0xd06b41
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xd06b60..0xd06b61]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd06b60..0xd06b61
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xd06b60..0xd06b61
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd06b80..0xd06b81]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 111 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd06b80..0xd06b81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd06ba0..0xd06ba1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd06b40..0xd06b41
+            - Range: 0xd06ba0..0xd06ba1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 183 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd06b40..0xd06b41
+            - Range: 0xd06ba0..0xd06ba1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -2849,37 +2774,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xd06b40..0xd06b41
+            - Range: 0xd06ba0..0xd06ba1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd06b60..0xd06b61]
+      OutOfLinePCRanges: [0xd06bc0..0xd06bc1]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 184 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xd06b60..0xd06b61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd06b80..0xd06b81]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 177 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd06b80..0xd06b81
+            - Range: 0xd06bc0..0xd06bc1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,24 +2797,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 93
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xd06be0..0xd06be1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd06be0..0xd06be1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.stackC
-      OutOfLinePCRanges: [0xd06ec0..0xd06f12]
+      OutOfLinePCRanges: [0xd06f20..0xd06f72]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0xd06ec0..0xd06f12, Pieces: []}]
+          Locations: [{Range: 0xd06f20..0xd06f72, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd06f20..0xd06f21]
+      OutOfLinePCRanges: [0xd06f80..0xd06f81]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f20..0xd06f21
+            - Range: 0xd06f80..0xd06f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2915,15 +2840,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd06f40..0xd06f41]
+      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd06fa0..0xd06fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2859,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd06fa0..0xd06fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2870,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd06f40..0xd06f41
+            - Range: 0xd06fa0..0xd06fa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2953,15 +2878,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 97
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd06f60..0xd06f7f]
+      OutOfLinePCRanges: [0xd06fc0..0xd06fdf]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 186 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd06f60..0xd06f7f
+            - Range: 0xd06fc0..0xd06fdf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2977,55 +2902,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 98
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd06f80..0xd06f81]
+      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 187 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd06f80..0xd06f81
+            - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd06fa0..0xd06fa1]
+      OutOfLinePCRanges: [0xd07000..0xd07001]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 188 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd06fa0..0xd06fa1
+            - Range: 0xd07000..0xd07001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd06fc0..0xd06fc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xd06fc0..0xd06fc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 100
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd06fe0..0xd06fe1]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xd07020..0xd07021]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd06fe0..0xd06fe1
+            - Range: 0xd07020..0xd07021
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3034,14 +2943,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xd07000..0xd07001]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xd07040..0xd07041]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xd07000..0xd07001
+            - Range: 0xd07040..0xd07041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3050,14 +2959,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 102
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd07060..0xd07061]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xd07060..0xd07061
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd07280..0xd072a3]
+      OutOfLinePCRanges: [0xd072e0..0xd07303]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 190 StructureType main.aStruct
           Locations:
-            - Range: 0xd07280..0xd072a3
+            - Range: 0xd072e0..0xd07303
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3075,43 +3000,43 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 104
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd07400..0xd07401]
+      OutOfLinePCRanges: [0xd07460..0xd07461]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 191 StructureType main.emptyStruct
-          Locations: [{Range: 0xd07400..0xd07401, Pieces: []}]
+          Locations: [{Range: 0xd07460..0xd07461, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xd03880..0xd038e2]
+      OutOfLinePCRanges: [0xd038e0..0xd03942]
       InlinePCRanges:
-        - Ranges: [0xd03911..0xd0394d]
-          RootRanges: [0xd03900..0xd03971]
-        - Ranges: [0xd03a52..0xd03a8e]
-          RootRanges: [0xd03a20..0xd03aa8]
-        - Ranges: [0xd03adc..0xd03b18]
-          RootRanges: [0xd03ac0..0xd03b85]
-        - Ranges: [0xd03baf..0xd03beb]
-          RootRanges: [0xd03ba0..0xd03c02]
+        - Ranges: [0xd03971..0xd039ad]
+          RootRanges: [0xd03960..0xd039d1]
+        - Ranges: [0xd03ab2..0xd03aee]
+          RootRanges: [0xd03a80..0xd03b08]
+        - Ranges: [0xd03b3c..0xd03b78]
+          RootRanges: [0xd03b20..0xd03be5]
+        - Ranges: [0xd03c0f..0xd03c4b]
+          RootRanges: [0xd03c00..0xd03c62]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03880..0xd03899
+            - Range: 0xd038e0..0xd038f9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03911..0xd0391c
+            - Range: 0xd03971..0xd0397c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03a52..0xd03a5d
+            - Range: 0xd03ab2..0xd03abd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03ad6..0xd03ae7
+            - Range: 0xd03b36..0xd03b47
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd03ae7..0xd03b85
+            - Range: 0xd03b47..0xd03be5
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd03ba0..0xd03bba
+            - Range: 0xd03c00..0xd03c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3119,34 +3044,34 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03b26..0xd03b5e]
-          RootRanges: [0xd03ac0..0xd03b85]
+        - Ranges: [0xd03b86..0xd03bbe]
+          RootRanges: [0xd03b20..0xd03be5]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03c33..0xd03c71]
-          RootRanges: [0xd03c20..0xd03d2e]
+        - Ranges: [0xd03c93..0xd03cd1]
+          RootRanges: [0xd03c80..0xd03d8e]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03ce6..0xd03d1e]
-          RootRanges: [0xd03c20..0xd03d2e]
+        - Ranges: [0xd03d46..0xd03d7e]
+          RootRanges: [0xd03c80..0xd03d8e]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03d41..0xd03d45]
-          RootRanges: [0xd03d40..0xd03d46]
+        - Ranges: [0xd03da1..0xd03da5]
+          RootRanges: [0xd03da0..0xd03da6]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xd03d40..0xd03d45
+            - Range: 0xd03da0..0xd03da5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3154,17 +3079,17 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xd03d85..0xd03d9d]
-          RootRanges: [0xd03d60..0xd03da3]
-        - Ranges: [0xd03e25..0xd03e43]
-          RootRanges: [0xd03dc0..0xd03f45]
+        - Ranges: [0xd03de5..0xd03dfd]
+          RootRanges: [0xd03dc0..0xd03e03]
+        - Ranges: [0xd03e85..0xd03ea3]
+          RootRanges: [0xd03e20..0xd03fa5]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0xd03d6d..0xd03da3
+            - Range: 0xd03dcd..0xd03e03
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xd03e0c..0xd03f45
+            - Range: 0xd03e6c..0xd03fa5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
@@ -3173,7 +3098,7 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 527392
+      GoRuntimeType: 527424
       GoKind: 2
     - __kind: ArrayType
       ID: 2
@@ -3187,7 +3112,7 @@ Types:
       ID: 3
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 618752
+      GoRuntimeType: 618784
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3196,13 +3121,13 @@ Types:
       ID: 4
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 526944
+      GoRuntimeType: 526976
       GoKind: 8
     - __kind: ArrayType
       ID: 5
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 618848
+      GoRuntimeType: 618880
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3211,13 +3136,13 @@ Types:
       ID: 6
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 527136
+      GoRuntimeType: 527168
       GoKind: 5
     - __kind: ArrayType
       ID: 7
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 618944
+      GoRuntimeType: 618976
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3226,7 +3151,7 @@ Types:
       ID: 8
       Name: string
       ByteSize: 16
-      GoRuntimeType: 526816
+      GoRuntimeType: 526848
       GoKind: 24
       RawFields:
         - Name: str
@@ -3240,7 +3165,7 @@ Types:
       ID: 9
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 359296
+      GoRuntimeType: 359328
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: ArrayType
@@ -3255,13 +3180,13 @@ Types:
       ID: 11
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 527840
+      GoRuntimeType: 527872
       GoKind: 1
     - __kind: ArrayType
       ID: 12
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 617888
+      GoRuntimeType: 617728
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3278,7 +3203,7 @@ Types:
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 526880
+      GoRuntimeType: 526912
       GoKind: 3
     - __kind: ArrayType
       ID: 15
@@ -3292,7 +3217,7 @@ Types:
       ID: 16
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 527008
+      GoRuntimeType: 527040
       GoKind: 4
     - __kind: ArrayType
       ID: 17
@@ -3306,7 +3231,7 @@ Types:
       ID: 18
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 527264
+      GoRuntimeType: 527296
       GoKind: 6
     - __kind: ArrayType
       ID: 19
@@ -3320,7 +3245,7 @@ Types:
       ID: 20
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 527456
+      GoRuntimeType: 527488
       GoKind: 7
     - __kind: ArrayType
       ID: 21
@@ -3334,7 +3259,7 @@ Types:
       ID: 22
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 527072
+      GoRuntimeType: 527104
       GoKind: 9
     - __kind: ArrayType
       ID: 23
@@ -3348,13 +3273,13 @@ Types:
       ID: 24
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 527200
+      GoRuntimeType: 527232
       GoKind: 10
     - __kind: ArrayType
       ID: 25
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 619040
+      GoRuntimeType: 619072
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3363,7 +3288,7 @@ Types:
       ID: 26
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 527328
+      GoRuntimeType: 527360
       GoKind: 11
     - __kind: ArrayType
       ID: 27
@@ -3393,13 +3318,13 @@ Types:
       ID: 30
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 527712
+      GoRuntimeType: 527744
       GoKind: 13
     - __kind: BaseType
       ID: 31
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 527776
+      GoRuntimeType: 527808
       GoKind: 14
     - __kind: BaseType
       ID: 32
@@ -3425,7 +3350,7 @@ Types:
       ID: 34
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 443200
+      GoRuntimeType: 443232
       GoKind: 23
       RawFields:
         - Name: array
@@ -3442,21 +3367,21 @@ Types:
       ID: 35
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 485984
+      GoRuntimeType: 486016
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
       ID: 36
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 359168
+      GoRuntimeType: 359200
       GoKind: 22
       Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
       ID: 37
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 973472
+      GoRuntimeType: 973760
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
@@ -3475,14 +3400,14 @@ Types:
       ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
-      GoRuntimeType: 383296
+      GoRuntimeType: 383328
       GoKind: 22
       Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
       ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
-      GoRuntimeType: 1.62688e+06
+      GoRuntimeType: 1.627168e+06
       GoKind: 25
       RawFields:
         - Name: Inter
@@ -3501,14 +3426,14 @@ Types:
       ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
-      GoRuntimeType: 2.054016e+06
+      GoRuntimeType: 2.054304e+06
       GoKind: 22
       Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
       ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
-      GoRuntimeType: 1.436928e+06
+      GoRuntimeType: 1.437216e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -3524,7 +3449,7 @@ Types:
       ID: 43
       Name: internal/abi.Type
       ByteSize: 48
-      GoRuntimeType: 1.980832e+06
+      GoRuntimeType: 1.98112e+06
       GoKind: 25
       RawFields:
         - Name: Size_
@@ -3564,43 +3489,43 @@ Types:
       ID: 44
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 527520
+      GoRuntimeType: 527552
       GoKind: 12
     - __kind: BaseType
       ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
-      GoRuntimeType: 530528
+      GoRuntimeType: 530560
       GoKind: 8
     - __kind: BaseType
       ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
-      GoRuntimeType: 759136
+      GoRuntimeType: 759232
       GoKind: 8
     - __kind: GoSubroutineType
       ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 773152
+      GoRuntimeType: 773248
       GoKind: 19
     - __kind: BaseType
       ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
-      GoRuntimeType: 530592
+      GoRuntimeType: 530624
       GoKind: 5
     - __kind: BaseType
       ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
-      GoRuntimeType: 530656
+      GoRuntimeType: 530688
       GoKind: 5
     - __kind: StructureType
       ID: 50
       Name: internal/abi.Name
       ByteSize: 8
-      GoRuntimeType: 1.828384e+06
+      GoRuntimeType: 1.828672e+06
       GoKind: 25
       RawFields:
         - Name: Bytes
@@ -3610,7 +3535,7 @@ Types:
       ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
-      GoRuntimeType: 468352
+      GoRuntimeType: 468384
       GoKind: 23
       RawFields:
         - Name: array
@@ -3627,14 +3552,14 @@ Types:
       ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
-      GoRuntimeType: 383232
+      GoRuntimeType: 383264
       GoKind: 22
       Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
       ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
-      GoRuntimeType: 1.295808e+06
+      GoRuntimeType: 1.296096e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -3647,14 +3572,14 @@ Types:
       ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.054464e+06
+      GoRuntimeType: 2.054752e+06
       GoKind: 22
       Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
       ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
-      GoRuntimeType: 616928
+      GoRuntimeType: 618592
       GoKind: 17
       Count: 1
       HasCount: true
@@ -3663,13 +3588,13 @@ Types:
       ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 527904
+      GoRuntimeType: 527936
       GoKind: 26
     - __kind: StructureType
       ID: 57
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.818592e+06
+      GoRuntimeType: 1.81888e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3696,13 +3621,13 @@ Types:
     - __kind: GoChannelType
       ID: 58
       Name: chan struct {}
-      GoRuntimeType: 538016
+      GoRuntimeType: 538048
       GoKind: 18
     - __kind: GoEmptyInterfaceType
       ID: 59
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 772288
+      GoRuntimeType: 772384
       GoKind: 20
       UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
@@ -3721,27 +3646,27 @@ Types:
       ID: 61
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 973216
+      GoRuntimeType: 973504
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
       ID: 62
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 441792
+      GoRuntimeType: 441824
       GoKind: 19
     - __kind: PointerType
       ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 354112
+      GoRuntimeType: 354144
       GoKind: 22
       Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
       ID: 64
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.692128e+06
+      GoRuntimeType: 1.692416e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -3763,7 +3688,7 @@ Types:
       ID: 65
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.271008e+06
+      GoRuntimeType: 1.271296e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -3776,7 +3701,7 @@ Types:
       ID: 66
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.272128e+06
+      GoRuntimeType: 1.272416e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -3789,7 +3714,7 @@ Types:
       ID: 67
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.272608e+06
+      GoRuntimeType: 1.272896e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3801,14 +3726,14 @@ Types:
     - __kind: StructureType
       ID: 68
       Name: sync/atomic.noCopy
-      GoRuntimeType: 940416
+      GoRuntimeType: 940608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.410816e+06
+      GoRuntimeType: 1.411104e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -3823,14 +3748,14 @@ Types:
     - __kind: StructureType
       ID: 70
       Name: sync.noCopy
-      GoRuntimeType: 940320
+      GoRuntimeType: 940512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 71
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.4112e+06
+      GoRuntimeType: 1.411488e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3845,14 +3770,14 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: sync/atomic.align64
-      GoRuntimeType: 940512
+      GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 73
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.272448e+06
+      GoRuntimeType: 1.272736e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3865,21 +3790,21 @@ Types:
       ID: 74
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 973088
+      GoRuntimeType: 973376
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
       ID: 75
       Name: error
       ByteSize: 16
-      GoRuntimeType: 977568
+      GoRuntimeType: 977856
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
       ID: 76
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.09216e+06
+      GoRuntimeType: 1.092448e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -3889,7 +3814,7 @@ Types:
       ID: 77
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 872704
+      GoRuntimeType: 872896
       GoKind: 21
       HeaderType: 79 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
@@ -3959,7 +3884,7 @@ Types:
       ID: 82
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 615392
+      GoRuntimeType: 615424
       GoKind: 17
       Count: 8
       HasCount: true
@@ -3982,14 +3907,14 @@ Types:
       ID: 85
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 363072
+      GoRuntimeType: 363104
       GoKind: 22
       Pointee: 86 StructureType runtime.mapextra
     - __kind: StructureType
       ID: 86
       Name: runtime.mapextra
       ByteSize: 24
-      GoRuntimeType: 1.416768e+06
+      GoRuntimeType: 1.417056e+06
       GoKind: 25
       RawFields:
         - Name: overflow
@@ -4005,14 +3930,14 @@ Types:
       ID: 87
       Name: '*[]*runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 451648
+      GoRuntimeType: 451680
       GoKind: 22
       Pointee: 88 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 88
       Name: '[]*runtime.bmap'
       ByteSize: 24
-      GoRuntimeType: 451584
+      GoRuntimeType: 451616
       GoKind: 23
       RawFields:
         - Name: array
@@ -4034,14 +3959,14 @@ Types:
       ID: 90
       Name: '*runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 1.100608e+06
+      GoRuntimeType: 1.100896e+06
       GoKind: 22
       Pointee: 91 StructureType runtime.bmap
     - __kind: StructureType
       ID: 91
       Name: runtime.bmap
       ByteSize: 8
-      GoRuntimeType: 1.10048e+06
+      GoRuntimeType: 1.100768e+06
       GoKind: 25
       RawFields:
         - Name: tophash
@@ -4051,7 +3976,7 @@ Types:
       ID: 92
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 874432
+      GoRuntimeType: 874624
       GoKind: 21
       HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
@@ -4135,7 +4060,7 @@ Types:
       ID: 99
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.269728e+06
+      GoRuntimeType: 1.270016e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -4148,7 +4073,7 @@ Types:
       ID: 100
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 874336
+      GoRuntimeType: 874528
       GoKind: 21
       HeaderType: 102 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
@@ -4218,7 +4143,7 @@ Types:
       ID: 105
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 874240
+      GoRuntimeType: 874432
       GoKind: 21
       HeaderType: 107 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
@@ -4295,7 +4220,7 @@ Types:
       ID: 111
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 449856
+      GoRuntimeType: 449888
       GoKind: 23
       RawFields:
         - Name: array
@@ -4312,7 +4237,7 @@ Types:
       ID: 112
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 873856
+      GoRuntimeType: 874048
       GoKind: 21
       HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
@@ -4389,7 +4314,7 @@ Types:
       ID: 118
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 617792
+      GoRuntimeType: 617632
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4419,7 +4344,7 @@ Types:
       ID: 122
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 874144
+      GoRuntimeType: 874336
       GoKind: 21
       HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
@@ -4496,7 +4421,7 @@ Types:
       ID: 128
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 442688
+      GoRuntimeType: 442720
       GoKind: 23
       RawFields:
         - Name: array
@@ -4513,14 +4438,14 @@ Types:
       ID: 129
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 354048
+      GoRuntimeType: 354080
       GoKind: 22
       Pointee: 76 StructureType main.structWithMap
     - __kind: GoMapType
       ID: 130
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 873952
+      GoRuntimeType: 874144
       GoKind: 21
       HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
@@ -4604,7 +4529,7 @@ Types:
       ID: 137
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.269568e+06
+      GoRuntimeType: 1.269856e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -4617,14 +4542,14 @@ Types:
       ID: 138
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 354176
+      GoRuntimeType: 354208
       GoKind: 22
       Pointee: 137 StructureType main.node
     - __kind: GoMapType
       ID: 139
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 874048
+      GoRuntimeType: 874240
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
@@ -4701,7 +4626,7 @@ Types:
       ID: 145
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 874624
+      GoRuntimeType: 874816
       GoKind: 21
       HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
@@ -4778,7 +4703,7 @@ Types:
       ID: 151
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 874528
+      GoRuntimeType: 874720
       GoKind: 21
       HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
@@ -4855,7 +4780,7 @@ Types:
       ID: 157
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 617504
+      GoRuntimeType: 617344
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4864,7 +4789,7 @@ Types:
       ID: 158
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 873760
+      GoRuntimeType: 873952
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
@@ -4941,7 +4866,7 @@ Types:
       ID: 164
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 873664
+      GoRuntimeType: 873856
       GoKind: 21
       HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
@@ -5010,7 +4935,7 @@ Types:
     - __kind: GoChannelType
       ID: 169
       Name: chan bool
-      GoRuntimeType: 539104
+      GoRuntimeType: 539136
       GoKind: 18
     - __kind: PointerType
       ID: 170
@@ -5034,14 +4959,14 @@ Types:
       ID: 172
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 359808
+      GoRuntimeType: 359840
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
       ID: 173
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 360192
+      GoRuntimeType: 360224
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
@@ -5075,7 +5000,7 @@ Types:
       ID: 177
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 449344
+      GoRuntimeType: 449376
       GoKind: 23
       RawFields:
         - Name: array
@@ -5146,7 +5071,7 @@ Types:
       ID: 183
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 449728
+      GoRuntimeType: 449760
       GoKind: 23
       RawFields:
         - Name: array
@@ -5163,7 +5088,7 @@ Types:
       ID: 184
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 448704
+      GoRuntimeType: 448736
       GoKind: 23
       RawFields:
         - Name: array
@@ -5180,7 +5105,7 @@ Types:
       ID: 185
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 359424
+      GoRuntimeType: 359456
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
@@ -6080,6 +6005,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 272
+      Name: Probe[main.testAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6090,11 +6030,11 @@ Types:
             Type: 75 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: e}
+                  Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 274
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6105,11 +6045,11 @@ Types:
             Type: 76 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 275
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6120,11 +6060,11 @@ Types:
             Type: 92 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 276
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6135,11 +6075,11 @@ Types:
             Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 277
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6150,11 +6090,11 @@ Types:
             Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 278
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6165,11 +6105,11 @@ Types:
             Type: 112 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 279
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6180,11 +6120,11 @@ Types:
             Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 280
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6195,11 +6135,11 @@ Types:
             Type: 120 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 281
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6210,11 +6150,11 @@ Types:
             Type: 121 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 282
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6225,11 +6165,11 @@ Types:
             Type: 77 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 283
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6240,11 +6180,11 @@ Types:
             Type: 122 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 284
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6255,11 +6195,11 @@ Types:
             Type: 122 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 285
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6270,11 +6210,11 @@ Types:
             Type: 130 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 286
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6285,11 +6225,11 @@ Types:
             Type: 139 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 287
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6300,27 +6240,12 @@ Types:
             Type: 139 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 145 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 288
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6335,7 +6260,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 289
-      Name: Probe[main.testMapSmallKeySmallValue]
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6350,6 +6275,21 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 290
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6360,11 +6300,11 @@ Types:
             Type: 151 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 292
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6375,11 +6315,11 @@ Types:
             Type: 158 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 293
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6390,11 +6330,11 @@ Types:
             Type: 164 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 294
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6405,7 +6345,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: w}
+                  Variable: {subprogram: 73, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -6414,7 +6354,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: x}
+                  Variable: {subprogram: 73, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -6423,11 +6363,11 @@ Types:
             Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: y}
+                  Variable: {subprogram: 73, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 295
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6438,7 +6378,7 @@ Types:
             Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: a}
+                  Variable: {subprogram: 74, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -6447,7 +6387,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: b}
+                  Variable: {subprogram: 74, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -6456,7 +6396,7 @@ Types:
             Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: c}
+                  Variable: {subprogram: 74, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -6465,7 +6405,7 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 3, name: d}
+                  Variable: {subprogram: 74, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -6474,11 +6414,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 4, name: e}
+                  Variable: {subprogram: 74, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 296
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6489,11 +6429,11 @@ Types:
             Type: 169 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: c}
+                  Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 296
+      ID: 297
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6504,11 +6444,11 @@ Types:
             Type: 170 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 298
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6519,11 +6459,11 @@ Types:
             Type: 137 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 299
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6534,11 +6474,11 @@ Types:
             Type: 138 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 300
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6549,11 +6489,11 @@ Types:
             Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 301
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6564,11 +6504,11 @@ Types:
             Type: 172 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 302
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6579,11 +6519,11 @@ Types:
             Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 303
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6594,7 +6534,7 @@ Types:
             Type: 173 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 82, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -6603,11 +6543,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 304
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6618,27 +6558,12 @@ Types:
             Type: 174 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: t}
+                  Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 177 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 305
-      Name: Probe[main.testEmptySlice]
+      Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
@@ -6653,6 +6578,21 @@ Types:
                   ByteSize: 24
     - __kind: EventRootType
       ID: 306
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 307
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6663,36 +6603,12 @@ Types:
             Type: 178 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 308
-      Name: Probe[main.testEmptySliceOfStructs]
+      Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -6716,7 +6632,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 309
-      Name: Probe[main.testNilSliceOfStructs]
+      Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -6740,6 +6656,30 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 310
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6750,11 +6690,11 @@ Types:
             Type: 111 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: s}
+                  Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6765,7 +6705,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -6774,7 +6714,7 @@ Types:
             Type: 183 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: s}
+                  Variable: {subprogram: 91, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -6783,11 +6723,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: x}
+                  Variable: {subprogram: 91, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6798,11 +6738,11 @@ Types:
             Type: 184 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6813,31 +6753,16 @@ Types:
             Type: 177 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testSingleString]
       ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testThreeStrings]
-      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -6849,13 +6774,28 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: y}
+                  Variable: {subprogram: 96, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -6864,11 +6804,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 2, name: z}
+                  Variable: {subprogram: 96, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6879,11 +6819,11 @@ Types:
             Type: 186 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6894,11 +6834,11 @@ Types:
             Type: 187 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6909,27 +6849,12 @@ Types:
             Type: 188 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testMassiveString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
       ID: 321
-      Name: Probe[main.testUnitializedString]
+      Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -6944,7 +6869,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 322
-      Name: Probe[main.testEmptyString]
+      Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -6959,6 +6884,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 323
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 324
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6969,11 +6909,11 @@ Types:
             Type: 190 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6984,11 +6924,11 @@ Types:
             Type: 191 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: e}
+                  Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 325
+      ID: 326
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7003,16 +6943,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 327
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 327
+      ID: 328
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 328
+      ID: 329
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 329
+      ID: 330
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7027,7 +6967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 331
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7041,5 +6981,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 330
+MaxTypeID: 331
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 295 EventRootType Probe[main.stackC]
+          Type: 308 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd06f2a", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 252 EventRootType Probe[main.testAny]
+          Type: 265 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd0410a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 222 EventRootType Probe[main.testArrayOfArrays]
+          Type: 235 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 224 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 260 EventRootType Probe[main.testArrayOfMaps]
+          Type: 273 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 223 EventRootType Probe[main.testArrayOfStrings]
+          Type: 236 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 242 EventRootType Probe[main.testBigStruct]
+          Type: 255 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd032a0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 211 EventRootType Probe[main.testBoolArray]
+          Type: 224 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 208 EventRootType Probe[main.testByteArray]
+          Type: 221 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02980", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 276 EventRootType Probe[main.testChannel]
+          Type: 289 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd061e0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 274 EventRootType Probe[main.testCombinedByte]
+          Type: 287 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd05e00", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 284 EventRootType Probe[main.testCycle]
+          Type: 297 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 286 EventRootType Probe[main.testEmptySlice]
+          Type: 299 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 289 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 303 EventRootType Probe[main.testEmptyString]
+          Type: 316 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 305 EventRootType Probe[main.testEmptyStruct]
+          Type: 318 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd07460", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 253 EventRootType Probe[main.testError]
+          Type: 266 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04180", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 244 EventRootType Probe[main.testEsotericHeap]
+          Type: 257 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0364a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 243 EventRootType Probe[main.testEsotericStack]
+          Type: 256 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0352e", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 249 EventRootType Probe[main.testFrameless]
+          Type: 262 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 250 EventRootType Probe[main.testFramelessArray]
+          Type: 263 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd03dc4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 245 EventRootType Probe[main.testInlinedBA]
+          Type: 258 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd03a8a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 246 EventRootType Probe[main.testInlinedBB]
+          Type: 259 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd03b2e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 247 EventRootType Probe[main.testInlinedBBA]
+          Type: 260 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd03c0a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 307 EventRootType Probe[main.testInlinedBBB]
+          Type: 320 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd03b86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 248 EventRootType Probe[main.testInlinedBC]
+          Type: 261 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd03c8e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 308 EventRootType Probe[main.testInlinedBCA]
+          Type: 321 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 309 EventRootType Probe[main.testInlinedBCB]
+          Type: 322 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd03d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 306 EventRootType Probe[main.testInlinedPrint]
+          Type: 319 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd038ea"
               Frameless: false
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 310 EventRootType Probe[main.testInlinedSq]
+          Type: 323 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd03da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 311 EventRootType Probe[main.testInlinedSumArray]
+          Type: 324 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd03de5"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 214 EventRootType Probe[main.testInt16Array]
+          Type: 227 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 215 EventRootType Probe[main.testInt32Array]
+          Type: 228 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 216 EventRootType Probe[main.testInt64Array]
+          Type: 229 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 213 EventRootType Probe[main.testInt8Array]
+          Type: 226 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 212 EventRootType Probe[main.testIntArray]
+          Type: 225 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 251 EventRootType Probe[main.testInterface]
+          Type: 264 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd040aa", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 278 EventRootType Probe[main.testLinkedList]
+          Type: 291 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd063c0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 258 EventRootType Probe[main.testMapArrayToArray]
+          Type: 271 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd04660", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 264 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd04720", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 262 EventRootType Probe[main.testMapIntToInt]
+          Type: 275 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 273 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd04840", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 272 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 263 EventRootType Probe[main.testMapMassive]
+          Type: 276 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd04700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 271 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd04800", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 270 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 256 EventRootType Probe[main.testMapStringToInt]
+          Type: 269 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd04620", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 257 EventRootType Probe[main.testMapStringToSlice]
+          Type: 270 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd04640", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 255 EventRootType Probe[main.testMapStringToStruct]
+          Type: 268 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd04600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 265 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 278 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd04740", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 268 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 269 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 266 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 279 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd04760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 267 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd04780", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 301 EventRootType Probe[main.testMassiveString]
+          Type: 314 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd07020", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 275 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 283 EventRootType Probe[main.testNilPointer]
+          Type: 296 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd06560", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 293 EventRootType Probe[main.testNilSlice]
+          Type: 306 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 290 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 292 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 300 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd07000", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 279 EventRootType Probe[main.testPointerLoop]
+          Type: 292 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 261 EventRootType Probe[main.testPointerToMap]
+          Type: 274 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 277 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 209 EventRootType Probe[main.testRuneArray]
+          Type: 222 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 228 EventRootType Probe[main.testSingleBool]
+          Type: 241 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 226 EventRootType Probe[main.testSingleByte]
+          Type: 239 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 239 EventRootType Probe[main.testSingleFloat32]
+          Type: 252 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03100", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 240 EventRootType Probe[main.testSingleFloat64]
+          Type: 253 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03120", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 229 EventRootType Probe[main.testSingleInt]
+          Type: 242 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 231 EventRootType Probe[main.testSingleInt16]
+          Type: 244 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 232 EventRootType Probe[main.testSingleInt32]
+          Type: 245 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 233 EventRootType Probe[main.testSingleInt64]
+          Type: 246 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 230 EventRootType Probe[main.testSingleInt8]
+          Type: 243 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 227 EventRootType Probe[main.testSingleRune]
+          Type: 240 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 296 EventRootType Probe[main.testSingleString]
+          Type: 309 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 234 EventRootType Probe[main.testSingleUint]
+          Type: 247 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03060", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 236 EventRootType Probe[main.testSingleUint16]
+          Type: 249 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 237 EventRootType Probe[main.testSingleUint32]
+          Type: 250 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 238 EventRootType Probe[main.testSingleUint64]
+          Type: 251 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 235 EventRootType Probe[main.testSingleUint8]
+          Type: 248 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 287 EventRootType Probe[main.testSliceOfSlices]
+          Type: 300 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 259 EventRootType Probe[main.testSmallMap]
+          Type: 272 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd04680", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 210 EventRootType Probe[main.testStringArray]
+          Type: 223 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 282 EventRootType Probe[main.testStringPointer]
+          Type: 295 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd06520", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 291 EventRootType Probe[main.testStringSlice]
+          Type: 304 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 304 EventRootType Probe[main.testStruct]
+          Type: 317 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 288 EventRootType Probe[main.testStructSlice]
+          Type: 301 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 254 EventRootType Probe[main.testStructWithMap]
+          Type: 267 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 297 EventRootType Probe[main.testThreeStrings]
+          Type: 310 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 298 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 299 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 241 EventRootType Probe[main.testTypeAlias]
+          Type: 254 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd03140", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 219 EventRootType Probe[main.testUint16Array]
+          Type: 232 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 220 EventRootType Probe[main.testUint32Array]
+          Type: 233 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 221 EventRootType Probe[main.testUint64Array]
+          Type: 234 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 218 EventRootType Probe[main.testUint8Array]
+          Type: 231 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 217 EventRootType Probe[main.testUintArray]
+          Type: 230 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 281 EventRootType Probe[main.testUintPointer]
+          Type: 294 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd06440", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 285 EventRootType Probe[main.testUintSlice]
+          Type: 298 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 302 EventRootType Probe[main.testUnitializedString]
+          Type: 315 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 280 EventRootType Probe[main.testUnsafePointer]
+          Type: 293 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd06400", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 225 EventRootType Probe[main.testVeryLargeArray]
+          Type: 238 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 294 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 307 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 188 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 187 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 189 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3673,7 +3673,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 62 GoHMapBucketType bucket<int,int>
-      BucketsType: 178 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: PointerType
       ID: 61
       Name: '*bucket<int,int>'
@@ -3773,7 +3773,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 179 GoSliceDataType []*runtime.bmap.array
+      Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 71
       Name: '**runtime.bmap'
@@ -3841,7 +3841,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 181 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: PointerType
       ID: 77
       Name: '*bucket<string,main.nestedStruct>'
@@ -3938,7 +3938,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 86 GoHMapBucketType bucket<string,int>
-      BucketsType: 182 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
     - __kind: PointerType
       ID: 85
       Name: '*bucket<string,int>'
@@ -4008,7 +4008,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 91 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: PointerType
       ID: 90
       Name: '*bucket<string,[]string>'
@@ -4056,7 +4056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 197 GoSliceDataType []string.array
     - __kind: GoMapType
       ID: 94
       Name: map[[4]string][2]int
@@ -4102,7 +4102,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 186 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: PointerType
       ID: 97
       Name: '*bucket<[4]string,[2]int>'
@@ -4209,7 +4209,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 187 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,[]main.structWithMap>'
@@ -4257,7 +4257,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 188 GoSliceDataType []main.structWithMap.array
+      Data: 201 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 111
       Name: '*main.structWithMap'
@@ -4310,7 +4310,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 116 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 190 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: PointerType
       ID: 115
       Name: '*bucket<bool,main.node>'
@@ -4414,7 +4414,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 125 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 191 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
     - __kind: PointerType
       ID: 124
       Name: '*bucket<int,uint8>'
@@ -4491,7 +4491,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 192 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: PointerType
       ID: 130
       Name: '*bucket<uint8,uint8>'
@@ -4568,7 +4568,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 193 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<uint8,[4]int>'
@@ -4654,7 +4654,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 194 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: PointerType
       ID: 143
       Name: '*bucket<[4]int,uint8>'
@@ -4731,7 +4731,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 195 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: PointerType
       ID: 149
       Name: '*bucket<[4]int,[4]int>'
@@ -4814,7 +4814,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 196 GoSliceDataType main.t.array
+      Data: 209 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 158
       Name: '**main.t'
@@ -4836,7 +4836,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 198 GoSliceDataType []uint.array
+      Data: 211 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
       ID: 160
       Name: '[][]uint'
@@ -4852,7 +4852,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 200 GoSliceDataType [][]uint.array
+      Data: 213 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 161
       Name: '*[]uint'
@@ -4873,7 +4873,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 202 GoSliceDataType []main.structWithNoStrings.array
+      Data: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 163
       Name: '*main.structWithNoStrings'
@@ -4907,7 +4907,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 204 GoSliceDataType []bool.array
+      Data: 217 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]uint16'
@@ -4924,7 +4924,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 206 GoSliceDataType []uint16.array
+      Data: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 167
       Name: '*uint16'
@@ -4991,177 +4991,266 @@ Types:
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 174
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 359904
+      GoKind: 22
+      Pointee: 66 BaseType uintptr
+    - __kind: PointerType
+      ID: 175
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 359520
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 176
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 359584
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 177
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 527616
+      GoKind: 15
+    - __kind: BaseType
+      ID: 178
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 527680
+      GoKind: 16
+    - __kind: PointerType
+      ID: 179
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 360160
+      GoKind: 22
+      Pointee: 31 BaseType float64
+    - __kind: PointerType
+      ID: 180
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 359648
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 181
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 359776
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 182
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 359712
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 183
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 359392
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 184
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 359264
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 185
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 359136
+      GoKind: 22
+      Pointee: 56 GoInterfaceType error
+    - __kind: PointerType
+      ID: 186
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 360096
+      GoKind: 22
+      Pointee: 30 BaseType float32
+    - __kind: GoStringDataType
+      ID: 187
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 175
+      ID: 188
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 187 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 189
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 177
+      ID: 190
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 189 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 192
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 180
+      ID: 193
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*runtime.bmap.array
+      Pointee: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 194
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 195
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 197
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 185
+      ID: 198
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 197 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 199
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 200
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 201
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 57 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 189
+      ID: 202
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []main.structWithMap.array
+      Pointee: 201 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 203
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 204
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 205
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 206
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 207
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 208
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 209
       Name: main.t.array
       ByteSize: 2048
       Element: 156 PointerType *main.t
     - __kind: PointerType
-      ID: 197
+      ID: 210
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType main.t.array
+      Pointee: 209 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 211
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 199
+      ID: 212
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uint.array
+      Pointee: 211 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 213
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 201
+      ID: 214
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType [][]uint.array
+      Pointee: 213 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 215
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 216
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 217
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 205
+      ID: 218
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []bool.array
+      Pointee: 217 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 219
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 207
+      ID: 220
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []uint16.array
+      Pointee: 219 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 208
+      ID: 221
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5176,7 +5265,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 209
+      ID: 222
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5191,7 +5280,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 223
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5206,7 +5295,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 211
+      ID: 224
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5221,7 +5310,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 212
+      ID: 225
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5236,7 +5325,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 213
+      ID: 226
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5251,7 +5340,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 214
+      ID: 227
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5266,7 +5355,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 215
+      ID: 228
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5281,7 +5370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 229
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5296,7 +5385,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 230
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5311,7 +5400,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 218
+      ID: 231
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5326,7 +5415,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 219
+      ID: 232
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5341,7 +5430,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 220
+      ID: 233
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5356,7 +5445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 221
+      ID: 234
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5371,7 +5460,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 235
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5386,7 +5475,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 223
+      ID: 236
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5401,7 +5490,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 224
+      ID: 237
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5416,7 +5505,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 225
+      ID: 238
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5431,7 +5520,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 226
+      ID: 239
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5446,7 +5535,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 227
+      ID: 240
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5461,7 +5550,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 228
+      ID: 241
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5476,7 +5565,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 229
+      ID: 242
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5491,7 +5580,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 230
+      ID: 243
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5506,7 +5595,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 231
+      ID: 244
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5521,7 +5610,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 245
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5536,7 +5625,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 233
+      ID: 246
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5551,7 +5640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 247
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5566,7 +5655,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 235
+      ID: 248
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5581,7 +5670,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 236
+      ID: 249
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5596,7 +5685,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 237
+      ID: 250
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5611,7 +5700,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 238
+      ID: 251
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5626,7 +5715,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 239
+      ID: 252
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5641,7 +5730,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 240
+      ID: 253
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5656,7 +5745,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 254
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5671,7 +5760,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 242
+      ID: 255
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5686,7 +5775,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 243
+      ID: 256
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5701,7 +5790,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 244
+      ID: 257
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5716,7 +5805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 245
+      ID: 258
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5731,7 +5820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 246
+      ID: 259
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5755,7 +5844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 247
+      ID: 260
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5770,10 +5859,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 248
+      ID: 261
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 249
+      ID: 262
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5788,7 +5877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 250
+      ID: 263
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5803,7 +5892,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 251
+      ID: 264
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5818,7 +5907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 265
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5833,7 +5922,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 253
+      ID: 266
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5848,7 +5937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 267
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5863,7 +5952,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 255
+      ID: 268
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5878,7 +5967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 269
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5893,7 +5982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 257
+      ID: 270
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5908,7 +5997,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 258
+      ID: 271
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5923,7 +6012,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 259
+      ID: 272
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5938,7 +6027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 273
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5953,7 +6042,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 274
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5968,7 +6057,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 262
+      ID: 275
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5983,7 +6072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 263
+      ID: 276
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5998,7 +6087,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 264
+      ID: 277
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6013,7 +6102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 278
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6028,7 +6117,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 279
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6043,7 +6132,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 280
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6058,7 +6147,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 281
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6073,7 +6162,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 282
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6088,7 +6177,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 283
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6103,7 +6192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 284
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6118,7 +6207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 272
+      ID: 285
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6133,7 +6222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 273
+      ID: 286
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6148,7 +6237,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 287
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6181,7 +6270,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 275
+      ID: 288
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6232,7 +6321,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 276
+      ID: 289
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6247,7 +6336,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 277
+      ID: 290
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6262,7 +6351,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 291
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6277,7 +6366,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 292
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6292,7 +6381,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 293
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6307,7 +6396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 294
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6322,7 +6411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 295
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6337,7 +6426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 296
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6361,7 +6450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 297
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6376,7 +6465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 298
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6391,7 +6480,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 286
+      ID: 299
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6406,7 +6495,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 287
+      ID: 300
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6421,7 +6510,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 288
+      ID: 301
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6445,7 +6534,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 302
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6469,7 +6558,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 303
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6493,7 +6582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 304
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6508,7 +6597,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 292
+      ID: 305
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6541,7 +6630,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 306
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6556,7 +6645,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 294
+      ID: 307
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6571,10 +6660,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 295
+      ID: 308
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 296
+      ID: 309
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6589,7 +6678,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 310
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6622,7 +6711,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 311
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6637,7 +6726,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 299
+      ID: 312
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6652,7 +6741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 313
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6667,7 +6756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 314
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6682,7 +6771,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 302
+      ID: 315
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6697,7 +6786,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 316
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6712,7 +6801,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 304
+      ID: 317
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6727,7 +6816,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 305
+      ID: 318
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6742,7 +6831,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 306
+      ID: 319
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6757,16 +6846,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 320
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 308
+      ID: 321
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 309
+      ID: 322
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 310
+      ID: 323
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6781,7 +6870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 324
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6795,5 +6884,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 311
+MaxTypeID: 324
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -6886,3 +6886,4 @@ Types:
                   ByteSize: 40
 MaxTypeID: 324
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x1752740", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 315 EventRootType Probe[main.stackC]
+          Type: 295 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd06f2a", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 272 EventRootType Probe[main.testAny]
+          Type: 252 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xd0410a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 242 EventRootType Probe[main.testArrayOfArrays]
+          Type: 222 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xd02b40", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 224 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xd02b80", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 280 EventRootType Probe[main.testArrayOfMaps]
+          Type: 260 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xd046a0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 243 EventRootType Probe[main.testArrayOfStrings]
+          Type: 223 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xd02b60", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 262 EventRootType Probe[main.testBigStruct]
+          Type: 242 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xd032a0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 231 EventRootType Probe[main.testBoolArray]
+          Type: 211 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xd029e0", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 228 EventRootType Probe[main.testByteArray]
+          Type: 208 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xd02980", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 296 EventRootType Probe[main.testChannel]
+          Type: 276 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd061e0", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 294 EventRootType Probe[main.testCombinedByte]
+          Type: 274 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xd05e00", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 304 EventRootType Probe[main.testCycle]
+          Type: 284 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd065a0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 306 EventRootType Probe[main.testEmptySlice]
+          Type: 286 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd06ae0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 309 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 289 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd06b40", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 323 EventRootType Probe[main.testEmptyString]
+          Type: 303 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd07060", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 325 EventRootType Probe[main.testEmptyStruct]
+          Type: 305 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd07460", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 273 EventRootType Probe[main.testError]
+          Type: 253 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xd04180", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 264 EventRootType Probe[main.testEsotericHeap]
+          Type: 244 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xd0364a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 263 EventRootType Probe[main.testEsotericStack]
+          Type: 243 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xd0352e", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 269 EventRootType Probe[main.testFrameless]
+          Type: 249 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xd03da0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 270 EventRootType Probe[main.testFramelessArray]
+          Type: 250 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xd03dc4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 265 EventRootType Probe[main.testInlinedBA]
+          Type: 245 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xd03a8a", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 266 EventRootType Probe[main.testInlinedBB]
+          Type: 246 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xd03b2e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 267 EventRootType Probe[main.testInlinedBBA]
+          Type: 247 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xd03c0a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 327 EventRootType Probe[main.testInlinedBBB]
+          Type: 307 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd03b86", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 268 EventRootType Probe[main.testInlinedBC]
+          Type: 248 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xd03c8e", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 328 EventRootType Probe[main.testInlinedBCA]
+          Type: 308 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd03c93", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 329 EventRootType Probe[main.testInlinedBCB]
+          Type: 309 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd03d46", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 326 EventRootType Probe[main.testInlinedPrint]
+          Type: 306 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd038ea"
               Frameless: false
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 330 EventRootType Probe[main.testInlinedSq]
+          Type: 310 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd03da1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 331 EventRootType Probe[main.testInlinedSumArray]
+          Type: 311 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd03de5"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 234 EventRootType Probe[main.testInt16Array]
+          Type: 214 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xd02a40", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 235 EventRootType Probe[main.testInt32Array]
+          Type: 215 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xd02a60", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 236 EventRootType Probe[main.testInt64Array]
+          Type: 216 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xd02a80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 233 EventRootType Probe[main.testInt8Array]
+          Type: 213 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xd02a20", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 232 EventRootType Probe[main.testIntArray]
+          Type: 212 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xd02a00", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 271 EventRootType Probe[main.testInterface]
+          Type: 251 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xd040aa", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 298 EventRootType Probe[main.testLinkedList]
+          Type: 278 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd063c0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 278 EventRootType Probe[main.testMapArrayToArray]
+          Type: 258 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xd04660", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 284 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 264 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xd04720", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 282 EventRootType Probe[main.testMapIntToInt]
+          Type: 262 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xd046e0", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 293 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 273 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xd04840", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 292 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 272 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xd04820", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 283 EventRootType Probe[main.testMapMassive]
+          Type: 263 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xd04700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 291 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 271 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xd04800", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 290 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 270 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xd047e0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 276 EventRootType Probe[main.testMapStringToInt]
+          Type: 256 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xd04620", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 277 EventRootType Probe[main.testMapStringToSlice]
+          Type: 257 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xd04640", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 275 EventRootType Probe[main.testMapStringToStruct]
+          Type: 255 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xd04600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 285 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 265 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xd04740", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 268 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xd047a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 289 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 269 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xd047c0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 286 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 266 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xd04760", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 287 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 267 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xd04780", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 321 EventRootType Probe[main.testMassiveString]
+          Type: 301 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd07020", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 295 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 275 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd05fc0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 303 EventRootType Probe[main.testNilPointer]
+          Type: 283 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd06560", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 313 EventRootType Probe[main.testNilSlice]
+          Type: 293 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd06bc0", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 310 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 290 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd06b60", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 312 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 292 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd06ba0", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 320 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 300 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd07000", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 299 EventRootType Probe[main.testPointerLoop]
+          Type: 279 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd063e0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 281 EventRootType Probe[main.testPointerToMap]
+          Type: 261 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xd046c0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 297 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 277 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd063a0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 229 EventRootType Probe[main.testRuneArray]
+          Type: 209 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xd029a0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 248 EventRootType Probe[main.testSingleBool]
+          Type: 228 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xd02fa0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 246 EventRootType Probe[main.testSingleByte]
+          Type: 226 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xd02f60", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 259 EventRootType Probe[main.testSingleFloat32]
+          Type: 239 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xd03100", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 260 EventRootType Probe[main.testSingleFloat64]
+          Type: 240 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xd03120", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 249 EventRootType Probe[main.testSingleInt]
+          Type: 229 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xd02fc0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 251 EventRootType Probe[main.testSingleInt16]
+          Type: 231 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xd03000", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 252 EventRootType Probe[main.testSingleInt32]
+          Type: 232 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xd03020", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 253 EventRootType Probe[main.testSingleInt64]
+          Type: 233 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xd03040", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 250 EventRootType Probe[main.testSingleInt8]
+          Type: 230 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xd02fe0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 247 EventRootType Probe[main.testSingleRune]
+          Type: 227 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xd02f80", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 316 EventRootType Probe[main.testSingleString]
+          Type: 296 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 254 EventRootType Probe[main.testSingleUint]
+          Type: 234 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xd03060", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 256 EventRootType Probe[main.testSingleUint16]
+          Type: 236 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xd030a0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 257 EventRootType Probe[main.testSingleUint32]
+          Type: 237 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xd030c0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 258 EventRootType Probe[main.testSingleUint64]
+          Type: 238 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xd030e0", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 255 EventRootType Probe[main.testSingleUint8]
+          Type: 235 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xd03080", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 307 EventRootType Probe[main.testSliceOfSlices]
+          Type: 287 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd06b00", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 279 EventRootType Probe[main.testSmallMap]
+          Type: 259 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xd04680", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 230 EventRootType Probe[main.testStringArray]
+          Type: 210 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xd029c0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 302 EventRootType Probe[main.testStringPointer]
+          Type: 282 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd06520", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 311 EventRootType Probe[main.testStringSlice]
+          Type: 291 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd06b80", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 324 EventRootType Probe[main.testStruct]
+          Type: 304 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd072e0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 308 EventRootType Probe[main.testStructSlice]
+          Type: 288 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd06b20", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 274 EventRootType Probe[main.testStructWithMap]
+          Type: 254 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xd045e0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 317 EventRootType Probe[main.testThreeStrings]
+          Type: 297 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd06fa0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 318 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 298 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd06fc0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 319 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 299 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd06fe0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 261 EventRootType Probe[main.testTypeAlias]
+          Type: 241 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xd03140", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 239 EventRootType Probe[main.testUint16Array]
+          Type: 219 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xd02ae0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 240 EventRootType Probe[main.testUint32Array]
+          Type: 220 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xd02b00", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 241 EventRootType Probe[main.testUint64Array]
+          Type: 221 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xd02b20", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 238 EventRootType Probe[main.testUint8Array]
+          Type: 218 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xd02ac0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 237 EventRootType Probe[main.testUintArray]
+          Type: 217 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xd02aa0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 301 EventRootType Probe[main.testUintPointer]
+          Type: 281 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd06440", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 305 EventRootType Probe[main.testUintSlice]
+          Type: 285 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd06ac0", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 322 EventRootType Probe[main.testUnitializedString]
+          Type: 302 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd07040", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 300 EventRootType Probe[main.testUnsafePointer]
+          Type: 280 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd06400", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 245 EventRootType Probe[main.testVeryLargeArray]
+          Type: 225 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xd02be0", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 314 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 294 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd06be0", Frameless: true}]
           Condition: null
 Subprograms:
@@ -1911,7 +1911,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
           Locations:
             - Range: 0xd03520..0xd03573
               Pieces:
@@ -1981,7 +1981,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 63 PointerType *main.esotericHeap
+          Type: 44 PointerType *main.esotericHeap
           Locations:
             - Range: 0xd03640..0xd0366d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 55 GoInterfaceType main.behavior
           Locations:
             - Range: 0xd040a0..0xd040bf
               Pieces:
@@ -2133,7 +2133,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0xd04100..0xd04129
               Pieces:
@@ -2160,7 +2160,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 75 GoInterfaceType error
+          Type: 56 GoInterfaceType error
           Locations:
             - Range: 0xd04180..0xd04181
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 76 StructureType main.structWithMap
+          Type: 57 StructureType main.structWithMap
           Locations:
             - Range: 0xd045e0..0xd045e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 92 GoMapType map[string]main.nestedStruct
+          Type: 74 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xd04600..0xd04601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[string]int
+          Type: 82 GoMapType map[string]int
           Locations:
             - Range: 0xd04620..0xd04621
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 105 GoMapType map[string][]string
+          Type: 87 GoMapType map[string][]string
           Locations:
             - Range: 0xd04640..0xd04641
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
+          Type: 94 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xd04660..0xd04661
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[string]int
+          Type: 82 GoMapType map[string]int
           Locations:
             - Range: 0xd04680..0xd04681
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 ArrayType [2]map[string]int
+          Type: 102 ArrayType [2]map[string]int
           Locations:
             - Range: 0xd046a0..0xd046a1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 PointerType *map[string]int
+          Type: 103 PointerType *map[string]int
           Locations:
             - Range: 0xd046c0..0xd046c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 77 GoMapType map[int]int
+          Type: 58 GoMapType map[int]int
           Locations:
             - Range: 0xd046e0..0xd046e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 122 GoMapType map[string][]main.structWithMap
+          Type: 104 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04700..0xd04701
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[string][]main.structWithMap
+          Type: 104 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xd04720..0xd04721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 130 GoMapType map[bool]main.node
+          Type: 112 GoMapType map[bool]main.node
           Locations:
             - Range: 0xd04740..0xd04741
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 139 GoMapType map[int]uint8
+          Type: 121 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04760..0xd04761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 139 GoMapType map[int]uint8
+          Type: 121 GoMapType map[int]uint8
           Locations:
             - Range: 0xd04780..0xd04781
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047a0..0xd047a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047c0..0xd047c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xd047e0..0xd047e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[uint8][4]int
+          Type: 133 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xd04800..0xd04801
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 158 GoMapType map[[4]int]uint8
+          Type: 140 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xd04820..0xd04821
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[[4]int][4]int
+          Type: 146 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xd04840..0xd04841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 169 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
             - Range: 0xd061e0..0xd061e1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 170 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xd063a0..0xd063a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 137 StructureType main.node
+          Type: 119 StructureType main.node
           Locations:
             - Range: 0xd063c0..0xd063c1
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 138 PointerType *main.node
+          Type: 120 PointerType *main.node
           Locations:
             - Range: 0xd063e0..0xd063e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2538,7 +2538,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xd06400..0xd06401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2550,7 +2550,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 PointerType *uint
+          Type: 154 PointerType *uint
           Locations:
             - Range: 0xd06440..0xd06441
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2574,7 +2574,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 173 PointerType *bool
+          Type: 155 PointerType *bool
           Locations:
             - Range: 0xd06560..0xd06561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 174 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
             - Range: 0xd065a0..0xd065a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ac0..0xd06ac1
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06ae0..0xd06ae1
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 178 GoSliceHeaderType [][]uint
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd06b00..0xd06b01
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b20..0xd06b21
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b40..0xd06b41
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd06b60..0xd06b61
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 111 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
           Locations:
             - Range: 0xd06b80..0xd06b81
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 183 GoSliceHeaderType []bool
+          Type: 165 GoSliceHeaderType []bool
           Locations:
             - Range: 0xd06ba0..0xd06ba1
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 184 GoSliceHeaderType []uint16
+          Type: 166 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xd06bc0..0xd06bc1
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd06be0..0xd06be1
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 186 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
             - Range: 0xd06fc0..0xd06fdf
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 187 PointerType *main.threeStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xd06fe0..0xd06fe1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 188 PointerType *main.oneStringStruct
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xd07000..0xd07001
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 190 StructureType main.aStruct
+          Type: 172 StructureType main.aStruct
           Locations:
             - Range: 0xd072e0..0xd07303
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 191 StructureType main.emptyStruct
+          Type: 173 StructureType main.emptyStruct
           Locations: [{Range: 0xd07460..0xd07461, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 193 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 192 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 194 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3383,215 +3383,21 @@ Types:
       ByteSize: 16
       GoRuntimeType: 973760
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 38
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 39 PointerType *internal/abi.ITab
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 39
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 383328
-      GoKind: 22
-      Pointee: 40 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 40
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.627168e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 41 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 54 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 55 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 41
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.054304e+06
-      GoKind: 22
-      Pointee: 42 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 42
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.437216e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 43 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 50 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 51 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 43
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 1.98112e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 44 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 44 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 45 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 4 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 4 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 46 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 9 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 44
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 527552
-      GoKind: 12
-    - __kind: BaseType
-      ID: 45
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 530560
-      GoKind: 8
-    - __kind: BaseType
-      ID: 46
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 759232
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 47
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 773248
-      GoKind: 19
-    - __kind: BaseType
-      ID: 48
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 530624
-      GoKind: 5
-    - __kind: BaseType
-      ID: 49
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 530688
-      GoKind: 5
-    - __kind: StructureType
-      ID: 50
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.828672e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 9 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 51
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 468384
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 52 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 196 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 52
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 383264
-      GoKind: 22
-      Pointee: 53 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 53
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.296096e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: PointerType
-      ID: 54
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.054752e+06
-      GoKind: 22
-      Pointee: 43 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 55
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 618592
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 44 BaseType uintptr
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 56
+      ID: 38
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 527936
       GoKind: 26
     - __kind: StructureType
-      ID: 57
+      ID: 39
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.81888e+06
@@ -3605,65 +3411,65 @@ Types:
           Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 58 GoChannelType chan struct {}
+          Type: 40 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 61 GoInterfaceType main.something
+          Type: 42 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 62 GoSubroutineType func()
+          Type: 43 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 58
+      ID: 40
       Name: chan struct {}
       GoRuntimeType: 538048
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 59
+      ID: 41
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 772384
       GoKind: 20
-      UnderlyingStructure: 60 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 60
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 54 PointerType *internal/abi.Type
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 42
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 973504
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 62
+      ID: 43
       Name: func()
       ByteSize: 8
       GoRuntimeType: 441824
       GoKind: 19
     - __kind: PointerType
-      ID: 63
+      ID: 44
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 354144
       GoKind: 22
-      Pointee: 64 StructureType main.esotericHeap
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 64
+      ID: 45
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.692416e+06
@@ -3671,21 +3477,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 47 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 50 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 73 StructureType sync/atomic.Int32
+          Type: 54 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 65
+      ID: 46
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271296e+06
@@ -3698,7 +3504,7 @@ Types:
           Offset: 4
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 66
+      ID: 47
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272416e+06
@@ -3706,12 +3512,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Uint32
+          Type: 48 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 67
+      ID: 48
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.272896e+06
@@ -3719,18 +3525,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 49
       Name: sync/atomic.noCopy
       GoRuntimeType: 940608
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 69
+      ID: 50
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411104e+06
@@ -3738,21 +3544,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 70 StructureType sync.noCopy
+          Type: 51 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 71 StructureType sync/atomic.Uint64
+          Type: 52 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 51
       Name: sync.noCopy
       GoRuntimeType: 940512
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 52
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.411488e+06
@@ -3760,21 +3566,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 72 StructureType sync/atomic.align64
+          Type: 53 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 72
+      ID: 53
       Name: sync/atomic.align64
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 73
+      ID: 54
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272736e+06
@@ -3782,26 +3588,38 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 55
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973376
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 56
       Name: error
       ByteSize: 16
       GoRuntimeType: 977856
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 76
+      ID: 57
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.092448e+06
@@ -3809,21 +3627,21 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 77 GoMapType map[int]int
+          Type: 58 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 77
+      ID: 58
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872896
       GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<int,int>
+      HeaderType: 60 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 78
+      ID: 59
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 79 GoHMapHeaderType hash<int,int>
+      Pointee: 60 GoHMapHeaderType hash<int,int>
     - __kind: GoHMapHeaderType
-      ID: 79
+      ID: 60
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -3844,44 +3662,44 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 81 GoHMapBucketType bucket<int,int>
-      BucketsType: 198 GoSliceDataType []bucket<int,int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<int,int>
+      BucketsType: 178 GoSliceDataType []bucket<int,int>.array
     - __kind: PointerType
-      ID: 80
+      ID: 61
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 81 GoHMapBucketType bucket<int,int>
+      Pointee: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoHMapBucketType
-      ID: 81
+      ID: 62
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 83 ArrayType []key<int>
+          Type: 64 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 84 ArrayType []val<int>
+          Type: 65 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
       KeyType: 1 BaseType int
       ValueType: 1 BaseType int
     - __kind: ArrayType
-      ID: 82
+      ID: 63
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615424
@@ -3890,28 +3708,34 @@ Types:
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 83
+      ID: 64
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 1 BaseType int
     - __kind: ArrayType
-      ID: 84
+      ID: 65
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 1 BaseType int
+    - __kind: BaseType
+      ID: 66
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527552
+      GoKind: 12
     - __kind: PointerType
-      ID: 85
+      ID: 67
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363104
       GoKind: 22
-      Pointee: 86 StructureType runtime.mapextra
+      Pointee: 68 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 86
+      ID: 68
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417056e+06
@@ -3919,22 +3743,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 87 PointerType *[]*runtime.bmap
+          Type: 69 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 87 PointerType *[]*runtime.bmap
+          Type: 69 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 90 PointerType *runtime.bmap
+          Type: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451680
       GoKind: 22
-      Pointee: 88 GoSliceHeaderType []*runtime.bmap
+      Pointee: 70 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 70
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451616
@@ -3942,28 +3766,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType **runtime.bmap
+          Type: 71 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 199 GoSliceDataType []*runtime.bmap.array
+      Data: 179 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 89
+      ID: 71
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 90 PointerType *runtime.bmap
+      Pointee: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.100896e+06
       GoKind: 22
-      Pointee: 91 StructureType runtime.bmap
+      Pointee: 73 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.100768e+06
@@ -3971,21 +3795,21 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
     - __kind: GoMapType
-      ID: 92
+      ID: 74
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoHMapHeaderType
-      ID: 94
+      ID: 76
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -4006,58 +3830,58 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 96 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 201 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 181 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: PointerType
-      ID: 95
+      ID: 77
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoHMapBucketType
-      ID: 96
+      ID: 78
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 98 ArrayType []val<main.nestedStruct>
+          Type: 80 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 99 StructureType main.nestedStruct
+      ValueType: 81 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 97
+      ID: 79
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 98
+      ID: 80
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 99 StructureType main.nestedStruct
+      Element: 81 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 99
+      ID: 81
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270016e+06
@@ -4070,19 +3894,19 @@ Types:
           Offset: 8
           Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 100
+      ID: 82
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 102 GoHMapHeaderType hash<string,int>
+      HeaderType: 84 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 101
+      ID: 83
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 102 GoHMapHeaderType hash<string,int>
+      Pointee: 84 GoHMapHeaderType hash<string,int>
     - __kind: GoHMapHeaderType
-      ID: 102
+      ID: 84
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -4103,56 +3927,56 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 104 GoHMapBucketType bucket<string,int>
-      BucketsType: 202 GoSliceDataType []bucket<string,int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 86 GoHMapBucketType bucket<string,int>
+      BucketsType: 182 GoSliceDataType []bucket<string,int>.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 104 GoHMapBucketType bucket<string,int>
+      Pointee: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoHMapBucketType
-      ID: 104
+      ID: 86
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 84 ArrayType []val<int>
+          Type: 65 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
       KeyType: 8 GoStringHeaderType string
       ValueType: 1 BaseType int
     - __kind: GoMapType
-      ID: 105
+      ID: 87
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 107 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoHMapHeaderType hash<string,[]string>
+      Pointee: 89 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 107
+      ID: 89
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -4173,51 +3997,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 109 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 203 GoSliceDataType []bucket<string,[]string>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 109 GoHMapBucketType bucket<string,[]string>
+      Pointee: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 109
+      ID: 91
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 110 ArrayType []val<[]string>
+          Type: 92 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 111 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 110
+      ID: 92
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 111 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -4232,21 +4056,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 204 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 112
+      ID: 94
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 113
+      ID: 95
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 96
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -4267,51 +4091,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 97 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 97 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 206 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 186 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: PointerType
-      ID: 115
+      ID: 97
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 98
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<[4]string>
+          Type: 99 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 119 ArrayType []val<[2]int>
+          Type: 101 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 115 PointerType *bucket<[4]string,[2]int>
-      KeyType: 118 ArrayType [4]string
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+      KeyType: 100 ArrayType [4]string
       ValueType: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 117
+      ID: 99
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 118 ArrayType [4]string
+      Element: 100 ArrayType [4]string
     - __kind: ArrayType
-      ID: 118
+      ID: 100
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617632
@@ -4320,40 +4144,40 @@ Types:
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 119
+      ID: 101
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 120
+      ID: 102
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 82 GoMapType map[string]int
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 82 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 122
+      ID: 104
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 123
+      ID: 105
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoHMapHeaderType
-      ID: 124
+      ID: 106
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -4374,51 +4198,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 187 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: PointerType
-      ID: 125
+      ID: 107
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoHMapBucketType
-      ID: 126
+      ID: 108
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 127 ArrayType []val<[]main.structWithMap>
+          Type: 109 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 128 GoSliceHeaderType []main.structWithMap
+      ValueType: 110 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 127
+      ID: 109
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 128 GoSliceHeaderType []main.structWithMap
+      Element: 110 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 110
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442720
@@ -4426,35 +4250,35 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *main.structWithMap
+          Type: 111 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 208 GoSliceDataType []main.structWithMap.array
+      Data: 188 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 129
+      ID: 111
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354080
       GoKind: 22
-      Pointee: 76 StructureType main.structWithMap
+      Pointee: 57 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 130
+      ID: 112
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 131
+      ID: 113
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 132 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoHMapHeaderType
-      ID: 132
+      ID: 114
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -4475,58 +4299,58 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 134 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 190 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 134 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoHMapBucketType
-      ID: 134
+      ID: 116
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 135 ArrayType []key<bool>
+          Type: 117 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 136 ArrayType []val<main.node>
+          Type: 118 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
       KeyType: 11 BaseType bool
-      ValueType: 137 StructureType main.node
+      ValueType: 119 StructureType main.node
     - __kind: ArrayType
-      ID: 135
+      ID: 117
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 11 BaseType bool
     - __kind: ArrayType
-      ID: 136
+      ID: 118
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 137 StructureType main.node
+      Element: 119 StructureType main.node
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.269856e+06
@@ -4537,28 +4361,28 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 138 PointerType *main.node
+          Type: 120 PointerType *main.node
     - __kind: PointerType
-      ID: 138
+      ID: 120
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354208
       GoKind: 22
-      Pointee: 137 StructureType main.node
+      Pointee: 119 StructureType main.node
     - __kind: GoMapType
-      ID: 139
+      ID: 121
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 122
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<int,uint8>
+      Pointee: 123 GoHMapHeaderType hash<int,uint8>
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 123
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -4579,63 +4403,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 191 GoSliceDataType []bucket<int,uint8>.array
     - __kind: PointerType
-      ID: 142
+      ID: 124
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<int,uint8>
+      Pointee: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 125
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 83 ArrayType []key<int>
+          Type: 64 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
       KeyType: 1 BaseType int
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 144
+      ID: 126
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 145
+      ID: 127
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 146
+      ID: 128
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
     - __kind: GoHMapHeaderType
-      ID: 147
+      ID: 129
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -4656,63 +4480,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 149 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 192 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: PointerType
-      ID: 148
+      ID: 130
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 149 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoHMapBucketType
-      ID: 149
+      ID: 131
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 132 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
       KeyType: 4 BaseType uint8
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 150
+      ID: 132
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 135
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -4733,51 +4557,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 213 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 193 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 137
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 132 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 156 ArrayType []val<[4]int>
+          Type: 138 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
       KeyType: 4 BaseType uint8
-      ValueType: 157 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
     - __kind: ArrayType
-      ID: 156
+      ID: 138
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 157 ArrayType [4]int
+      Element: 139 ArrayType [4]int
     - __kind: ArrayType
-      ID: 157
+      ID: 139
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617344
@@ -4786,19 +4610,19 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 158
+      ID: 140
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 159
+      ID: 141
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 160 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoHMapHeaderType
-      ID: 160
+      ID: 142
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -4819,63 +4643,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 161 PointerType *bucket<[4]int,uint8>
+          Type: 143 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 161 PointerType *bucket<[4]int,uint8>
+          Type: 143 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 162 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 214 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 194 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: PointerType
-      ID: 161
+      ID: 143
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 162 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoHMapBucketType
-      ID: 162
+      ID: 144
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<[4]int>
+          Type: 145 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 161 PointerType *bucket<[4]int,uint8>
-      KeyType: 157 ArrayType [4]int
+          Type: 143 PointerType *bucket<[4]int,uint8>
+      KeyType: 139 ArrayType [4]int
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 163
+      ID: 145
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 157 ArrayType [4]int
+      Element: 139 ArrayType [4]int
     - __kind: GoMapType
-      ID: 164
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873856
       GoKind: 21
-      HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 166 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoHMapHeaderType
-      ID: 166
+      ID: 148
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -4896,55 +4720,55 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 167 PointerType *bucket<[4]int,[4]int>
+          Type: 149 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 167 PointerType *bucket<[4]int,[4]int>
+          Type: 149 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 168 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 215 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 195 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: PointerType
-      ID: 167
+      ID: 149
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoHMapBucketType
-      ID: 168
+      ID: 150
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<[4]int>
+          Type: 145 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 156 ArrayType []val<[4]int>
+          Type: 138 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 167 PointerType *bucket<[4]int,[4]int>
-      KeyType: 157 ArrayType [4]int
-      ValueType: 157 ArrayType [4]int
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 169
+      ID: 151
       Name: chan bool
       GoRuntimeType: 539136
       GoKind: 18
     - __kind: PointerType
-      ID: 170
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 171
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -4956,48 +4780,48 @@ Types:
           Offset: 8
           Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 172
+      ID: 154
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 359840
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 173
+      ID: 155
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 360224
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 174
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType **main.t
+          Type: 158 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 216 GoSliceDataType main.t.array
+      Data: 196 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 174 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449376
@@ -5005,58 +4829,58 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *uint
+          Type: 154 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 218 GoSliceDataType []uint.array
+      Data: 198 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 220 GoSliceDataType [][]uint.array
+      Data: 200 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 177 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 222 GoSliceDataType []main.structWithNoStrings.array
+      Data: 202 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 181
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 182 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 182
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -5068,7 +4892,7 @@ Types:
           Offset: 1
           Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449760
@@ -5076,16 +4900,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *bool
+          Type: 155 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 224 GoSliceDataType []bool.array
+      Data: 204 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448736
@@ -5093,23 +4917,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *uint16
+          Type: 167 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 226 GoSliceDataType []uint16.array
+      Data: 206 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 185
+      ID: 167
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 359456
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 186
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -5124,19 +4948,19 @@ Types:
           Offset: 32
           Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 186 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 188
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 189 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 189
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -5145,7 +4969,7 @@ Types:
           Offset: 0
           Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5161,193 +4985,183 @@ Types:
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 99 StructureType main.nestedStruct
+          Type: 81 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 191
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 192
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 192 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 195
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 53 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 197
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 81 GoHMapBucketType bucket<int,int>
+      Element: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 179
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 90 PointerType *runtime.bmap
+      Element: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 200
+      ID: 180
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*runtime.bmap.array
+      Pointee: 179 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 181
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 182
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 104 GoHMapBucketType bucket<string,int>
+      Element: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 109 GoHMapBucketType bucket<string,[]string>
+      Element: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 184
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 205
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 186
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 187
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 188
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 76 StructureType main.structWithMap
+      Element: 57 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 209
+      ID: 189
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []main.structWithMap.array
+      Pointee: 188 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 190
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 134 GoHMapBucketType bucket<bool,main.node>
+      Element: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 191
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<int,uint8>
+      Element: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 192
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 149 GoHMapBucketType bucket<uint8,uint8>
+      Element: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 193
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 194
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 162 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 195
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 196
       Name: main.t.array
       ByteSize: 2048
-      Element: 174 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: PointerType
-      ID: 217
+      ID: 197
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType main.t.array
+      Pointee: 196 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 198
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 219
+      ID: 199
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 218 GoSliceDataType []uint.array
+      Pointee: 198 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 200
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 177 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 221
+      ID: 201
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType [][]uint.array
+      Pointee: 200 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 202
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 182 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 223
+      ID: 203
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 202 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 204
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 205
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []bool.array
+      Pointee: 204 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 206
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 207
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []uint16.array
+      Pointee: 206 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 228
+      ID: 208
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5362,7 +5176,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 229
+      ID: 209
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5377,7 +5191,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 230
+      ID: 210
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5392,7 +5206,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 231
+      ID: 211
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5407,7 +5221,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 212
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5422,7 +5236,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 233
+      ID: 213
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5437,7 +5251,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 234
+      ID: 214
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5452,7 +5266,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 235
+      ID: 215
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5467,7 +5281,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 236
+      ID: 216
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5482,7 +5296,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 217
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5497,7 +5311,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 238
+      ID: 218
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5512,7 +5326,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 239
+      ID: 219
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5527,7 +5341,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 240
+      ID: 220
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5542,7 +5356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 221
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5557,7 +5371,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 222
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5572,7 +5386,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 243
+      ID: 223
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5587,7 +5401,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 244
+      ID: 224
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5602,7 +5416,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 245
+      ID: 225
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5617,7 +5431,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 246
+      ID: 226
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5632,7 +5446,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 247
+      ID: 227
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5647,7 +5461,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 248
+      ID: 228
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5662,7 +5476,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 249
+      ID: 229
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5677,7 +5491,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 250
+      ID: 230
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5692,7 +5506,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 251
+      ID: 231
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5707,7 +5521,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 252
+      ID: 232
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5722,7 +5536,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 253
+      ID: 233
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5737,7 +5551,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 254
+      ID: 234
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5752,7 +5566,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 255
+      ID: 235
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5767,7 +5581,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 256
+      ID: 236
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5782,7 +5596,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 257
+      ID: 237
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5797,7 +5611,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 258
+      ID: 238
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5812,7 +5626,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 259
+      ID: 239
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5827,7 +5641,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 260
+      ID: 240
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5842,7 +5656,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 241
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5857,7 +5671,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 262
+      ID: 242
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5872,7 +5686,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 263
+      ID: 243
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5880,14 +5694,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 StructureType main.esotericStack
+            Type: 39 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 264
+      ID: 244
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5895,14 +5709,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 63 PointerType *main.esotericHeap
+            Type: 44 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 245
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5917,7 +5731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 246
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5941,7 +5755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 247
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5956,10 +5770,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 248
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 269
+      ID: 249
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5974,7 +5788,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 250
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5989,7 +5803,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 271
+      ID: 251
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5997,14 +5811,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 55 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 252
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6012,14 +5826,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 59 GoEmptyInterfaceType interface {}
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 253
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6027,14 +5841,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType error
+            Type: 56 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 254
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6042,14 +5856,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 76 StructureType main.structWithMap
+            Type: 57 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 255
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6057,14 +5871,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 GoMapType map[string]main.nestedStruct
+            Type: 74 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 256
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6072,14 +5886,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 82 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 257
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6087,14 +5901,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 87 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 258
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6102,14 +5916,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[[4]string][2]int
+            Type: 94 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 259
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6117,14 +5931,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 82 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 260
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6132,14 +5946,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 ArrayType [2]map[string]int
+            Type: 102 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 261
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6147,14 +5961,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 PointerType *map[string]int
+            Type: 103 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 262
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6162,14 +5976,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 77 GoMapType map[int]int
+            Type: 58 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 263
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6177,14 +5991,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[string][]main.structWithMap
+            Type: 104 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 264
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6192,14 +6006,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[string][]main.structWithMap
+            Type: 104 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 265
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6207,14 +6021,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 130 GoMapType map[bool]main.node
+            Type: 112 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 266
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6222,14 +6036,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[int]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 287
+      ID: 267
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6237,14 +6051,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[int]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 288
+      ID: 268
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6252,14 +6066,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 269
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6267,14 +6081,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 270
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6282,14 +6096,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 271
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6297,14 +6111,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 151 GoMapType map[uint8][4]int
+            Type: 133 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 272
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6312,14 +6126,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 158 GoMapType map[[4]int]uint8
+            Type: 140 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 273
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6327,14 +6141,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 294
+      ID: 274
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6367,7 +6181,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 295
+      ID: 275
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6418,7 +6232,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 276
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6426,14 +6240,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 169 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 297
+      ID: 277
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6441,14 +6255,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 278
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6456,14 +6270,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 137 StructureType main.node
+            Type: 119 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 279
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6471,14 +6285,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 138 PointerType *main.node
+            Type: 120 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 280
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6486,14 +6300,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 56 VoidPointerType unsafe.Pointer
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 281
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6501,14 +6315,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 PointerType *uint
+            Type: 154 PointerType *uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 282
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6523,7 +6337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 283
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6531,7 +6345,7 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 173 PointerType *bool
+            Type: 155 PointerType *bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: z}
@@ -6547,7 +6361,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6555,14 +6369,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6570,14 +6384,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 306
+      ID: 286
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6585,14 +6399,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 307
+      ID: 287
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6600,14 +6414,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 178 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 308
+      ID: 288
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6615,7 +6429,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -6631,7 +6445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 289
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6639,7 +6453,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 88, index: 0, name: xs}
@@ -6655,7 +6469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 290
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6663,7 +6477,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 89, index: 0, name: xs}
@@ -6679,7 +6493,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 291
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6687,14 +6501,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 111 GoSliceHeaderType []string
+            Type: 93 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 312
+      ID: 292
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6711,7 +6525,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 183 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 1, name: s}
@@ -6727,7 +6541,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 293
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6735,14 +6549,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 184 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 314
+      ID: 294
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6750,17 +6564,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 315
+      ID: 295
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 316
+      ID: 296
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6775,7 +6589,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
+      ID: 297
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6808,7 +6622,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 298
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6816,14 +6630,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 186 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 319
+      ID: 299
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6831,14 +6645,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 187 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 300
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6846,14 +6660,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 188 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 301
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6868,7 +6682,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
+      ID: 302
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6883,7 +6697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 303
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6898,7 +6712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 324
+      ID: 304
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6906,14 +6720,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 190 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 325
+      ID: 305
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6921,14 +6735,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 191 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 326
+      ID: 306
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6943,16 +6757,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 307
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 328
+      ID: 308
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 329
+      ID: 309
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 330
+      ID: 310
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6967,7 +6781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 311
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6981,5 +6795,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 331
+MaxTypeID: 311
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,11 +8,25 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 87
-          Type: 375 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcd836a", Frameless: false}]
+        - ID: 88
+          Type: 376 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcd83ca", Frameless: false}]
+          Condition: null
+    - id: testAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAny}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 333 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0xcd542a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -26,7 +40,7 @@ Probes:
       events:
         - ID: 15
           Type: 303 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0xcd3e00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3e60", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -40,7 +54,7 @@ Probes:
       events:
         - ID: 17
           Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0xcd3e40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -50,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 52
-          Type: 340 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0xcd5960", Frameless: true}]
+        - ID: 53
+          Type: 341 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0xcd59c0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -68,7 +82,7 @@ Probes:
       events:
         - ID: 16
           Type: 304 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0xcd3e20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3e80", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -82,7 +96,7 @@ Probes:
       events:
         - ID: 35
           Type: 323 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0xcd4560", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd45c0", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -96,7 +110,7 @@ Probes:
       events:
         - ID: 4
           Type: 292 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0xcd3ca0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3d00", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -110,7 +124,7 @@ Probes:
       events:
         - ID: 1
           Type: 289 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0xcd3c40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3ca0", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -120,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 68
-          Type: 356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd7620", Frameless: true}]
+        - ID: 69
+          Type: 357 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd7680", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 66
-          Type: 354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0xcd7240", Frameless: true}]
+        - ID: 67
+          Type: 355 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0xcd72a0", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 76
-          Type: 364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd79e0", Frameless: true}]
+        - ID: 77
+          Type: 365 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 78
-          Type: 366 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcd7f20", Frameless: true}]
+        - ID: 79
+          Type: 367 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcd7f80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 81
-          Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7f80", Frameless: true}]
+        - ID: 82
+          Type: 370 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 95
-          Type: 383 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
+        - ID: 96
+          Type: 384 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 97
-          Type: 385 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcd88a0", Frameless: true}]
+        - ID: 98
+          Type: 386 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcd8900", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +232,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 45
-          Type: 333 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0xcd5600", Frameless: true}]
+        - ID: 46
+          Type: 334 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -236,7 +250,7 @@ Probes:
       events:
         - ID: 37
           Type: 325 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0xcd490a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd496a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -250,7 +264,7 @@ Probes:
       events:
         - ID: 36
           Type: 324 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0xcd47ee", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd484e", Frameless: false}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -264,7 +278,7 @@ Probes:
       events:
         - ID: 42
           Type: 330 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0xcd5060", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -278,7 +292,7 @@ Probes:
       events:
         - ID: 43
           Type: 331 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0xcd5084", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd50e4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -292,7 +306,7 @@ Probes:
       events:
         - ID: 38
           Type: 326 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0xcd4d4a", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd4daa", Frameless: false}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -306,7 +320,7 @@ Probes:
       events:
         - ID: 39
           Type: 327 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0xcd4dee", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd4e4e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -320,7 +334,7 @@ Probes:
       events:
         - ID: 40
           Type: 328 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0xcd4eca", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd4f2a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -332,9 +346,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 99
-          Type: 387 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0xcd4e46", Frameless: false}]
+        - ID: 100
+          Type: 388 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0xcd4ea6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -348,7 +362,7 @@ Probes:
       events:
         - ID: 41
           Type: 329 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0xcd4f4e", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd4fae", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -360,9 +374,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 100
-          Type: 388 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0xcd4f53", Frameless: false}]
+        - ID: 101
+          Type: 389 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0xcd4fb3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -374,9 +388,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 101
-          Type: 389 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0xcd5006", Frameless: false}]
+        - ID: 102
+          Type: 390 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0xcd5066", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -389,18 +403,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 98
-          Type: 386 EventRootType Probe[main.testInlinedPrint]
+        - ID: 99
+          Type: 387 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0xcd4baa"
+            - PC: "0xcd4c0a"
               Frameless: false
-            - PC: "0xcd4c31"
+            - PC: "0xcd4c91"
               Frameless: false
-            - PC: "0xcd4d72"
+            - PC: "0xcd4dd2"
               Frameless: false
-            - PC: "0xcd4dfc"
+            - PC: "0xcd4e5c"
               Frameless: false
-            - PC: "0xcd4ecf"
+            - PC: "0xcd4f2f"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -413,9 +427,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 102
-          Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0xcd5061", Frameless: true}]
+        - ID: 103
+          Type: 391 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0xcd50c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -428,12 +442,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 103
-          Type: 391 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 104
+          Type: 392 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0xcd50a5"
+            - PC: "0xcd5105"
               Frameless: false
-            - PC: "0xcd5145"
+            - PC: "0xcd51a5"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -448,7 +462,7 @@ Probes:
       events:
         - ID: 7
           Type: 295 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0xcd3d00", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3d60", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -462,7 +476,7 @@ Probes:
       events:
         - ID: 8
           Type: 296 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0xcd3d20", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3d80", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -476,7 +490,7 @@ Probes:
       events:
         - ID: 9
           Type: 297 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0xcd3d40", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3da0", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -490,7 +504,7 @@ Probes:
       events:
         - ID: 6
           Type: 294 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0xcd3ce0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3d40", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -504,13 +518,13 @@ Probes:
       events:
         - ID: 5
           Type: 293 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0xcd3cc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3d20", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInterface}
-      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
@@ -518,7 +532,7 @@ Probes:
       events:
         - ID: 44
           Type: 332 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0xcd5373", Frameless: false}]
+          InjectionPoints: [{PC: "0xcd53ca", Frameless: false}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -528,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 70
-          Type: 358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd7800", Frameless: true}]
+        - ID: 71
+          Type: 359 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd7860", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -542,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 50
-          Type: 338 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
+        - ID: 51
+          Type: 339 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0xcd5980", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -556,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 56
-          Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0xcd59e0", Frameless: true}]
+        - ID: 57
+          Type: 345 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -570,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 54
-          Type: 342 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0xcd59a0", Frameless: true}]
+        - ID: 55
+          Type: 343 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0xcd5a00", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -584,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 65
-          Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd5b00", Frameless: true}]
+        - ID: 66
+          Type: 354 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd5b60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -598,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 64
-          Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5ae0", Frameless: true}]
+        - ID: 65
+          Type: 353 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -612,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 55
-          Type: 343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0xcd59c0", Frameless: true}]
+        - ID: 56
+          Type: 344 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -626,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 63
-          Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
+        - ID: 64
+          Type: 352 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0xcd5b20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -640,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 62
-          Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
+        - ID: 63
+          Type: 351 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0xcd5b00", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -654,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 48
-          Type: 336 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0xcd58e0", Frameless: true}]
+        - ID: 49
+          Type: 337 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -668,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 49
-          Type: 337 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
+        - ID: 50
+          Type: 338 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0xcd5960", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -682,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 47
-          Type: 335 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0xcd58c0", Frameless: true}]
+        - ID: 48
+          Type: 336 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -696,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 57
-          Type: 345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0xcd5a00", Frameless: true}]
+        - ID: 58
+          Type: 346 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0xcd5a60", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -710,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 60
-          Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0xcd5a60", Frameless: true}]
+        - ID: 61
+          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -724,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 61
-          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0xcd5a80", Frameless: true}]
+        - ID: 62
+          Type: 350 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0xcd5ae0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -738,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 58
-          Type: 346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
+        - ID: 59
+          Type: 347 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0xcd5a80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -752,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 59
-          Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
+        - ID: 60
+          Type: 348 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -766,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 93
-          Type: 381 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+        - ID: 94
+          Type: 382 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -780,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 67
-          Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0xcd7400", Frameless: true}]
+        - ID: 68
+          Type: 356 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -794,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 75
-          Type: 363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd79a0", Frameless: true}]
+        - ID: 76
+          Type: 364 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd7a00", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -808,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 85
-          Type: 373 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
+        - ID: 86
+          Type: 374 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -822,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 82
-          Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
+        - ID: 83
+          Type: 371 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -836,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 84
-          Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
+        - ID: 85
+          Type: 373 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -850,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 92
-          Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
+        - ID: 93
+          Type: 381 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -864,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 71
-          Type: 359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd7820", Frameless: true}]
+        - ID: 72
+          Type: 360 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd7880", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -878,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 53
-          Type: 341 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0xcd5980", Frameless: true}]
+        - ID: 54
+          Type: 342 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0xcd59e0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -892,11 +906,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 69
-          Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd77e0", Frameless: true}]
+        - ID: 70
+          Type: 358 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd7840", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -910,7 +924,7 @@ Probes:
       events:
         - ID: 2
           Type: 290 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0xcd3c60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3cc0", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -924,7 +938,7 @@ Probes:
       events:
         - ID: 21
           Type: 309 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0xcd4260", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -938,7 +952,7 @@ Probes:
       events:
         - ID: 19
           Type: 307 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0xcd4220", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -952,7 +966,7 @@ Probes:
       events:
         - ID: 32
           Type: 320 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0xcd43c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4420", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -966,7 +980,7 @@ Probes:
       events:
         - ID: 33
           Type: 321 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0xcd43e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4440", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -980,7 +994,7 @@ Probes:
       events:
         - ID: 22
           Type: 310 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -994,7 +1008,7 @@ Probes:
       events:
         - ID: 24
           Type: 312 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1008,7 +1022,7 @@ Probes:
       events:
         - ID: 25
           Type: 313 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1022,7 +1036,7 @@ Probes:
       events:
         - ID: 26
           Type: 314 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1036,7 +1050,7 @@ Probes:
       events:
         - ID: 23
           Type: 311 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1050,7 +1064,7 @@ Probes:
       events:
         - ID: 20
           Type: 308 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0xcd4240", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1060,11 +1074,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 88
-          Type: 376 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcd83c0", Frameless: true}]
+        - ID: 89
+          Type: 377 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1078,7 +1092,7 @@ Probes:
       events:
         - ID: 27
           Type: 315 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4380", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1092,7 +1106,7 @@ Probes:
       events:
         - ID: 29
           Type: 317 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd43c0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1106,7 +1120,7 @@ Probes:
       events:
         - ID: 30
           Type: 318 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0xcd4380", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd43e0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1120,7 +1134,7 @@ Probes:
       events:
         - ID: 31
           Type: 319 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4400", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1134,7 +1148,7 @@ Probes:
       events:
         - ID: 28
           Type: 316 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1144,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 79
-          Type: 367 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcd7f40", Frameless: true}]
+        - ID: 80
+          Type: 368 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1158,11 +1172,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 51
-          Type: 339 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
+        - ID: 52
+          Type: 340 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0xcd59a0", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1176,7 +1190,7 @@ Probes:
       events:
         - ID: 3
           Type: 291 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0xcd3c80", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3ce0", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1186,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 74
-          Type: 362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd7960", Frameless: true}]
+        - ID: 75
+          Type: 363 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1200,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 83
-          Type: 371 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
+        - ID: 84
+          Type: 372 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1214,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 96
-          Type: 384 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcd8720", Frameless: true}]
+        - ID: 97
+          Type: 385 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1228,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 80
-          Type: 368 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
+        - ID: 81
+          Type: 369 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1242,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 46
-          Type: 334 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0xcd58a0", Frameless: true}]
+        - ID: 47
+          Type: 335 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1256,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 89
-          Type: 377 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcd83e0", Frameless: true}]
+        - ID: 90
+          Type: 378 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1270,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 90
-          Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcd8400", Frameless: true}]
+        - ID: 91
+          Type: 379 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1284,11 +1298,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 91
-          Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
+        - ID: 92
+          Type: 380 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1302,7 +1316,7 @@ Probes:
       events:
         - ID: 34
           Type: 322 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0xcd4400", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd4460", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1316,7 +1330,7 @@ Probes:
       events:
         - ID: 12
           Type: 300 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0xcd3da0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3e00", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1330,7 +1344,7 @@ Probes:
       events:
         - ID: 13
           Type: 301 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0xcd3dc0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3e20", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1344,7 +1358,7 @@ Probes:
       events:
         - ID: 14
           Type: 302 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0xcd3de0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3e40", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1358,7 +1372,7 @@ Probes:
       events:
         - ID: 11
           Type: 299 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0xcd3d80", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3de0", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1372,7 +1386,7 @@ Probes:
       events:
         - ID: 10
           Type: 298 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0xcd3d60", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3dc0", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1382,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 73
-          Type: 361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd7880", Frameless: true}]
+        - ID: 74
+          Type: 362 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd78e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1396,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 77
-          Type: 365 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcd7f00", Frameless: true}]
+        - ID: 78
+          Type: 366 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1410,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 94
-          Type: 382 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
+        - ID: 95
+          Type: 383 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1424,11 +1438,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 72
-          Type: 360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd7840", Frameless: true}]
+        - ID: 73
+          Type: 361 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd78a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1442,7 +1456,7 @@ Probes:
       events:
         - ID: 18
           Type: 306 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
+          InjectionPoints: [{PC: "0xcd3f00", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1452,430 +1466,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 86
-          Type: 374 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
+        - ID: 87
+          Type: 375 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
       Name: main.testByteArray
-      OutOfLinePCRanges: [0xcd3c40..0xcd3c41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 3 ArrayType [2]uint8
-          Locations:
-            - Range: 0xcd3c40..0xcd3c41
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 8
-      Name: main.testRuneArray
-      OutOfLinePCRanges: [0xcd3c60..0xcd3c61]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 5 ArrayType [2]int32
-          Locations:
-            - Range: 0xcd3c60..0xcd3c61
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 9
-      Name: main.testStringArray
-      OutOfLinePCRanges: [0xcd3c80..0xcd3c81]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 7 ArrayType [2]string
-          Locations:
-            - Range: 0xcd3c80..0xcd3c81
-              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 10
-      Name: main.testBoolArray
       OutOfLinePCRanges: [0xcd3ca0..0xcd3ca1]
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 10 ArrayType [2]bool
+          Type: 3 ArrayType [2]uint8
           Locations:
             - Range: 0xcd3ca0..0xcd3ca1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 11
-      Name: main.testIntArray
+    - ID: 8
+      Name: main.testRuneArray
       OutOfLinePCRanges: [0xcd3cc0..0xcd3cc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 12 ArrayType [2]int
-          Locations:
-            - Range: 0xcd3cc0..0xcd3cc1
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 12
-      Name: main.testInt8Array
-      OutOfLinePCRanges: [0xcd3ce0..0xcd3ce1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 13 ArrayType [2]int8
-          Locations:
-            - Range: 0xcd3ce0..0xcd3ce1
-              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 13
-      Name: main.testInt16Array
-      OutOfLinePCRanges: [0xcd3d00..0xcd3d01]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 15 ArrayType [2]int16
-          Locations:
-            - Range: 0xcd3d00..0xcd3d01
-              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 14
-      Name: main.testInt32Array
-      OutOfLinePCRanges: [0xcd3d20..0xcd3d21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
+            - Range: 0xcd3cc0..0xcd3cc1
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 9
+      Name: main.testStringArray
+      OutOfLinePCRanges: [0xcd3ce0..0xcd3ce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 ArrayType [2]string
+          Locations:
+            - Range: 0xcd3ce0..0xcd3ce1
+              Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 10
+      Name: main.testBoolArray
+      OutOfLinePCRanges: [0xcd3d00..0xcd3d01]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 ArrayType [2]bool
+          Locations:
+            - Range: 0xcd3d00..0xcd3d01
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 11
+      Name: main.testIntArray
+      OutOfLinePCRanges: [0xcd3d20..0xcd3d21]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 12 ArrayType [2]int
+          Locations:
             - Range: 0xcd3d20..0xcd3d21
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 12
+      Name: main.testInt8Array
+      OutOfLinePCRanges: [0xcd3d40..0xcd3d41]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 13 ArrayType [2]int8
+          Locations:
+            - Range: 0xcd3d40..0xcd3d41
+              Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 13
+      Name: main.testInt16Array
+      OutOfLinePCRanges: [0xcd3d60..0xcd3d61]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 15 ArrayType [2]int16
+          Locations:
+            - Range: 0xcd3d60..0xcd3d61
+              Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 14
+      Name: main.testInt32Array
+      OutOfLinePCRanges: [0xcd3d80..0xcd3d81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 5 ArrayType [2]int32
+          Locations:
+            - Range: 0xcd3d80..0xcd3d81
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0xcd3d40..0xcd3d41]
+      OutOfLinePCRanges: [0xcd3da0..0xcd3da1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 ArrayType [2]int64
           Locations:
-            - Range: 0xcd3d40..0xcd3d41
+            - Range: 0xcd3da0..0xcd3da1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testUintArray
-      OutOfLinePCRanges: [0xcd3d60..0xcd3d61]
+      OutOfLinePCRanges: [0xcd3dc0..0xcd3dc1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 ArrayType [2]uint
           Locations:
-            - Range: 0xcd3d60..0xcd3d61
+            - Range: 0xcd3dc0..0xcd3dc1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0xcd3d80..0xcd3d81]
+      OutOfLinePCRanges: [0xcd3de0..0xcd3de1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0xcd3d80..0xcd3d81
+            - Range: 0xcd3de0..0xcd3de1
               Pieces: [{Size: 2, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0xcd3da0..0xcd3da1]
+      OutOfLinePCRanges: [0xcd3e00..0xcd3e01]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 ArrayType [2]uint16
           Locations:
-            - Range: 0xcd3da0..0xcd3da1
+            - Range: 0xcd3e00..0xcd3e01
               Pieces: [{Size: 4, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0xcd3dc0..0xcd3dc1]
+      OutOfLinePCRanges: [0xcd3e20..0xcd3e21]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 ArrayType [2]uint32
           Locations:
-            - Range: 0xcd3dc0..0xcd3dc1
+            - Range: 0xcd3e20..0xcd3e21
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0xcd3de0..0xcd3de1]
+      OutOfLinePCRanges: [0xcd3e40..0xcd3e41]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 25 ArrayType [2]uint64
           Locations:
-            - Range: 0xcd3de0..0xcd3de1
+            - Range: 0xcd3e40..0xcd3e41
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0xcd3e00..0xcd3e01]
+      OutOfLinePCRanges: [0xcd3e60..0xcd3e61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 27 ArrayType [2][2]int
           Locations:
-            - Range: 0xcd3e00..0xcd3e01
+            - Range: 0xcd3e60..0xcd3e61
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0xcd3e20..0xcd3e21]
+      OutOfLinePCRanges: [0xcd3e80..0xcd3e81]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0xcd3e20..0xcd3e21
+            - Range: 0xcd3e80..0xcd3e81
               Pieces: [{Size: 32, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0xcd3e40..0xcd3e41]
+      OutOfLinePCRanges: [0xcd3ea0..0xcd3ea1]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 28 ArrayType [2][2][2]int
           Locations:
-            - Range: 0xcd3e40..0xcd3e41
+            - Range: 0xcd3ea0..0xcd3ea1
               Pieces: [{Size: 64, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0xcd3ea0..0xcd3ea1]
+      OutOfLinePCRanges: [0xcd3f00..0xcd3f01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 29 ArrayType [100]uint
           Locations:
-            - Range: 0xcd3ea0..0xcd3ea1
+            - Range: 0xcd3f00..0xcd3f01
               Pieces: [{Size: 800, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0xcd4220..0xcd4221]
+      OutOfLinePCRanges: [0xcd4280..0xcd4281]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd4220..0xcd4221
+            - Range: 0xcd4280..0xcd4281
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0xcd4240..0xcd4241]
+      OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xcd4240..0xcd4241
+            - Range: 0xcd42a0..0xcd42a1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0xcd4260..0xcd4261]
+      OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType bool
           Locations:
-            - Range: 0xcd4260..0xcd4261
+            - Range: 0xcd42c0..0xcd42c1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0xcd4280..0xcd4281]
+      OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4280..0xcd4281
+            - Range: 0xcd42e0..0xcd42e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0xcd42a0..0xcd42a1]
+      OutOfLinePCRanges: [0xcd4300..0xcd4301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xcd42a0..0xcd42a1
+            - Range: 0xcd4300..0xcd4301
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0xcd42c0..0xcd42c1]
+      OutOfLinePCRanges: [0xcd4320..0xcd4321]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int16
           Locations:
-            - Range: 0xcd42c0..0xcd42c1
+            - Range: 0xcd4320..0xcd4321
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0xcd42e0..0xcd42e1]
+      OutOfLinePCRanges: [0xcd4340..0xcd4341]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xcd42e0..0xcd42e1
+            - Range: 0xcd4340..0xcd4341
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0xcd4300..0xcd4301]
+      OutOfLinePCRanges: [0xcd4360..0xcd4361]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int64
           Locations:
-            - Range: 0xcd4300..0xcd4301
+            - Range: 0xcd4360..0xcd4361
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0xcd4320..0xcd4321]
+      OutOfLinePCRanges: [0xcd4380..0xcd4381]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd4320..0xcd4321
+            - Range: 0xcd4380..0xcd4381
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0xcd4340..0xcd4341]
+      OutOfLinePCRanges: [0xcd43a0..0xcd43a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd4340..0xcd4341
+            - Range: 0xcd43a0..0xcd43a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0xcd4360..0xcd4361]
+      OutOfLinePCRanges: [0xcd43c0..0xcd43c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 22 BaseType uint16
           Locations:
-            - Range: 0xcd4360..0xcd4361
+            - Range: 0xcd43c0..0xcd43c1
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 36
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0xcd4380..0xcd4381]
+      OutOfLinePCRanges: [0xcd43e0..0xcd43e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 24 BaseType uint32
           Locations:
-            - Range: 0xcd4380..0xcd4381
+            - Range: 0xcd43e0..0xcd43e1
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 37
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0xcd43a0..0xcd43a1]
+      OutOfLinePCRanges: [0xcd4400..0xcd4401]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 26 BaseType uint64
           Locations:
-            - Range: 0xcd43a0..0xcd43a1
+            - Range: 0xcd4400..0xcd4401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 38
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0xcd43c0..0xcd43c1]
+      OutOfLinePCRanges: [0xcd4420..0xcd4421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 30 BaseType float32
           Locations:
-            - Range: 0xcd43c0..0xcd43c1
+            - Range: 0xcd4420..0xcd4421
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 39
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0xcd43e0..0xcd43e1]
+      OutOfLinePCRanges: [0xcd4440..0xcd4441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType float64
           Locations:
-            - Range: 0xcd43e0..0xcd43e1
+            - Range: 0xcd4440..0xcd4441
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 40
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0xcd4400..0xcd4401]
+      OutOfLinePCRanges: [0xcd4460..0xcd4461]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 32 BaseType main.typeAlias
           Locations:
-            - Range: 0xcd4400..0xcd4401
+            - Range: 0xcd4460..0xcd4461
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 41
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0xcd4560..0xcd457f]
+      OutOfLinePCRanges: [0xcd45c0..0xcd45df]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 33 StructureType main.bigStruct
           Locations:
-            - Range: 0xcd4560..0xcd457f
+            - Range: 0xcd45c0..0xcd45df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1893,13 +1907,13 @@ Subprograms:
           IsReturn: false
     - ID: 42
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0xcd47e0..0xcd48e5]
+      OutOfLinePCRanges: [0xcd4840..0xcd4945]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 57 StructureType main.esotericStack
           Locations:
-            - Range: 0xcd47e0..0xcd4833
+            - Range: 0xcd4840..0xcd4893
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1919,7 +1933,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd4833..0xcd4838
+            - Range: 0xcd4893..0xcd4898
               Pieces:
                 - Size: 4
                   Op: null
@@ -1939,7 +1953,7 @@ Subprograms:
                   Op: {RegNo: 10, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
-            - Range: 0xcd4838..0xcd483d
+            - Range: 0xcd4898..0xcd489d
               Pieces:
                 - Size: 4
                   Op: null
@@ -1963,144 +1977,144 @@ Subprograms:
           IsReturn: false
     - ID: 43
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0xcd4900..0xcd4963]
+      OutOfLinePCRanges: [0xcd4960..0xcd49c3]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 63 PointerType *main.esotericHeap
           Locations:
-            - Range: 0xcd4900..0xcd492d
+            - Range: 0xcd4960..0xcd498d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 44
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0xcd4d40..0xcd4dc8]
+      OutOfLinePCRanges: [0xcd4da0..0xcd4e28]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4d40..0xcd4d55
+            - Range: 0xcd4da0..0xcd4db5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 45
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0xcd4de0..0xcd4ea5]
+      OutOfLinePCRanges: [0xcd4e40..0xcd4f05]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4de0..0xcd4df6
+            - Range: 0xcd4e40..0xcd4e56
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4de0..0xcd4e07
+            - Range: 0xcd4e40..0xcd4e67
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4df6..0xcd4e07
+            - Range: 0xcd4e56..0xcd4e67
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4e07..0xcd4ea5
+            - Range: 0xcd4e67..0xcd4f05
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           IsParameter: false
           IsReturn: false
     - ID: 46
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0xcd4ec0..0xcd4f22]
+      OutOfLinePCRanges: [0xcd4f20..0xcd4f82]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4ec0..0xcd4eda
+            - Range: 0xcd4f20..0xcd4f3a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0xcd4f40..0xcd504e]
+      OutOfLinePCRanges: [0xcd4fa0..0xcd50ae]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4f9b..0xcd4fa5
+            - Range: 0xcd4ffb..0xcd5005
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd4fa5..0xcd4fc0
+            - Range: 0xcd5005..0xcd5020
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
-            - Range: 0xcd4fc0..0xcd4fd4
+            - Range: 0xcd5020..0xcd5034
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4f96..0xcd4fa0
+            - Range: 0xcd4ff6..0xcd5000
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd4fa0..0xcd4fc0
+            - Range: 0xcd5000..0xcd5020
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0xcd4fc0..0xcd4fcf
+            - Range: 0xcd5020..0xcd502f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
     - ID: 48
       Name: main.testFrameless
-      OutOfLinePCRanges: [0xcd5060..0xcd5066]
+      OutOfLinePCRanges: [0xcd50c0..0xcd50c6]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd5060..0xcd5065
+            - Range: 0xcd50c0..0xcd50c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0xcd5060..0xcd5066, Pieces: []}]
+          Locations: [{Range: 0xcd50c0..0xcd50c6, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 49
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0xcd5080..0xcd50c3]
+      OutOfLinePCRanges: [0xcd50e0..0xcd5123]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0xcd5080..0xcd50c3
+            - Range: 0xcd50e0..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0xcd5080..0xcd50c3, Pieces: []}]
+          Locations: [{Range: 0xcd50e0..0xcd5123, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0xcd5360..0xcd55ed]
+      OutOfLinePCRanges: [0xcd53c0..0xcd5403]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 75 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd5360..0xcd539e
+            - Range: 0xcd53c0..0xcd53df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd539e..0xcd53a5
+            - Range: 0xcd53df..0xcd53e2
               Pieces:
                 - Size: 8
                   Op: null
@@ -2110,134 +2124,45 @@ Subprograms:
           IsReturn: false
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0xcd5360..0xcd55ed, Pieces: []}]
+          Locations: [{Range: 0xcd53c0..0xcd5403, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: hash
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd53dd..0xcd53e2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcd53e2..0xcd53fb
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd53fb..0xcd5405
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-            - Range: 0xcd5405..0xcd55ed
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-          IsParameter: false
-          IsReturn: false
-        - Name: inter
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd543d..0xcd5442
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcd5442..0xcd545c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd545c..0xcd5465
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-            - Range: 0xcd5465..0xcd55ed
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -128}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-          IsParameter: false
-          IsReturn: false
-        - Name: iType
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd549d..0xcd54a2
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcd54a2..0xcd54bc
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd54bc..0xcd54c5
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-            - Range: 0xcd54c5..0xcd55ed
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-          IsParameter: false
-          IsReturn: false
-        - Name: iFun
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd54fd..0xcd5502
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0xcd5502..0xcd552a
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd552a..0xcd552f
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-            - Range: 0xcd552f..0xcd55ed
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-          IsParameter: false
-          IsReturn: false
     - ID: 51
+      Name: main.testAny
+      OutOfLinePCRanges: [0xcd5420..0xcd5486]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcd5420..0xcd5449
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcd5449..0xcd544e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0xcd5420..0xcd5486, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 52
       Name: main.testError
-      OutOfLinePCRanges: [0xcd5600..0xcd5601]
+      OutOfLinePCRanges: [0xcd54a0..0xcd54a1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 76 GoInterfaceType error
           Locations:
-            - Range: 0xcd5600..0xcd5601
+            - Range: 0xcd54a0..0xcd54a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2245,68 +2170,32 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 52
+    - ID: 53
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0xcd58a0..0xcd58a1]
+      OutOfLinePCRanges: [0xcd5900..0xcd5901]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 77 StructureType main.structWithMap
           Locations:
-            - Range: 0xcd58a0..0xcd58a1
+            - Range: 0xcd5900..0xcd5901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0xcd58c0..0xcd58c1]
+      OutOfLinePCRanges: [0xcd5920..0xcd5921]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0xcd58c0..0xcd58c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0xcd58e0..0xcd58e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0xcd58e0..0xcd58e1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0xcd5900..0xcd5901]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[string][]string
-          Locations:
-            - Range: 0xcd5900..0xcd5901
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0xcd5920..0xcd5921]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 124 GoMapType map[[4]string][2]int
-          Locations:
             - Range: 0xcd5920..0xcd5921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 57
-      Name: main.testSmallMap
+    - ID: 55
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0xcd5940..0xcd5941]
       InlinePCRanges: []
       Variables:
@@ -2317,237 +2206,273 @@ Subprograms:
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 58
-      Name: main.testArrayOfMaps
+    - ID: 56
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0xcd5960..0xcd5961]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 ArrayType [2]map[string]int
+          Type: 112 GoMapType map[string][]string
           Locations:
             - Range: 0xcd5960..0xcd5961
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 59
-      Name: main.testPointerToMap
+    - ID: 57
+      Name: main.testMapArrayToArray
       OutOfLinePCRanges: [0xcd5980..0xcd5981]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 PointerType *map[string]int
+          Type: 124 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd5980..0xcd5981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 60
-      Name: main.testMapIntToInt
+    - ID: 58
+      Name: main.testSmallMap
       OutOfLinePCRanges: [0xcd59a0..0xcd59a1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 78 GoMapType map[int]int
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0xcd59a0..0xcd59a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 61
-      Name: main.testMapMassive
+    - ID: 59
+      Name: main.testArrayOfMaps
       OutOfLinePCRanges: [0xcd59c0..0xcd59c1]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
+        - Name: m
+          Type: 136 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd59c0..0xcd59c1
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
+    - ID: 60
+      Name: main.testPointerToMap
       OutOfLinePCRanges: [0xcd59e0..0xcd59e1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 137 PointerType *map[string]int
           Locations:
             - Range: 0xcd59e0..0xcd59e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
+    - ID: 61
+      Name: main.testMapIntToInt
       OutOfLinePCRanges: [0xcd5a00..0xcd5a01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[bool]main.node
+          Type: 78 GoMapType map[int]int
           Locations:
             - Range: 0xcd5a00..0xcd5a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
+    - ID: 62
+      Name: main.testMapMassive
       OutOfLinePCRanges: [0xcd5a20..0xcd5a21]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]uint8
+        - Name: redactMyEntries
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a20..0xcd5a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
+    - ID: 63
+      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0xcd5a40..0xcd5a41]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
+        - Name: m
+          Type: 138 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a40..0xcd5a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 64
+      Name: main.testMapWithLinkedList
       OutOfLinePCRanges: [0xcd5a60..0xcd5a61]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 151 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd5a60..0xcd5a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 65
+      Name: main.testMapWithSmallValue
       OutOfLinePCRanges: [0xcd5a80..0xcd5a81]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5a80..0xcd5a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
+    - ID: 66
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0xcd5aa0..0xcd5aa1]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5aa0..0xcd5aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0xcd5ac0..0xcd5ac1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[uint8][4]int
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ac0..0xcd5ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 68
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0xcd5ae0..0xcd5ae1]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ae0..0xcd5ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 69
+      Name: main.testMapSmallKeySmallValue
       OutOfLinePCRanges: [0xcd5b00..0xcd5b01]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 175 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5b00..0xcd5b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 70
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0xcd5b20..0xcd5b21]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0xcd5b20..0xcd5b21
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0xcd5b40..0xcd5b41]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0xcd5b40..0xcd5b41
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0xcd5b60..0xcd5b61]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0xcd5b60..0xcd5b61
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0xcd7240..0xcd7241]
+      OutOfLinePCRanges: [0xcd72a0..0xcd72a1]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd7240..0xcd7241
+            - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd7240..0xcd7241
+            - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0xcd7240..0xcd7241
+            - Range: 0xcd72a0..0xcd72a1
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 74
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0xcd7400..0xcd7401]
+      OutOfLinePCRanges: [0xcd7460..0xcd7461]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 1, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd7400..0xcd7401
+            - Range: 0xcd7460..0xcd7461
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2555,39 +2480,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 75
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd7620..0xcd7621]
+      OutOfLinePCRanges: [0xcd7680..0xcd7681]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0xcd7620..0xcd7621
+            - Range: 0xcd7680..0xcd7681
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd77e0..0xcd77e1]
+      OutOfLinePCRanges: [0xcd7840..0xcd7841]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd77e0..0xcd77e1
+            - Range: 0xcd7840..0xcd7841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd7800..0xcd7801]
+      OutOfLinePCRanges: [0xcd7860..0xcd7861]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 StructureType main.node
           Locations:
-            - Range: 0xcd7800..0xcd7801
+            - Range: 0xcd7860..0xcd7861
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2595,112 +2520,94 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd7820..0xcd7821]
+      OutOfLinePCRanges: [0xcd7880..0xcd7881]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *main.node
           Locations:
-            - Range: 0xcd7820..0xcd7821
+            - Range: 0xcd7880..0xcd7881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd7840..0xcd7841]
+      OutOfLinePCRanges: [0xcd78a0..0xcd78a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd7840..0xcd7841
+            - Range: 0xcd78a0..0xcd78a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd7880..0xcd7881]
+      OutOfLinePCRanges: [0xcd78e0..0xcd78e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 223 PointerType *uint
           Locations:
-            - Range: 0xcd7880..0xcd7881
+            - Range: 0xcd78e0..0xcd78e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd7960..0xcd7961]
+      OutOfLinePCRanges: [0xcd79c0..0xcd79c1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0xcd7960..0xcd7961
+            - Range: 0xcd79c0..0xcd79c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd79a0..0xcd79a1]
+      OutOfLinePCRanges: [0xcd7a00..0xcd7a01]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 224 PointerType *bool
           Locations:
-            - Range: 0xcd79a0..0xcd79a1
+            - Range: 0xcd7a00..0xcd7a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd79a0..0xcd79a1
+            - Range: 0xcd7a00..0xcd7a01
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd79e0..0xcd79e1]
+      OutOfLinePCRanges: [0xcd7a40..0xcd7a41]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 225 PointerType *main.t
           Locations:
-            - Range: 0xcd79e0..0xcd79e1
+            - Range: 0xcd7a40..0xcd7a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcd7f00..0xcd7f01]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 228 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd7f00..0xcd7f01
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 84
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcd7f20..0xcd7f21]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0xcd7f60..0xcd7f61]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd7f20..0xcd7f21
+            - Range: 0xcd7f60..0xcd7f61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2711,14 +2618,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 85
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0xcd7f40..0xcd7f41]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0xcd7f80..0xcd7f81]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 229 GoSliceHeaderType [][]uint
+          Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcd7f40..0xcd7f41
+            - Range: 0xcd7f80..0xcd7f81
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2729,62 +2636,12 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 86
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0xcd7f60..0xcd7f61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7f60..0xcd7f61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7f60..0xcd7f61
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0xcd7f80..0xcd7f81]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0xcd7f80..0xcd7f81
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7f80..0xcd7f81
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 88
-      Name: main.testNilSliceOfStructs
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcd7fa0..0xcd7fa1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 229 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcd7fa0..0xcd7fa1
               Pieces:
@@ -2796,20 +2653,13 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0xcd7fa0..0xcd7fa1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 89
-      Name: main.testStringSlice
+    - ID: 87
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcd7fc0..0xcd7fc1]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 123 GoSliceHeaderType []string
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
@@ -2821,22 +2671,97 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7fc0..0xcd7fc1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 88
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcd7fe0..0xcd7fe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd7fe0..0xcd7fe1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd7fe0..0xcd7fe1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 89
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0xcd8000..0xcd8001]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcd8000..0xcd8001
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0xcd8000..0xcd8001
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcd8020..0xcd8021]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 123 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcd8020..0xcd8021
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 91
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcd8040..0xcd8041]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
+            - Range: 0xcd8040..0xcd8041
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
+            - Range: 0xcd8040..0xcd8041
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -2849,37 +2774,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0xcd7fe0..0xcd7fe1
+            - Range: 0xcd8040..0xcd8041
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcd8000..0xcd8001]
+      OutOfLinePCRanges: [0xcd8060..0xcd8061]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0xcd8000..0xcd8001
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcd8020..0xcd8021]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 228 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcd8020..0xcd8021
+            - Range: 0xcd8060..0xcd8061
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,24 +2797,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 93
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0xcd8080..0xcd8081]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcd8080..0xcd8081
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.stackC
-      OutOfLinePCRanges: [0xcd8360..0xcd83b2]
+      OutOfLinePCRanges: [0xcd83c0..0xcd8412]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0xcd8360..0xcd83b2, Pieces: []}]
+          Locations: [{Range: 0xcd83c0..0xcd8412, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcd83c0..0xcd83c1]
+      OutOfLinePCRanges: [0xcd8420..0xcd8421]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd83c0..0xcd83c1
+            - Range: 0xcd8420..0xcd8421
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2915,15 +2840,15 @@ Subprograms:
                   Op: {RegNo: 3, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcd83e0..0xcd83e1]
+      OutOfLinePCRanges: [0xcd8440..0xcd8441]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd83e0..0xcd83e1
+            - Range: 0xcd8440..0xcd8441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2859,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd83e0..0xcd83e1
+            - Range: 0xcd8440..0xcd8441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2870,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd83e0..0xcd83e1
+            - Range: 0xcd8440..0xcd8441
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2953,15 +2878,15 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 97
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcd8400..0xcd841f]
+      OutOfLinePCRanges: [0xcd8460..0xcd847f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcd8400..0xcd841f
+            - Range: 0xcd8460..0xcd847f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2977,55 +2902,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 98
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcd8420..0xcd8421]
+      OutOfLinePCRanges: [0xcd8480..0xcd8481]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcd8420..0xcd8421
+            - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcd8440..0xcd8441]
+      OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcd8440..0xcd8441
+            - Range: 0xcd84a0..0xcd84a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcd8460..0xcd8461]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0xcd8460..0xcd8461
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 100
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcd8480..0xcd8481]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0xcd84c0..0xcd84c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd8480..0xcd8481
+            - Range: 0xcd84c0..0xcd84c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3034,14 +2943,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0xcd84a0..0xcd84a1]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0xcd84e0..0xcd84e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0xcd84a0..0xcd84a1
+            - Range: 0xcd84e0..0xcd84e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3050,14 +2959,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 102
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcd8500..0xcd8501]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd8500..0xcd8501
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcd8720..0xcd8743]
+      OutOfLinePCRanges: [0xcd8780..0xcd87a3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0xcd8720..0xcd8743
+            - Range: 0xcd8780..0xcd87a3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3075,43 +3000,43 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 104
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcd88a0..0xcd88a1]
+      OutOfLinePCRanges: [0xcd8900..0xcd8901]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 242 StructureType main.emptyStruct
-          Locations: [{Range: 0xcd88a0..0xcd88a1, Pieces: []}]
+          Locations: [{Range: 0xcd8900..0xcd8901, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0xcd4ba0..0xcd4c02]
+      OutOfLinePCRanges: [0xcd4c00..0xcd4c62]
       InlinePCRanges:
-        - Ranges: [0xcd4c31..0xcd4c6d]
-          RootRanges: [0xcd4c20..0xcd4c91]
-        - Ranges: [0xcd4d72..0xcd4dae]
-          RootRanges: [0xcd4d40..0xcd4dc8]
-        - Ranges: [0xcd4dfc..0xcd4e38]
-          RootRanges: [0xcd4de0..0xcd4ea5]
-        - Ranges: [0xcd4ecf..0xcd4f0b]
-          RootRanges: [0xcd4ec0..0xcd4f22]
+        - Ranges: [0xcd4c91..0xcd4ccd]
+          RootRanges: [0xcd4c80..0xcd4cf1]
+        - Ranges: [0xcd4dd2..0xcd4e0e]
+          RootRanges: [0xcd4da0..0xcd4e28]
+        - Ranges: [0xcd4e5c..0xcd4e98]
+          RootRanges: [0xcd4e40..0xcd4f05]
+        - Ranges: [0xcd4f2f..0xcd4f6b]
+          RootRanges: [0xcd4f20..0xcd4f82]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd4ba0..0xcd4bb9
+            - Range: 0xcd4c00..0xcd4c19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4c31..0xcd4c3c
+            - Range: 0xcd4c91..0xcd4c9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4d72..0xcd4d7d
+            - Range: 0xcd4dd2..0xcd4ddd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4df6..0xcd4e07
+            - Range: 0xcd4e56..0xcd4e67
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd4e07..0xcd4ea5
+            - Range: 0xcd4e67..0xcd4f05
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcd4ec0..0xcd4eda
+            - Range: 0xcd4f20..0xcd4f3a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3119,34 +3044,34 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd4e46..0xcd4e7e]
-          RootRanges: [0xcd4de0..0xcd4ea5]
+        - Ranges: [0xcd4ea6..0xcd4ede]
+          RootRanges: [0xcd4e40..0xcd4f05]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd4f53..0xcd4f91]
-          RootRanges: [0xcd4f40..0xcd504e]
+        - Ranges: [0xcd4fb3..0xcd4ff1]
+          RootRanges: [0xcd4fa0..0xcd50ae]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5006..0xcd503e]
-          RootRanges: [0xcd4f40..0xcd504e]
+        - Ranges: [0xcd5066..0xcd509e]
+          RootRanges: [0xcd4fa0..0xcd50ae]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd5061..0xcd5065]
-          RootRanges: [0xcd5060..0xcd5066]
+        - Ranges: [0xcd50c1..0xcd50c5]
+          RootRanges: [0xcd50c0..0xcd50c6]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0xcd5060..0xcd5065
+            - Range: 0xcd50c0..0xcd50c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3154,17 +3079,17 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xcd50a5..0xcd50bd]
-          RootRanges: [0xcd5080..0xcd50c3]
-        - Ranges: [0xcd5145..0xcd5163]
-          RootRanges: [0xcd50e0..0xcd5265]
+        - Ranges: [0xcd5105..0xcd511d]
+          RootRanges: [0xcd50e0..0xcd5123]
+        - Ranges: [0xcd51a5..0xcd51c3]
+          RootRanges: [0xcd5140..0xcd52c5]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0xcd508d..0xcd50c3
+            - Range: 0xcd50ed..0xcd5123
               Pieces: [{Size: 40, Op: {CfaOffset: -56}}]
-            - Range: 0xcd512c..0xcd5265
+            - Range: 0xcd518c..0xcd52c5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           IsParameter: true
           IsReturn: false
@@ -3173,7 +3098,7 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 575552
+      GoRuntimeType: 575584
       GoKind: 2
     - __kind: ArrayType
       ID: 2
@@ -3187,7 +3112,7 @@ Types:
       ID: 3
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 674496
+      GoRuntimeType: 674528
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3196,13 +3121,13 @@ Types:
       ID: 4
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 575104
+      GoRuntimeType: 575136
       GoKind: 8
     - __kind: ArrayType
       ID: 5
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 674592
+      GoRuntimeType: 674624
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3211,13 +3136,13 @@ Types:
       ID: 6
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 575296
+      GoRuntimeType: 575328
       GoKind: 5
     - __kind: ArrayType
       ID: 7
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 674688
+      GoRuntimeType: 674720
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3226,7 +3151,7 @@ Types:
       ID: 8
       Name: string
       ByteSize: 16
-      GoRuntimeType: 574976
+      GoRuntimeType: 575008
       GoKind: 24
       RawFields:
         - Name: str
@@ -3240,7 +3165,7 @@ Types:
       ID: 9
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 385312
+      GoRuntimeType: 385344
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: ArrayType
@@ -3255,13 +3180,13 @@ Types:
       ID: 11
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 576000
+      GoRuntimeType: 576032
       GoKind: 1
     - __kind: ArrayType
       ID: 12
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 673440
+      GoRuntimeType: 673280
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3278,7 +3203,7 @@ Types:
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 575040
+      GoRuntimeType: 575072
       GoKind: 3
     - __kind: ArrayType
       ID: 15
@@ -3292,7 +3217,7 @@ Types:
       ID: 16
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 575168
+      GoRuntimeType: 575200
       GoKind: 4
     - __kind: ArrayType
       ID: 17
@@ -3306,7 +3231,7 @@ Types:
       ID: 18
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 575424
+      GoRuntimeType: 575456
       GoKind: 6
     - __kind: ArrayType
       ID: 19
@@ -3320,7 +3245,7 @@ Types:
       ID: 20
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 575616
+      GoRuntimeType: 575648
       GoKind: 7
     - __kind: ArrayType
       ID: 21
@@ -3334,7 +3259,7 @@ Types:
       ID: 22
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 575232
+      GoRuntimeType: 575264
       GoKind: 9
     - __kind: ArrayType
       ID: 23
@@ -3348,13 +3273,13 @@ Types:
       ID: 24
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 575360
+      GoRuntimeType: 575392
       GoKind: 10
     - __kind: ArrayType
       ID: 25
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 674784
+      GoRuntimeType: 674816
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3363,7 +3288,7 @@ Types:
       ID: 26
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 575488
+      GoRuntimeType: 575520
       GoKind: 11
     - __kind: ArrayType
       ID: 27
@@ -3393,13 +3318,13 @@ Types:
       ID: 30
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 575872
+      GoRuntimeType: 575904
       GoKind: 13
     - __kind: BaseType
       ID: 31
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 575936
+      GoRuntimeType: 575968
       GoKind: 14
     - __kind: BaseType
       ID: 32
@@ -3425,7 +3350,7 @@ Types:
       ID: 34
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 470624
+      GoRuntimeType: 470656
       GoKind: 23
       RawFields:
         - Name: array
@@ -3442,21 +3367,21 @@ Types:
       ID: 35
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 521024
+      GoRuntimeType: 521056
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
       ID: 36
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 385184
+      GoRuntimeType: 385216
       GoKind: 22
       Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
       ID: 37
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.01216e+06
+      GoRuntimeType: 1.012448e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
@@ -3475,14 +3400,14 @@ Types:
       ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
-      GoRuntimeType: 409760
+      GoRuntimeType: 409792
       GoKind: 22
       Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
       ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
-      GoRuntimeType: 1.742688e+06
+      GoRuntimeType: 1.742976e+06
       GoKind: 25
       RawFields:
         - Name: Inter
@@ -3501,14 +3426,14 @@ Types:
       ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
-      GoRuntimeType: 2.189088e+06
+      GoRuntimeType: 2.189376e+06
       GoKind: 22
       Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
       ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
-      GoRuntimeType: 1.61952e+06
+      GoRuntimeType: 1.619808e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -3524,7 +3449,7 @@ Types:
       ID: 43
       Name: internal/abi.Type
       ByteSize: 48
-      GoRuntimeType: 2.11088e+06
+      GoRuntimeType: 2.111168e+06
       GoKind: 25
       RawFields:
         - Name: Size_
@@ -3564,43 +3489,43 @@ Types:
       ID: 44
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 575680
+      GoRuntimeType: 575712
       GoKind: 12
     - __kind: BaseType
       ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
-      GoRuntimeType: 578688
+      GoRuntimeType: 578720
       GoKind: 8
     - __kind: BaseType
       ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
-      GoRuntimeType: 824704
+      GoRuntimeType: 824800
       GoKind: 8
     - __kind: GoSubroutineType
       ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 834784
+      GoRuntimeType: 834880
       GoKind: 19
     - __kind: BaseType
       ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
-      GoRuntimeType: 578752
+      GoRuntimeType: 578784
       GoKind: 5
     - __kind: BaseType
       ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
-      GoRuntimeType: 578816
+      GoRuntimeType: 578848
       GoKind: 5
     - __kind: StructureType
       ID: 50
       Name: internal/abi.Name
       ByteSize: 8
-      GoRuntimeType: 1.95472e+06
+      GoRuntimeType: 1.955008e+06
       GoKind: 25
       RawFields:
         - Name: Bytes
@@ -3610,7 +3535,7 @@ Types:
       ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
-      GoRuntimeType: 499264
+      GoRuntimeType: 499296
       GoKind: 23
       RawFields:
         - Name: array
@@ -3627,14 +3552,14 @@ Types:
       ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
-      GoRuntimeType: 409696
+      GoRuntimeType: 409728
       GoKind: 22
       Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
       ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
-      GoRuntimeType: 1.470336e+06
+      GoRuntimeType: 1.470624e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -3647,14 +3572,14 @@ Types:
       ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.189536e+06
+      GoRuntimeType: 2.189824e+06
       GoKind: 22
       Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
       ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
-      GoRuntimeType: 672480
+      GoRuntimeType: 674336
       GoKind: 17
       Count: 1
       HasCount: true
@@ -3663,13 +3588,13 @@ Types:
       ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 576064
+      GoRuntimeType: 576096
       GoKind: 26
     - __kind: StructureType
       ID: 57
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.945216e+06
+      GoRuntimeType: 1.945504e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3696,13 +3621,13 @@ Types:
     - __kind: GoChannelType
       ID: 58
       Name: chan struct {}
-      GoRuntimeType: 586240
+      GoRuntimeType: 586272
       GoKind: 18
     - __kind: GoEmptyInterfaceType
       ID: 59
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 838240
+      GoRuntimeType: 838336
       GoKind: 20
       UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
@@ -3721,27 +3646,27 @@ Types:
       ID: 61
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.011904e+06
+      GoRuntimeType: 1.012192e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
       ID: 62
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 468896
+      GoRuntimeType: 468928
       GoKind: 19
     - __kind: PointerType
       ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 380192
+      GoRuntimeType: 380224
       GoKind: 22
       Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
       ID: 64
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.811392e+06
+      GoRuntimeType: 1.81168e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -3763,7 +3688,7 @@ Types:
       ID: 65
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.445056e+06
+      GoRuntimeType: 1.445344e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3775,14 +3700,14 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: sync.noCopy
-      GoRuntimeType: 977536
+      GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 67
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.454336e+06
+      GoRuntimeType: 1.454624e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -3795,7 +3720,7 @@ Types:
       ID: 68
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.593408e+06
+      GoRuntimeType: 1.593696e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3811,7 +3736,7 @@ Types:
       ID: 69
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.446496e+06
+      GoRuntimeType: 1.446784e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3823,14 +3748,14 @@ Types:
     - __kind: StructureType
       ID: 70
       Name: sync/atomic.noCopy
-      GoRuntimeType: 977632
+      GoRuntimeType: 977824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 71
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.5936e+06
+      GoRuntimeType: 1.593888e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -3846,7 +3771,7 @@ Types:
       ID: 72
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.593984e+06
+      GoRuntimeType: 1.594272e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3861,14 +3786,14 @@ Types:
     - __kind: StructureType
       ID: 73
       Name: sync/atomic.align64
-      GoRuntimeType: 977728
+      GoRuntimeType: 977920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 74
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.446336e+06
+      GoRuntimeType: 1.446624e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3881,21 +3806,21 @@ Types:
       ID: 75
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.011776e+06
+      GoRuntimeType: 1.012064e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
       ID: 76
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.016128e+06
+      GoRuntimeType: 1.016416e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
       ID: 77
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.173216e+06
+      GoRuntimeType: 1.173504e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -3905,7 +3830,7 @@ Types:
       ID: 78
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.116896e+06
+      GoRuntimeType: 1.117184e+06
       GoKind: 21
       HeaderType: 80 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
@@ -4002,7 +3927,7 @@ Types:
       ID: 86
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.276192e+06
+      GoRuntimeType: 1.27648e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4015,7 +3940,7 @@ Types:
       ID: 87
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 671232
+      GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4024,7 +3949,7 @@ Types:
       ID: 88
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.276064e+06
+      GoRuntimeType: 1.276352e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4037,7 +3962,7 @@ Types:
       ID: 89
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.118304e+06
+      GoRuntimeType: 1.118592e+06
       GoKind: 21
       HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
@@ -4134,7 +4059,7 @@ Types:
       ID: 97
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.279008e+06
+      GoRuntimeType: 1.279296e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4147,7 +4072,7 @@ Types:
       ID: 98
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 674112
+      GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4156,7 +4081,7 @@ Types:
       ID: 99
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.27888e+06
+      GoRuntimeType: 1.279168e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4169,7 +4094,7 @@ Types:
       ID: 100
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.443776e+06
+      GoRuntimeType: 1.444064e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -4182,7 +4107,7 @@ Types:
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.118176e+06
+      GoRuntimeType: 1.118464e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
@@ -4279,7 +4204,7 @@ Types:
       ID: 109
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.278752e+06
+      GoRuntimeType: 1.27904e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4292,7 +4217,7 @@ Types:
       ID: 110
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 674016
+      GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4301,7 +4226,7 @@ Types:
       ID: 111
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.278624e+06
+      GoRuntimeType: 1.278912e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4314,7 +4239,7 @@ Types:
       ID: 112
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.118048e+06
+      GoRuntimeType: 1.118336e+06
       GoKind: 21
       HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
@@ -4411,7 +4336,7 @@ Types:
       ID: 120
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.278496e+06
+      GoRuntimeType: 1.278784e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4424,7 +4349,7 @@ Types:
       ID: 121
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 673920
+      GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4433,7 +4358,7 @@ Types:
       ID: 122
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.278368e+06
+      GoRuntimeType: 1.278656e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4446,7 +4371,7 @@ Types:
       ID: 123
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 478624
+      GoRuntimeType: 478656
       GoKind: 23
       RawFields:
         - Name: array
@@ -4463,7 +4388,7 @@ Types:
       ID: 124
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.117536e+06
+      GoRuntimeType: 1.117824e+06
       GoKind: 21
       HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
@@ -4560,7 +4485,7 @@ Types:
       ID: 132
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.277472e+06
+      GoRuntimeType: 1.27776e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4573,7 +4498,7 @@ Types:
       ID: 133
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 673536
+      GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4582,7 +4507,7 @@ Types:
       ID: 134
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.277344e+06
+      GoRuntimeType: 1.277632e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4595,7 +4520,7 @@ Types:
       ID: 135
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 673344
+      GoRuntimeType: 673184
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4618,7 +4543,7 @@ Types:
       ID: 138
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.11792e+06
+      GoRuntimeType: 1.118208e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
@@ -4715,7 +4640,7 @@ Types:
       ID: 146
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.27824e+06
+      GoRuntimeType: 1.278528e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4728,7 +4653,7 @@ Types:
       ID: 147
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 673824
+      GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4737,7 +4662,7 @@ Types:
       ID: 148
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.278112e+06
+      GoRuntimeType: 1.2784e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4750,7 +4675,7 @@ Types:
       ID: 149
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 469856
+      GoRuntimeType: 469888
       GoKind: 23
       RawFields:
         - Name: array
@@ -4767,14 +4692,14 @@ Types:
       ID: 150
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 380128
+      GoRuntimeType: 380160
       GoKind: 22
       Pointee: 77 StructureType main.structWithMap
     - __kind: GoMapType
       ID: 151
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.117664e+06
+      GoRuntimeType: 1.117952e+06
       GoKind: 21
       HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
@@ -4871,7 +4796,7 @@ Types:
       ID: 159
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.277728e+06
+      GoRuntimeType: 1.278016e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4884,7 +4809,7 @@ Types:
       ID: 160
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 673632
+      GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4893,7 +4818,7 @@ Types:
       ID: 161
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.2776e+06
+      GoRuntimeType: 1.277888e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4906,7 +4831,7 @@ Types:
       ID: 162
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.443616e+06
+      GoRuntimeType: 1.443904e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -4919,14 +4844,14 @@ Types:
       ID: 163
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 380256
+      GoRuntimeType: 380288
       GoKind: 22
       Pointee: 162 StructureType main.node
     - __kind: GoMapType
       ID: 164
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117792e+06
+      GoRuntimeType: 1.11808e+06
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
@@ -5023,7 +4948,7 @@ Types:
       ID: 172
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.277984e+06
+      GoRuntimeType: 1.278272e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5036,7 +4961,7 @@ Types:
       ID: 173
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 673728
+      GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5045,7 +4970,7 @@ Types:
       ID: 174
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.277856e+06
+      GoRuntimeType: 1.278144e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5058,7 +4983,7 @@ Types:
       ID: 175
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.11856e+06
+      GoRuntimeType: 1.118848e+06
       GoKind: 21
       HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
@@ -5155,7 +5080,7 @@ Types:
       ID: 183
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.27952e+06
+      GoRuntimeType: 1.279808e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5168,7 +5093,7 @@ Types:
       ID: 184
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 674304
+      GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5177,7 +5102,7 @@ Types:
       ID: 185
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.279392e+06
+      GoRuntimeType: 1.27968e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5190,7 +5115,7 @@ Types:
       ID: 186
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.118432e+06
+      GoRuntimeType: 1.11872e+06
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
@@ -5287,7 +5212,7 @@ Types:
       ID: 194
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.279264e+06
+      GoRuntimeType: 1.279552e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5300,7 +5225,7 @@ Types:
       ID: 195
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 674208
+      GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5309,7 +5234,7 @@ Types:
       ID: 196
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.279136e+06
+      GoRuntimeType: 1.279424e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5322,7 +5247,7 @@ Types:
       ID: 197
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 673056
+      GoRuntimeType: 672896
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5331,7 +5256,7 @@ Types:
       ID: 198
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117408e+06
+      GoRuntimeType: 1.117696e+06
       GoKind: 21
       HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
@@ -5428,7 +5353,7 @@ Types:
       ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.277216e+06
+      GoRuntimeType: 1.277504e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5441,7 +5366,7 @@ Types:
       ID: 207
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 673248
+      GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5450,7 +5375,7 @@ Types:
       ID: 208
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.277088e+06
+      GoRuntimeType: 1.277376e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5463,7 +5388,7 @@ Types:
       ID: 209
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.11728e+06
+      GoRuntimeType: 1.117568e+06
       GoKind: 21
       HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
@@ -5560,7 +5485,7 @@ Types:
       ID: 217
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.27696e+06
+      GoRuntimeType: 1.277248e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5573,7 +5498,7 @@ Types:
       ID: 218
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 673152
+      GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5582,7 +5507,7 @@ Types:
       ID: 219
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.276832e+06
+      GoRuntimeType: 1.27712e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5594,7 +5519,7 @@ Types:
     - __kind: GoChannelType
       ID: 220
       Name: chan bool
-      GoRuntimeType: 587328
+      GoRuntimeType: 587360
       GoKind: 18
     - __kind: PointerType
       ID: 221
@@ -5618,14 +5543,14 @@ Types:
       ID: 223
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 385824
+      GoRuntimeType: 385856
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
       ID: 224
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 386208
+      GoRuntimeType: 386240
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
@@ -5659,7 +5584,7 @@ Types:
       ID: 228
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 478112
+      GoRuntimeType: 478144
       GoKind: 23
       RawFields:
         - Name: array
@@ -5730,7 +5655,7 @@ Types:
       ID: 234
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 478496
+      GoRuntimeType: 478528
       GoKind: 23
       RawFields:
         - Name: array
@@ -5747,7 +5672,7 @@ Types:
       ID: 235
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 477472
+      GoRuntimeType: 477504
       GoKind: 23
       RawFields:
         - Name: array
@@ -5764,7 +5689,7 @@ Types:
       ID: 236
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 385440
+      GoRuntimeType: 385472
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
@@ -6714,6 +6639,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 333
+      Name: Probe[main.testAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 334
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6724,11 +6664,11 @@ Types:
             Type: 76 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: e}
+                  Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 335
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6739,11 +6679,11 @@ Types:
             Type: 77 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 336
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6754,11 +6694,11 @@ Types:
             Type: 89 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 337
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6769,11 +6709,11 @@ Types:
             Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 338
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6784,11 +6724,11 @@ Types:
             Type: 112 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 339
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6799,11 +6739,11 @@ Types:
             Type: 124 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 340
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6814,11 +6754,11 @@ Types:
             Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 341
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6829,11 +6769,11 @@ Types:
             Type: 136 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 341
+      ID: 342
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6844,11 +6784,11 @@ Types:
             Type: 137 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 343
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6859,11 +6799,11 @@ Types:
             Type: 78 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 344
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6874,11 +6814,11 @@ Types:
             Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 345
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6889,11 +6829,11 @@ Types:
             Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 346
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6904,11 +6844,11 @@ Types:
             Type: 151 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 347
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6919,11 +6859,11 @@ Types:
             Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 348
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6934,27 +6874,12 @@ Types:
             Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 175 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 349
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6969,7 +6894,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 350
-      Name: Probe[main.testMapSmallKeySmallValue]
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6984,6 +6909,21 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 351
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 175 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 352
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6994,11 +6934,11 @@ Types:
             Type: 186 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 353
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7009,11 +6949,11 @@ Types:
             Type: 198 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 354
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7024,11 +6964,11 @@ Types:
             Type: 209 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 355
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7039,7 +6979,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: w}
+                  Variable: {subprogram: 73, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7048,7 +6988,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: x}
+                  Variable: {subprogram: 73, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7057,11 +6997,11 @@ Types:
             Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: y}
+                  Variable: {subprogram: 73, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 355
+      ID: 356
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7072,7 +7012,7 @@ Types:
             Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: a}
+                  Variable: {subprogram: 74, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -7081,7 +7021,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: b}
+                  Variable: {subprogram: 74, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -7090,7 +7030,7 @@ Types:
             Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: c}
+                  Variable: {subprogram: 74, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -7099,7 +7039,7 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 3, name: d}
+                  Variable: {subprogram: 74, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -7108,11 +7048,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 4, name: e}
+                  Variable: {subprogram: 74, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 356
+      ID: 357
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7123,11 +7063,11 @@ Types:
             Type: 220 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: c}
+                  Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 357
+      ID: 358
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7138,11 +7078,11 @@ Types:
             Type: 221 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 359
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7153,11 +7093,11 @@ Types:
             Type: 162 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 359
+      ID: 360
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7168,11 +7108,11 @@ Types:
             Type: 163 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 361
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7183,11 +7123,11 @@ Types:
             Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 362
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7198,11 +7138,11 @@ Types:
             Type: 223 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 363
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7213,11 +7153,11 @@ Types:
             Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 364
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7228,7 +7168,7 @@ Types:
             Type: 224 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 82, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -7237,11 +7177,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7252,27 +7192,12 @@ Types:
             Type: 225 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: t}
+                  Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 228 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 366
-      Name: Probe[main.testEmptySlice]
+      Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
@@ -7287,6 +7212,21 @@ Types:
                   ByteSize: 24
     - __kind: EventRootType
       ID: 367
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 228 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 368
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7297,36 +7237,12 @@ Types:
             Type: 229 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
-    - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 369
-      Name: Probe[main.testEmptySliceOfStructs]
+      Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -7350,7 +7266,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 370
-      Name: Probe[main.testNilSliceOfStructs]
+      Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -7374,6 +7290,30 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 371
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7384,11 +7324,11 @@ Types:
             Type: 123 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: s}
+                  Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 372
+      ID: 373
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7399,7 +7339,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -7408,7 +7348,7 @@ Types:
             Type: 234 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: s}
+                  Variable: {subprogram: 91, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -7417,11 +7357,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: x}
+                  Variable: {subprogram: 91, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 374
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7432,11 +7372,11 @@ Types:
             Type: 235 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 375
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7447,31 +7387,16 @@ Types:
             Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 375
+      ID: 376
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 376
+      ID: 377
       Name: Probe[main.testSingleString]
       ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testThreeStrings]
-      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -7483,13 +7408,28 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: y}
+                  Variable: {subprogram: 96, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -7498,11 +7438,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 2, name: z}
+                  Variable: {subprogram: 96, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 378
+      ID: 379
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7513,11 +7453,11 @@ Types:
             Type: 237 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 379
+      ID: 380
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7528,11 +7468,11 @@ Types:
             Type: 238 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 381
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7543,27 +7483,12 @@ Types:
             Type: 239 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testMassiveString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
       ID: 382
-      Name: Probe[main.testUnitializedString]
+      Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -7578,7 +7503,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 383
-      Name: Probe[main.testEmptyString]
+      Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -7593,6 +7518,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 384
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 385
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7603,11 +7543,11 @@ Types:
             Type: 241 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 385
+      ID: 386
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7618,11 +7558,11 @@ Types:
             Type: 242 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: e}
+                  Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 386
+      ID: 387
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7637,16 +7577,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 387
+      ID: 388
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 388
+      ID: 389
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 389
+      ID: 390
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 390
+      ID: 391
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7661,7 +7601,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 391
+      ID: 392
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7675,5 +7615,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 391
+MaxTypeID: 392
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 356 EventRootType Probe[main.stackC]
+          Type: 369 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd83ca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 313 EventRootType Probe[main.testAny]
+          Type: 326 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd542a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 283 EventRootType Probe[main.testArrayOfArrays]
+          Type: 296 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd3e60", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 285 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 321 EventRootType Probe[main.testArrayOfMaps]
+          Type: 334 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd59c0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 284 EventRootType Probe[main.testArrayOfStrings]
+          Type: 297 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd3e80", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 303 EventRootType Probe[main.testBigStruct]
+          Type: 316 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd45c0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 272 EventRootType Probe[main.testBoolArray]
+          Type: 285 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd3d00", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 269 EventRootType Probe[main.testByteArray]
+          Type: 282 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd3ca0", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 337 EventRootType Probe[main.testChannel]
+          Type: 350 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd7680", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 335 EventRootType Probe[main.testCombinedByte]
+          Type: 348 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd72a0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 345 EventRootType Probe[main.testCycle]
+          Type: 358 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 347 EventRootType Probe[main.testEmptySlice]
+          Type: 360 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd7f80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 350 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 364 EventRootType Probe[main.testEmptyString]
+          Type: 377 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 366 EventRootType Probe[main.testEmptyStruct]
+          Type: 379 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcd8900", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 314 EventRootType Probe[main.testError]
+          Type: 327 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 305 EventRootType Probe[main.testEsotericHeap]
+          Type: 318 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd496a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 304 EventRootType Probe[main.testEsotericStack]
+          Type: 317 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd484e", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 310 EventRootType Probe[main.testFrameless]
+          Type: 323 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 311 EventRootType Probe[main.testFramelessArray]
+          Type: 324 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd50e4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 306 EventRootType Probe[main.testInlinedBA]
+          Type: 319 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd4daa", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 307 EventRootType Probe[main.testInlinedBB]
+          Type: 320 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd4e4e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 308 EventRootType Probe[main.testInlinedBBA]
+          Type: 321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd4f2a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 368 EventRootType Probe[main.testInlinedBBB]
+          Type: 381 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd4ea6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 309 EventRootType Probe[main.testInlinedBC]
+          Type: 322 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd4fae", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 369 EventRootType Probe[main.testInlinedBCA]
+          Type: 382 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd4fb3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 370 EventRootType Probe[main.testInlinedBCB]
+          Type: 383 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5066", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 367 EventRootType Probe[main.testInlinedPrint]
+          Type: 380 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd4c0a"
               Frameless: false
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 371 EventRootType Probe[main.testInlinedSq]
+          Type: 384 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd50c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 372 EventRootType Probe[main.testInlinedSumArray]
+          Type: 385 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5105"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 275 EventRootType Probe[main.testInt16Array]
+          Type: 288 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd3d60", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 276 EventRootType Probe[main.testInt32Array]
+          Type: 289 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd3d80", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 277 EventRootType Probe[main.testInt64Array]
+          Type: 290 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd3da0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 274 EventRootType Probe[main.testInt8Array]
+          Type: 287 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd3d40", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 273 EventRootType Probe[main.testIntArray]
+          Type: 286 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd3d20", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 312 EventRootType Probe[main.testInterface]
+          Type: 325 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd53ca", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 339 EventRootType Probe[main.testLinkedList]
+          Type: 352 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd7860", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 319 EventRootType Probe[main.testMapArrayToArray]
+          Type: 332 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd5980", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 325 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 323 EventRootType Probe[main.testMapIntToInt]
+          Type: 336 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd5a00", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 334 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd5b60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 333 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 324 EventRootType Probe[main.testMapMassive]
+          Type: 337 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 332 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd5b20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 331 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd5b00", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 317 EventRootType Probe[main.testMapStringToInt]
+          Type: 330 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 318 EventRootType Probe[main.testMapStringToSlice]
+          Type: 331 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd5960", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 316 EventRootType Probe[main.testMapStringToStruct]
+          Type: 329 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 326 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd5a60", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd5ae0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 327 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd5a80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 328 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 362 EventRootType Probe[main.testMassiveString]
+          Type: 375 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 336 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 344 EventRootType Probe[main.testNilPointer]
+          Type: 357 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd7a00", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 354 EventRootType Probe[main.testNilSlice]
+          Type: 367 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 351 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 353 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 361 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 340 EventRootType Probe[main.testPointerLoop]
+          Type: 353 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd7880", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 322 EventRootType Probe[main.testPointerToMap]
+          Type: 335 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd59e0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 338 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd7840", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 270 EventRootType Probe[main.testRuneArray]
+          Type: 283 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd3cc0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 289 EventRootType Probe[main.testSingleBool]
+          Type: 302 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 287 EventRootType Probe[main.testSingleByte]
+          Type: 300 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 300 EventRootType Probe[main.testSingleFloat32]
+          Type: 313 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4420", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 301 EventRootType Probe[main.testSingleFloat64]
+          Type: 314 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd4440", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 290 EventRootType Probe[main.testSingleInt]
+          Type: 303 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 292 EventRootType Probe[main.testSingleInt16]
+          Type: 305 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 293 EventRootType Probe[main.testSingleInt32]
+          Type: 306 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 294 EventRootType Probe[main.testSingleInt64]
+          Type: 307 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 291 EventRootType Probe[main.testSingleInt8]
+          Type: 304 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 288 EventRootType Probe[main.testSingleRune]
+          Type: 301 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 357 EventRootType Probe[main.testSingleString]
+          Type: 370 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 295 EventRootType Probe[main.testSingleUint]
+          Type: 308 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4380", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 297 EventRootType Probe[main.testSingleUint16]
+          Type: 310 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd43c0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 298 EventRootType Probe[main.testSingleUint32]
+          Type: 311 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd43e0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 299 EventRootType Probe[main.testSingleUint64]
+          Type: 312 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4400", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 296 EventRootType Probe[main.testSingleUint8]
+          Type: 309 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 348 EventRootType Probe[main.testSliceOfSlices]
+          Type: 361 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 320 EventRootType Probe[main.testSmallMap]
+          Type: 333 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd59a0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 271 EventRootType Probe[main.testStringArray]
+          Type: 284 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd3ce0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 343 EventRootType Probe[main.testStringPointer]
+          Type: 356 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 352 EventRootType Probe[main.testStringSlice]
+          Type: 365 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 365 EventRootType Probe[main.testStruct]
+          Type: 378 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 349 EventRootType Probe[main.testStructSlice]
+          Type: 362 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 315 EventRootType Probe[main.testStructWithMap]
+          Type: 328 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 358 EventRootType Probe[main.testThreeStrings]
+          Type: 371 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 359 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 360 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 302 EventRootType Probe[main.testTypeAlias]
+          Type: 315 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4460", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 280 EventRootType Probe[main.testUint16Array]
+          Type: 293 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd3e00", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 281 EventRootType Probe[main.testUint32Array]
+          Type: 294 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd3e20", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 282 EventRootType Probe[main.testUint64Array]
+          Type: 295 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd3e40", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 279 EventRootType Probe[main.testUint8Array]
+          Type: 292 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd3de0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 278 EventRootType Probe[main.testUintArray]
+          Type: 291 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd3dc0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 342 EventRootType Probe[main.testUintPointer]
+          Type: 355 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd78e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 346 EventRootType Probe[main.testUintSlice]
+          Type: 359 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 363 EventRootType Probe[main.testUnitializedString]
+          Type: 376 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 341 EventRootType Probe[main.testUnsafePointer]
+          Type: 354 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd78a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 286 EventRootType Probe[main.testVeryLargeArray]
+          Type: 299 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd3f00", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 355 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 226 PointerType *string.str
+          Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 225 GoStringDataType string.str
+      Data: 238 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 227 GoSliceDataType []*string.array
+      Data: 240 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3686,7 +3686,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<int,int>.array
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
       GroupType: 68 StructureType noalg.map.group[int]int
     - __kind: BaseType
       ID: 62
@@ -3741,7 +3741,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[int]int.array
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
       ID: 67
       Name: '*noalg.map.group[int]int'
@@ -3824,7 +3824,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,main.nestedStruct>.array
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
       GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
       ID: 74
@@ -3873,7 +3873,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
       ID: 78
       Name: '*noalg.map.group[string]main.nestedStruct'
@@ -3969,7 +3969,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<string,int>.array
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
       GroupType: 91 StructureType noalg.map.group[string]int
     - __kind: PointerType
       ID: 86
@@ -4018,7 +4018,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]int.array
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
       ID: 90
       Name: '*noalg.map.group[string]int'
@@ -4101,7 +4101,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
       GroupType: 102 StructureType noalg.map.group[string][]string
     - __kind: PointerType
       ID: 97
@@ -4150,7 +4150,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 101
       Name: '*noalg.map.group[string][]string'
@@ -4207,7 +4207,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 237 GoSliceDataType []string.array
+      Data: 250 GoSliceDataType []string.array
     - __kind: GoMapType
       ID: 106
       Name: map[[4]string][2]int
@@ -4250,7 +4250,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<[4]string,[2]int>.array
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
       GroupType: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 109
@@ -4299,7 +4299,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
       ID: 113
       Name: '*noalg.map.group[[4]string][2]int'
@@ -4405,7 +4405,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
       GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
       ID: 123
@@ -4454,7 +4454,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
       ID: 127
       Name: '*noalg.map.group[string][]main.structWithMap'
@@ -4511,7 +4511,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 243 GoSliceDataType []main.structWithMap.array
+      Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 132
       Name: '*main.structWithMap'
@@ -4561,7 +4561,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<bool,main.node>.array
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
       GroupType: 141 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
       ID: 136
@@ -4610,7 +4610,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
       ID: 140
       Name: '*noalg.map.group[bool]main.node'
@@ -4713,7 +4713,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<int,uint8>.array
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
       GroupType: 154 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
       ID: 149
@@ -4762,7 +4762,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
       ID: 153
       Name: '*noalg.map.group[int]uint8'
@@ -4845,7 +4845,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<uint8,uint8>.array
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
       GroupType: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 160
@@ -4894,7 +4894,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
       ID: 164
       Name: '*noalg.map.group[uint8]uint8'
@@ -4977,7 +4977,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<uint8,[4]int>.array
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
       GroupType: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
       ID: 171
@@ -5026,7 +5026,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
       ID: 175
       Name: '*noalg.map.group[uint8][4]int'
@@ -5118,7 +5118,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,uint8>.array
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
       GroupType: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
       ID: 183
@@ -5167,7 +5167,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
       ID: 187
       Name: '*noalg.map.group[[4]int]uint8'
@@ -5250,7 +5250,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 255 GoSliceDataType []*table<[4]int,[4]int>.array
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
       GroupType: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 194
@@ -5299,7 +5299,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 256 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
       ID: 198
       Name: '*noalg.map.group[[4]int][4]int'
@@ -5398,7 +5398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 257 GoSliceDataType main.t.array
+      Data: 270 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 209
       Name: '**main.t'
@@ -5420,7 +5420,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 259 GoSliceDataType []uint.array
+      Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
       ID: 211
       Name: '[][]uint'
@@ -5436,7 +5436,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 261 GoSliceDataType [][]uint.array
+      Data: 274 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 212
       Name: '*[]uint'
@@ -5457,7 +5457,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 263 GoSliceDataType []main.structWithNoStrings.array
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 214
       Name: '*main.structWithNoStrings'
@@ -5491,7 +5491,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 265 GoSliceDataType []bool.array
+      Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
       ID: 217
       Name: '[]uint16'
@@ -5508,7 +5508,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 267 GoSliceDataType []uint16.array
+      Data: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 218
       Name: '*uint16'
@@ -5575,227 +5575,316 @@ Types:
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 385920
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
+    - __kind: PointerType
+      ID: 226
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 385536
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 385600
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 575776
+      GoKind: 15
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 575840
+      GoKind: 16
+    - __kind: PointerType
+      ID: 230
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 386176
+      GoKind: 22
+      Pointee: 31 BaseType float64
+    - __kind: PointerType
+      ID: 231
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 385664
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 232
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 385792
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 233
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 385728
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 234
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 385408
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 235
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 385280
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 236
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 385152
+      GoKind: 22
+      Pointee: 57 GoInterfaceType error
+    - __kind: PointerType
+      ID: 237
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 386112
+      GoKind: 22
+      Pointee: 30 BaseType float32
+    - __kind: GoStringDataType
+      ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 226
+      ID: 239
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 225 GoStringDataType string.str
+      Pointee: 238 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 228
+      ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []*string.array
+      Pointee: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 64 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 68 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
       Element: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 87 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
       Element: 91 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 98 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 102 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 250
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 238
+      ID: 251
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []string.array
+      Pointee: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
       Element: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
       Element: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 244
+      ID: 257
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []main.structWithMap.array
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
       Element: 141 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 150 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
       Element: 154 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 161 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
       Element: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 172 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
       Element: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 184 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
       Element: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 195 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
       Element: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 270
       Name: main.t.array
       ByteSize: 2048
       Element: 207 PointerType *main.t
     - __kind: PointerType
-      ID: 258
+      ID: 271
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType main.t.array
+      Pointee: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 260
+      ID: 273
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []uint.array
+      Pointee: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 210 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 262
+      ID: 275
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType [][]uint.array
+      Pointee: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 264
+      ID: 277
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 266
+      ID: 279
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []bool.array
+      Pointee: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 268
+      ID: 281
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType []uint16.array
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 269
+      ID: 282
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5810,7 +5899,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 270
+      ID: 283
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5825,7 +5914,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 284
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5840,7 +5929,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 272
+      ID: 285
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5855,7 +5944,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 273
+      ID: 286
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5870,7 +5959,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 287
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5885,7 +5974,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 275
+      ID: 288
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5900,7 +5989,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 276
+      ID: 289
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5915,7 +6004,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 290
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5930,7 +6019,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 291
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5945,7 +6034,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 292
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5960,7 +6049,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 280
+      ID: 293
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5975,7 +6064,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 281
+      ID: 294
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5990,7 +6079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 295
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6005,7 +6094,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 296
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6020,7 +6109,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 284
+      ID: 297
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6035,7 +6124,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 285
+      ID: 298
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6050,7 +6139,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 286
+      ID: 299
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -6065,7 +6154,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 287
+      ID: 300
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6080,7 +6169,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 288
+      ID: 301
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6095,7 +6184,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 302
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6110,7 +6199,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 290
+      ID: 303
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6125,7 +6214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 304
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6140,7 +6229,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 292
+      ID: 305
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6155,7 +6244,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 306
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6170,7 +6259,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 307
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6185,7 +6274,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 308
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6200,7 +6289,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 309
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6215,7 +6304,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 297
+      ID: 310
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6230,7 +6319,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 298
+      ID: 311
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6245,7 +6334,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 299
+      ID: 312
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6260,7 +6349,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 313
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6275,7 +6364,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 301
+      ID: 314
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6290,7 +6379,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 315
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6305,7 +6394,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 303
+      ID: 316
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6320,7 +6409,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 304
+      ID: 317
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6335,7 +6424,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 305
+      ID: 318
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6350,7 +6439,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 319
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6365,7 +6454,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 320
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6389,7 +6478,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 321
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6404,10 +6493,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 322
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 310
+      ID: 323
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6422,7 +6511,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 324
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6437,7 +6526,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 312
+      ID: 325
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6452,7 +6541,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 326
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6467,7 +6556,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 314
+      ID: 327
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6482,7 +6571,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 328
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6497,7 +6586,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 329
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6512,7 +6601,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 330
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6527,7 +6616,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 331
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6542,7 +6631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 332
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6557,7 +6646,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 333
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6572,7 +6661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 334
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6587,7 +6676,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
+      ID: 335
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6602,7 +6691,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 336
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6617,7 +6706,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 337
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6632,7 +6721,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 338
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6647,7 +6736,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 339
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6662,7 +6751,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 340
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6677,7 +6766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 341
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6692,7 +6781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 342
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6707,7 +6796,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 343
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,7 +6811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 344
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6737,7 +6826,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 345
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6752,7 +6841,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 346
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,7 +6856,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 347
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,7 +6871,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 348
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6815,7 +6904,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 336
+      ID: 349
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6866,7 +6955,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 337
+      ID: 350
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6881,7 +6970,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 338
+      ID: 351
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6896,7 +6985,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 352
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6911,7 +7000,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 353
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6926,7 +7015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 354
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6941,7 +7030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 355
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6956,7 +7045,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 356
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6971,7 +7060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6995,7 +7084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 358
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7010,7 +7099,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 359
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7025,7 +7114,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 347
+      ID: 360
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7040,7 +7129,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 348
+      ID: 361
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7055,7 +7144,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 349
+      ID: 362
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7079,7 +7168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 363
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7103,7 +7192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 364
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7127,7 +7216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 365
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7142,7 +7231,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 353
+      ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7175,7 +7264,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 367
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7190,7 +7279,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 355
+      ID: 368
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7205,10 +7294,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 356
+      ID: 369
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 357
+      ID: 370
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7223,7 +7312,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 358
+      ID: 371
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7256,7 +7345,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 359
+      ID: 372
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7271,7 +7360,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 360
+      ID: 373
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7286,7 +7375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 374
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7301,7 +7390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 375
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7316,7 +7405,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 363
+      ID: 376
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7331,7 +7420,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 364
+      ID: 377
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7346,7 +7435,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 365
+      ID: 378
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7361,7 +7450,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 366
+      ID: 379
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7376,7 +7465,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 367
+      ID: 380
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7391,16 +7480,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 381
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 369
+      ID: 382
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 370
+      ID: 383
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 371
+      ID: 384
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7415,7 +7504,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 385
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7429,5 +7518,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 372
+MaxTypeID: 385
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 376 EventRootType Probe[main.stackC]
+          Type: 356 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcd83ca", Frameless: false}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 333 EventRootType Probe[main.testAny]
+          Type: 313 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0xcd542a", Frameless: false}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 303 EventRootType Probe[main.testArrayOfArrays]
+          Type: 283 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0xcd3e60", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 285 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0xcd3ea0", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 341 EventRootType Probe[main.testArrayOfMaps]
+          Type: 321 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0xcd59c0", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 304 EventRootType Probe[main.testArrayOfStrings]
+          Type: 284 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0xcd3e80", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 323 EventRootType Probe[main.testBigStruct]
+          Type: 303 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0xcd45c0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 292 EventRootType Probe[main.testBoolArray]
+          Type: 272 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0xcd3d00", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 289 EventRootType Probe[main.testByteArray]
+          Type: 269 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0xcd3ca0", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 357 EventRootType Probe[main.testChannel]
+          Type: 337 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd7680", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 355 EventRootType Probe[main.testCombinedByte]
+          Type: 335 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0xcd72a0", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 365 EventRootType Probe[main.testCycle]
+          Type: 345 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd7a40", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 367 EventRootType Probe[main.testEmptySlice]
+          Type: 347 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcd7f80", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 370 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 350 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcd7fe0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 384 EventRootType Probe[main.testEmptyString]
+          Type: 364 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcd8500", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 386 EventRootType Probe[main.testEmptyStruct]
+          Type: 366 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcd8900", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 334 EventRootType Probe[main.testError]
+          Type: 314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0xcd54a0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 325 EventRootType Probe[main.testEsotericHeap]
+          Type: 305 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0xcd496a", Frameless: false}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 324 EventRootType Probe[main.testEsotericStack]
+          Type: 304 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0xcd484e", Frameless: false}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 330 EventRootType Probe[main.testFrameless]
+          Type: 310 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0xcd50c0", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 331 EventRootType Probe[main.testFramelessArray]
+          Type: 311 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0xcd50e4", Frameless: false}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 326 EventRootType Probe[main.testInlinedBA]
+          Type: 306 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0xcd4daa", Frameless: false}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 327 EventRootType Probe[main.testInlinedBB]
+          Type: 307 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0xcd4e4e", Frameless: false}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 328 EventRootType Probe[main.testInlinedBBA]
+          Type: 308 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0xcd4f2a", Frameless: false}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 388 EventRootType Probe[main.testInlinedBBB]
+          Type: 368 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd4ea6", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 329 EventRootType Probe[main.testInlinedBC]
+          Type: 309 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0xcd4fae", Frameless: false}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 389 EventRootType Probe[main.testInlinedBCA]
+          Type: 369 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd4fb3", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 390 EventRootType Probe[main.testInlinedBCB]
+          Type: 370 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5066", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 387 EventRootType Probe[main.testInlinedPrint]
+          Type: 367 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd4c0a"
               Frameless: false
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 391 EventRootType Probe[main.testInlinedSq]
+          Type: 371 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd50c1", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 392 EventRootType Probe[main.testInlinedSumArray]
+          Type: 372 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5105"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 295 EventRootType Probe[main.testInt16Array]
+          Type: 275 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0xcd3d60", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 296 EventRootType Probe[main.testInt32Array]
+          Type: 276 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0xcd3d80", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 297 EventRootType Probe[main.testInt64Array]
+          Type: 277 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0xcd3da0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 294 EventRootType Probe[main.testInt8Array]
+          Type: 274 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0xcd3d40", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 293 EventRootType Probe[main.testIntArray]
+          Type: 273 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0xcd3d20", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 332 EventRootType Probe[main.testInterface]
+          Type: 312 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0xcd53ca", Frameless: false}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 359 EventRootType Probe[main.testLinkedList]
+          Type: 339 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd7860", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 339 EventRootType Probe[main.testMapArrayToArray]
+          Type: 319 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0xcd5980", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 345 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 325 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0xcd5a40", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 343 EventRootType Probe[main.testMapIntToInt]
+          Type: 323 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0xcd5a00", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 354 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 334 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0xcd5b60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 353 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 333 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0xcd5b40", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 344 EventRootType Probe[main.testMapMassive]
+          Type: 324 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0xcd5a20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 352 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 332 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0xcd5b20", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 351 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 331 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0xcd5b00", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 337 EventRootType Probe[main.testMapStringToInt]
+          Type: 317 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0xcd5940", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 338 EventRootType Probe[main.testMapStringToSlice]
+          Type: 318 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0xcd5960", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 336 EventRootType Probe[main.testMapStringToStruct]
+          Type: 316 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0xcd5920", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 346 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 326 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0xcd5a60", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0xcd5ac0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 350 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0xcd5ae0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 347 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 327 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0xcd5a80", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 348 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 328 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0xcd5aa0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 382 EventRootType Probe[main.testMassiveString]
+          Type: 362 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcd84c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 356 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 336 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd7460", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 364 EventRootType Probe[main.testNilPointer]
+          Type: 344 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd7a00", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 374 EventRootType Probe[main.testNilSlice]
+          Type: 354 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcd8060", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 371 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 351 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcd8000", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 373 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 353 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcd8040", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 381 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 361 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcd84a0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 360 EventRootType Probe[main.testPointerLoop]
+          Type: 340 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd7880", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 342 EventRootType Probe[main.testPointerToMap]
+          Type: 322 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0xcd59e0", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 358 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 338 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd7840", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 290 EventRootType Probe[main.testRuneArray]
+          Type: 270 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0xcd3cc0", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 309 EventRootType Probe[main.testSingleBool]
+          Type: 289 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0xcd42c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 307 EventRootType Probe[main.testSingleByte]
+          Type: 287 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0xcd4280", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 320 EventRootType Probe[main.testSingleFloat32]
+          Type: 300 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0xcd4420", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 321 EventRootType Probe[main.testSingleFloat64]
+          Type: 301 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0xcd4440", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 310 EventRootType Probe[main.testSingleInt]
+          Type: 290 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0xcd42e0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 312 EventRootType Probe[main.testSingleInt16]
+          Type: 292 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0xcd4320", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 313 EventRootType Probe[main.testSingleInt32]
+          Type: 293 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0xcd4340", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 314 EventRootType Probe[main.testSingleInt64]
+          Type: 294 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0xcd4360", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 311 EventRootType Probe[main.testSingleInt8]
+          Type: 291 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0xcd4300", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 308 EventRootType Probe[main.testSingleRune]
+          Type: 288 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0xcd42a0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 377 EventRootType Probe[main.testSingleString]
+          Type: 357 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcd8420", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 315 EventRootType Probe[main.testSingleUint]
+          Type: 295 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0xcd4380", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 317 EventRootType Probe[main.testSingleUint16]
+          Type: 297 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0xcd43c0", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 318 EventRootType Probe[main.testSingleUint32]
+          Type: 298 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0xcd43e0", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 319 EventRootType Probe[main.testSingleUint64]
+          Type: 299 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0xcd4400", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 316 EventRootType Probe[main.testSingleUint8]
+          Type: 296 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0xcd43a0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 368 EventRootType Probe[main.testSliceOfSlices]
+          Type: 348 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcd7fa0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 340 EventRootType Probe[main.testSmallMap]
+          Type: 320 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0xcd59a0", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 291 EventRootType Probe[main.testStringArray]
+          Type: 271 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0xcd3ce0", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 363 EventRootType Probe[main.testStringPointer]
+          Type: 343 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd79c0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 372 EventRootType Probe[main.testStringSlice]
+          Type: 352 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcd8020", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 385 EventRootType Probe[main.testStruct]
+          Type: 365 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcd8780", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 369 EventRootType Probe[main.testStructSlice]
+          Type: 349 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcd7fc0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 335 EventRootType Probe[main.testStructWithMap]
+          Type: 315 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0xcd5900", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 378 EventRootType Probe[main.testThreeStrings]
+          Type: 358 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcd8440", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 379 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 359 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 380 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 360 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcd8480", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 322 EventRootType Probe[main.testTypeAlias]
+          Type: 302 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0xcd4460", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 300 EventRootType Probe[main.testUint16Array]
+          Type: 280 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0xcd3e00", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 301 EventRootType Probe[main.testUint32Array]
+          Type: 281 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0xcd3e20", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 302 EventRootType Probe[main.testUint64Array]
+          Type: 282 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0xcd3e40", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 299 EventRootType Probe[main.testUint8Array]
+          Type: 279 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0xcd3de0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 298 EventRootType Probe[main.testUintArray]
+          Type: 278 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0xcd3dc0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 362 EventRootType Probe[main.testUintPointer]
+          Type: 342 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd78e0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 366 EventRootType Probe[main.testUintSlice]
+          Type: 346 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcd7f60", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 383 EventRootType Probe[main.testUnitializedString]
+          Type: 363 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcd84e0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 361 EventRootType Probe[main.testUnsafePointer]
+          Type: 341 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd78a0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 306 EventRootType Probe[main.testVeryLargeArray]
+          Type: 286 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0xcd3f00", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 375 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 355 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcd8080", Frameless: true}]
           Condition: null
 Subprograms:
@@ -1911,7 +1911,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
           Locations:
             - Range: 0xcd4840..0xcd4893
               Pieces:
@@ -1981,7 +1981,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 63 PointerType *main.esotericHeap
+          Type: 44 PointerType *main.esotericHeap
           Locations:
             - Range: 0xcd4960..0xcd498d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 75 GoInterfaceType main.behavior
+          Type: 56 GoInterfaceType main.behavior
           Locations:
             - Range: 0xcd53c0..0xcd53df
               Pieces:
@@ -2133,7 +2133,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0xcd5420..0xcd5449
               Pieces:
@@ -2160,7 +2160,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 76 GoInterfaceType error
+          Type: 57 GoInterfaceType error
           Locations:
             - Range: 0xcd54a0..0xcd54a1
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 77 StructureType main.structWithMap
+          Type: 58 StructureType main.structWithMap
           Locations:
             - Range: 0xcd5900..0xcd5901
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 89 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0xcd5920..0xcd5921
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 83 GoMapType map[string]int
           Locations:
             - Range: 0xcd5940..0xcd5941
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[string][]string
+          Type: 94 GoMapType map[string][]string
           Locations:
             - Range: 0xcd5960..0xcd5961
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 124 GoMapType map[[4]string][2]int
+          Type: 106 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0xcd5980..0xcd5981
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 83 GoMapType map[string]int
           Locations:
             - Range: 0xcd59a0..0xcd59a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 ArrayType [2]map[string]int
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0xcd59c0..0xcd59c1
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 PointerType *map[string]int
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0xcd59e0..0xcd59e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 78 GoMapType map[int]int
+          Type: 59 GoMapType map[int]int
           Locations:
             - Range: 0xcd5a00..0xcd5a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a20..0xcd5a21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0xcd5a40..0xcd5a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[bool]main.node
+          Type: 133 GoMapType map[bool]main.node
           Locations:
             - Range: 0xcd5a60..0xcd5a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[int]uint8
+          Type: 146 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5a80..0xcd5a81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
+          Type: 146 GoMapType map[int]uint8
           Locations:
             - Range: 0xcd5aa0..0xcd5aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ac0..0xcd5ac1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5ae0..0xcd5ae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0xcd5b00..0xcd5b01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[uint8][4]int
+          Type: 168 GoMapType map[uint8][4]int
           Locations:
             - Range: 0xcd5b20..0xcd5b21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 180 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0xcd5b40..0xcd5b41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 191 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0xcd5b60..0xcd5b61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 220 GoChannelType chan bool
+          Type: 202 GoChannelType chan bool
           Locations:
             - Range: 0xcd7680..0xcd7681
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.structWithTwoValues
+          Type: 203 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0xcd7840..0xcd7841
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 162 StructureType main.node
+          Type: 144 StructureType main.node
           Locations:
             - Range: 0xcd7860..0xcd7861
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 163 PointerType *main.node
+          Type: 145 PointerType *main.node
           Locations:
             - Range: 0xcd7880..0xcd7881
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2538,7 +2538,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0xcd78a0..0xcd78a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2550,7 +2550,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 PointerType *uint
+          Type: 205 PointerType *uint
           Locations:
             - Range: 0xcd78e0..0xcd78e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2574,7 +2574,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 224 PointerType *bool
+          Type: 206 PointerType *bool
           Locations:
             - Range: 0xcd7a00..0xcd7a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 225 PointerType *main.t
+          Type: 207 PointerType *main.t
           Locations:
             - Range: 0xcd7a40..0xcd7a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f60..0xcd7f61
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd7f80..0xcd7f81
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 229 GoSliceHeaderType [][]uint
+          Type: 211 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcd7fa0..0xcd7fa1
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fc0..0xcd7fc1
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd7fe0..0xcd7fe1
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcd8000..0xcd8001
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 123 GoSliceHeaderType []string
+          Type: 105 GoSliceHeaderType []string
           Locations:
             - Range: 0xcd8020..0xcd8021
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 234 GoSliceHeaderType []bool
+          Type: 216 GoSliceHeaderType []bool
           Locations:
             - Range: 0xcd8040..0xcd8041
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 235 GoSliceHeaderType []uint16
+          Type: 217 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcd8060..0xcd8061
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcd8080..0xcd8081
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 237 StructureType main.threeStringStruct
+          Type: 219 StructureType main.threeStringStruct
           Locations:
             - Range: 0xcd8460..0xcd847f
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 238 PointerType *main.threeStringStruct
+          Type: 220 PointerType *main.threeStringStruct
           Locations:
             - Range: 0xcd8480..0xcd8481
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 239 PointerType *main.oneStringStruct
+          Type: 221 PointerType *main.oneStringStruct
           Locations:
             - Range: 0xcd84a0..0xcd84a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 241 StructureType main.aStruct
+          Type: 223 StructureType main.aStruct
           Locations:
             - Range: 0xcd8780..0xcd87a3
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 242 StructureType main.emptyStruct
+          Type: 224 StructureType main.emptyStruct
           Locations: [{Range: 0xcd8900..0xcd8901, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 244 PointerType *string.str
+          Type: 226 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 243 GoStringDataType string.str
+      Data: 225 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 245 GoSliceDataType []*string.array
+      Data: 227 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3383,215 +3383,21 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.012448e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 38
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 39 PointerType *internal/abi.ITab
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 39
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 409792
-      GoKind: 22
-      Pointee: 40 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 40
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.742976e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 41 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 54 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 55 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 41
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.189376e+06
-      GoKind: 22
-      Pointee: 42 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 42
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.619808e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 43 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 50 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 51 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 43
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.111168e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 44 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 44 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 45 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 4 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 4 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 46 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 9 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 44
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 575712
-      GoKind: 12
-    - __kind: BaseType
-      ID: 45
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 578720
-      GoKind: 8
-    - __kind: BaseType
-      ID: 46
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 824800
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 47
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 834880
-      GoKind: 19
-    - __kind: BaseType
-      ID: 48
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 578784
-      GoKind: 5
-    - __kind: BaseType
-      ID: 49
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 578848
-      GoKind: 5
-    - __kind: StructureType
-      ID: 50
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.955008e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 9 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 51
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 499296
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 52 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 247 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 52
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 409728
-      GoKind: 22
-      Pointee: 53 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 53
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.470624e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: PointerType
-      ID: 54
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.189824e+06
-      GoKind: 22
-      Pointee: 43 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 55
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 674336
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 44 BaseType uintptr
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 56
+      ID: 38
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 576096
       GoKind: 26
     - __kind: StructureType
-      ID: 57
+      ID: 39
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.945504e+06
@@ -3605,65 +3411,65 @@ Types:
           Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 58 GoChannelType chan struct {}
+          Type: 40 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 61 GoInterfaceType main.something
+          Type: 42 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 62 GoSubroutineType func()
+          Type: 43 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 58
+      ID: 40
       Name: chan struct {}
       GoRuntimeType: 586272
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 59
+      ID: 41
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 838336
       GoKind: 20
-      UnderlyingStructure: 60 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 60
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 54 PointerType *internal/abi.Type
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 42
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.012192e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 62
+      ID: 43
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468928
       GoKind: 19
     - __kind: PointerType
-      ID: 63
+      ID: 44
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380224
       GoKind: 22
-      Pointee: 64 StructureType main.esotericHeap
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 64
+      ID: 45
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.81168e+06
@@ -3671,21 +3477,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 68 StructureType sync.Once
+          Type: 49 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 71 StructureType sync.WaitGroup
+          Type: 52 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 74 StructureType sync/atomic.Int32
+          Type: 55 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 65
+      ID: 46
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.445344e+06
@@ -3693,18 +3499,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 67 StructureType internal/sync.Mutex
+          Type: 48 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 47
       Name: sync.noCopy
       GoRuntimeType: 977728
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 67
+      ID: 48
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.454624e+06
@@ -3717,7 +3523,7 @@ Types:
           Offset: 4
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 49
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593696e+06
@@ -3725,15 +3531,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 69 StructureType sync/atomic.Uint32
+          Type: 50 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 50
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446784e+06
@@ -3741,18 +3547,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 51
       Name: sync/atomic.noCopy
       GoRuntimeType: 977824
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 52
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593888e+06
@@ -3760,15 +3566,15 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 72 StructureType sync/atomic.Uint64
+          Type: 53 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 72
+      ID: 53
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.594272e+06
@@ -3776,21 +3582,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 73 StructureType sync/atomic.align64
+          Type: 54 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 73
+      ID: 54
       Name: sync/atomic.align64
       GoRuntimeType: 977920
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 74
+      ID: 55
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.446624e+06
@@ -3798,26 +3604,38 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 56
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.012064e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 76
+      ID: 57
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.016416e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 77
+      ID: 58
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.173504e+06
@@ -3825,21 +3643,21 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 78 GoMapType map[int]int
+          Type: 59 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 78
+      ID: 59
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.117184e+06
       GoKind: 21
-      HeaderType: 80 GoSwissMapHeaderType map<int,int>
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 79
+      ID: 60
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 80 GoSwissMapHeaderType map<int,int>
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
     - __kind: GoSwissMapHeaderType
-      ID: 80
+      ID: 61
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -3849,10 +3667,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 81 PointerType **table<int,int>
+          Type: 63 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -3868,20 +3686,26 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<int,int>.array
-      GroupType: 86 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 229 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 575712
+      GoKind: 12
     - __kind: PointerType
-      ID: 81
+      ID: 63
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 82 PointerType *table<int,int>
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 82
+      ID: 64
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 83 StructureType table<int,int>
+      Pointee: 65 StructureType table<int,int>
     - __kind: StructureType
-      ID: 83
+      ID: 65
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -3903,28 +3727,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 84 GoSwissMapGroupsType groupReference<int,int>
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
     - __kind: GoSwissMapGroupsType
-      ID: 84
+      ID: 66
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 85 PointerType *noalg.map.group[int]int
+          Type: 67 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 86 StructureType noalg.map.group[int]int
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 230 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
-      ID: 85
+      ID: 67
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 86 StructureType noalg.map.group[int]int
+      Pointee: 68 StructureType noalg.map.group[int]int
     - __kind: StructureType
-      ID: 86
+      ID: 68
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.27648e+06
@@ -3935,18 +3759,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 87 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: ArrayType
-      ID: 87
+      ID: 69
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671264
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 88 StructureType noalg.struct { key int; elem int }
+      Element: 70 StructureType noalg.struct { key int; elem int }
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.276352e+06
@@ -3959,19 +3783,19 @@ Types:
           Offset: 8
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 89
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.118592e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -3981,10 +3805,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4000,20 +3824,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 92
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 StructureType table<string,main.nestedStruct>
+      Pointee: 76 StructureType table<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -4035,28 +3859,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 95 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 95
+      ID: 77
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 96 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 97 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.279296e+06
@@ -4067,18 +3891,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 98 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 98
+      ID: 80
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 99 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 99
+      ID: 81
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.279168e+06
@@ -4089,9 +3913,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 100 StructureType main.nestedStruct
+          Type: 82 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.444064e+06
@@ -4104,19 +3928,19 @@ Types:
           Offset: 8
           Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 101
+      ID: 83
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.118464e+06
       GoKind: 21
-      HeaderType: 103 GoSwissMapHeaderType map<string,int>
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 102
+      ID: 84
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 103 GoSwissMapHeaderType map<string,int>
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 103
+      ID: 85
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -4126,10 +3950,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 104 PointerType **table<string,int>
+          Type: 86 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4145,20 +3969,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<string,int>.array
-      GroupType: 109 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 104
+      ID: 86
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 105 PointerType *table<string,int>
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 106 StructureType table<string,int>
+      Pointee: 88 StructureType table<string,int>
     - __kind: StructureType
-      ID: 106
+      ID: 88
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -4180,28 +4004,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 107 GoSwissMapGroupsType groupReference<string,int>
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
     - __kind: GoSwissMapGroupsType
-      ID: 107
+      ID: 89
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 108 PointerType *noalg.map.group[string]int
+          Type: 90 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 109 StructureType noalg.map.group[string]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 109 StructureType noalg.map.group[string]int
+      Pointee: 91 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 109
+      ID: 91
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.27904e+06
@@ -4212,18 +4036,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 110 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 110
+      ID: 92
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 111 StructureType noalg.struct { key string; elem int }
+      Element: 93 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 111
+      ID: 93
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.278912e+06
@@ -4236,19 +4060,19 @@ Types:
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 112
+      ID: 94
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.118336e+06
       GoKind: 21
-      HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 95
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 114 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 114
+      ID: 96
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -4258,10 +4082,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 115 PointerType **table<string,[]string>
+          Type: 97 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4277,20 +4101,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 255 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 120 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 115
+      ID: 97
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 116 PointerType *table<string,[]string>
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 117 StructureType table<string,[]string>
+      Pointee: 99 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 117
+      ID: 99
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -4312,28 +4136,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 118 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: GoSwissMapGroupsType
-      ID: 118
+      ID: 100
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 119 PointerType *noalg.map.group[string][]string
+          Type: 101 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 120 StructureType noalg.map.group[string][]string
-      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 119
+      ID: 101
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 120 StructureType noalg.map.group[string][]string
+      Pointee: 102 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 120
+      ID: 102
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278784e+06
@@ -4344,18 +4168,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 121 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 121
+      ID: 103
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 122 StructureType noalg.struct { key string; elem []string }
+      Element: 104 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.278656e+06
@@ -4366,9 +4190,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 123 GoSliceHeaderType []string
+          Type: 105 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478656
@@ -4383,21 +4207,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 257 GoSliceDataType []string.array
+      Data: 237 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 124
+      ID: 106
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117824e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 107
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 108
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -4407,10 +4231,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<[4]string,[2]int>
+          Type: 109 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4426,20 +4250,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 239 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 127
+      ID: 109
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<[4]string,[2]int>
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 128
+      ID: 110
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 129 StructureType table<[4]string,[2]int>
+      Pointee: 111 StructureType table<[4]string,[2]int>
     - __kind: StructureType
-      ID: 129
+      ID: 111
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -4461,28 +4285,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 112
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[[4]string][2]int
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
-      ID: 131
+      ID: 113
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: StructureType
-      ID: 132
+      ID: 114
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.27776e+06
@@ -4493,18 +4317,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 133
+      ID: 115
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.277632e+06
@@ -4512,12 +4336,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 135 ArrayType [4]string
+          Type: 117 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 135
+      ID: 117
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 673184
@@ -4526,33 +4350,33 @@ Types:
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 136
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 101 GoMapType map[string]int
+      Element: 83 GoMapType map[string]int
     - __kind: PointerType
-      ID: 137
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 101 GoMapType map[string]int
+      Pointee: 83 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.118208e+06
       GoKind: 21
-      HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoSwissMapHeaderType
-      ID: 140
+      ID: 122
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -4562,10 +4386,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 141 PointerType **table<string,[]main.structWithMap>
+          Type: 123 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4581,20 +4405,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 261 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 142 PointerType *table<string,[]main.structWithMap>
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 142
+      ID: 124
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 143 StructureType table<string,[]main.structWithMap>
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 143
+      ID: 125
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -4616,28 +4440,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 144 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: GoSwissMapGroupsType
-      ID: 144
+      ID: 126
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 145 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
-      ID: 145
+      ID: 127
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 146 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: StructureType
-      ID: 146
+      ID: 128
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.278528e+06
@@ -4648,18 +4472,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 147 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 147
+      ID: 129
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 148 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 148
+      ID: 130
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.2784e+06
@@ -4670,9 +4494,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 GoSliceHeaderType []main.structWithMap
+          Type: 131 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 131
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469888
@@ -4680,35 +4504,35 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *main.structWithMap
+          Type: 132 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 263 GoSliceDataType []main.structWithMap.array
+      Data: 243 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 150
+      ID: 132
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 77 StructureType main.structWithMap
+      Pointee: 58 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.117952e+06
       GoKind: 21
-      HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoSwissMapHeaderType
-      ID: 153
+      ID: 135
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -4718,10 +4542,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 154 PointerType **table<bool,main.node>
+          Type: 136 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4737,20 +4561,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 159 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 245 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 155 PointerType *table<bool,main.node>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 155
+      ID: 137
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 156 StructureType table<bool,main.node>
+      Pointee: 138 StructureType table<bool,main.node>
     - __kind: StructureType
-      ID: 156
+      ID: 138
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -4772,28 +4596,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: GoSwissMapGroupsType
-      ID: 157
+      ID: 139
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 158 PointerType *noalg.map.group[bool]main.node
+          Type: 140 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
-      ID: 158
+      ID: 140
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[bool]main.node
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
     - __kind: StructureType
-      ID: 159
+      ID: 141
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.278016e+06
@@ -4804,18 +4628,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 160
+      ID: 142
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 161 StructureType noalg.struct { key bool; elem main.node }
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 161
+      ID: 143
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277888e+06
@@ -4826,9 +4650,9 @@ Types:
           Type: 11 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 162 StructureType main.node
+          Type: 144 StructureType main.node
     - __kind: StructureType
-      ID: 162
+      ID: 144
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443904e+06
@@ -4839,28 +4663,28 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 163 PointerType *main.node
+          Type: 145 PointerType *main.node
     - __kind: PointerType
-      ID: 163
+      ID: 145
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380288
       GoKind: 22
-      Pointee: 162 StructureType main.node
+      Pointee: 144 StructureType main.node
     - __kind: GoMapType
-      ID: 164
+      ID: 146
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.11808e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 148
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -4870,10 +4694,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<int,uint8>
+          Type: 149 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4889,20 +4713,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 172 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 247 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 167
+      ID: 149
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<int,uint8>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 168
+      ID: 150
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<int,uint8>
+      Pointee: 151 StructureType table<int,uint8>
     - __kind: StructureType
-      ID: 169
+      ID: 151
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -4924,28 +4748,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 170 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 170
+      ID: 152
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 171 PointerType *noalg.map.group[int]uint8
+          Type: 153 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 172 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 248 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
-      ID: 171
+      ID: 153
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 172 StructureType noalg.map.group[int]uint8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
     - __kind: StructureType
-      ID: 172
+      ID: 154
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.278272e+06
@@ -4956,18 +4780,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 173 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 173
+      ID: 155
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 174 StructureType noalg.struct { key int; elem uint8 }
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 174
+      ID: 156
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.278144e+06
@@ -4980,19 +4804,19 @@ Types:
           Offset: 8
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 175
+      ID: 157
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118848e+06
       GoKind: 21
-      HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 177
+      ID: 159
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -5002,10 +4826,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 178 PointerType **table<uint8,uint8>
+          Type: 160 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5021,20 +4845,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 269 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 183 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 249 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 178
+      ID: 160
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 179 PointerType *table<uint8,uint8>
+      Pointee: 161 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 180 StructureType table<uint8,uint8>
+      Pointee: 162 StructureType table<uint8,uint8>
     - __kind: StructureType
-      ID: 180
+      ID: 162
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -5056,28 +4880,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 181 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 181
+      ID: 163
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 182 PointerType *noalg.map.group[uint8]uint8
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 183 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 270 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
-      ID: 182
+      ID: 164
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 183 StructureType noalg.map.group[uint8]uint8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: StructureType
-      ID: 183
+      ID: 165
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279808e+06
@@ -5088,18 +4912,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 184 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: ArrayType
-      ID: 184
+      ID: 166
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 674144
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 185 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 185
+      ID: 167
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.27968e+06
@@ -5112,19 +4936,19 @@ Types:
           Offset: 1
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 186
+      ID: 168
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.11872e+06
       GoKind: 21
-      HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 188
+      ID: 170
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -5134,10 +4958,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 189 PointerType **table<uint8,[4]int>
+          Type: 171 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5153,20 +4977,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 271 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 194 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 251 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 190 PointerType *table<uint8,[4]int>
+      Pointee: 172 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 190
+      ID: 172
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 191 StructureType table<uint8,[4]int>
+      Pointee: 173 StructureType table<uint8,[4]int>
     - __kind: StructureType
-      ID: 191
+      ID: 173
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -5188,28 +5012,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 174
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[uint8][4]int
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 272 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[uint8][4]int
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: StructureType
-      ID: 194
+      ID: 176
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.279552e+06
@@ -5220,18 +5044,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 195
+      ID: 177
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 674048
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 196
+      ID: 178
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.279424e+06
@@ -5242,9 +5066,9 @@ Types:
           Type: 4 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
     - __kind: ArrayType
-      ID: 197
+      ID: 179
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672896
@@ -5253,19 +5077,19 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 198
+      ID: 180
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117696e+06
       GoKind: 21
-      HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 199
+      ID: 181
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 200
+      ID: 182
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -5275,10 +5099,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 201 PointerType **table<[4]int,uint8>
+          Type: 183 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5294,20 +5118,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 273 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 201
+      ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 202 PointerType *table<[4]int,uint8>
+      Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 202
+      ID: 184
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 203 StructureType table<[4]int,uint8>
+      Pointee: 185 StructureType table<[4]int,uint8>
     - __kind: StructureType
-      ID: 203
+      ID: 185
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -5329,28 +5153,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 186
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 274 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
-      ID: 205
+      ID: 187
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: StructureType
-      ID: 206
+      ID: 188
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.277504e+06
@@ -5361,18 +5185,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 207 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 207
+      ID: 189
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 673088
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 208 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.277376e+06
@@ -5380,24 +5204,24 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 209
+      ID: 191
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.117568e+06
       GoKind: 21
-      HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 210
+      ID: 192
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 211
+      ID: 193
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -5407,10 +5231,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 212 PointerType **table<[4]int,[4]int>
+          Type: 194 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5426,20 +5250,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 255 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 212
+      ID: 194
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 213 PointerType *table<[4]int,[4]int>
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 213
+      ID: 195
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 214 StructureType table<[4]int,[4]int>
+      Pointee: 196 StructureType table<[4]int,[4]int>
     - __kind: StructureType
-      ID: 214
+      ID: 196
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -5461,28 +5285,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 197
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[[4]int][4]int
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
-      ID: 216
+      ID: 198
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: StructureType
-      ID: 217
+      ID: 199
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.277248e+06
@@ -5493,18 +5317,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 218
+      ID: 200
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672992
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 219
+      ID: 201
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.27712e+06
@@ -5512,23 +5336,23 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 220
+      ID: 202
       Name: chan bool
       GoRuntimeType: 587360
       GoKind: 18
     - __kind: PointerType
-      ID: 221
+      ID: 203
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.structWithTwoValues
+      Pointee: 204 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 222
+      ID: 204
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -5540,48 +5364,48 @@ Types:
           Offset: 8
           Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 223
+      ID: 205
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385856
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 224
+      ID: 206
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386240
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 207
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 226 GoSliceHeaderType main.t
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 208
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 227 PointerType **main.t
+          Type: 209 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 277 GoSliceDataType main.t.array
+      Data: 257 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 227
+      ID: 209
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 225 PointerType *main.t
+      Pointee: 207 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 210
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478144
@@ -5589,58 +5413,58 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType *uint
+          Type: 205 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 279 GoSliceDataType []uint.array
+      Data: 259 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 229
+      ID: 211
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 230 PointerType *[]uint
+          Type: 212 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 281 GoSliceDataType [][]uint.array
+      Data: 261 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 230
+      ID: 212
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 228 GoSliceHeaderType []uint
+      Pointee: 210 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 213
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 232 PointerType *main.structWithNoStrings
+          Type: 214 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 283 GoSliceDataType []main.structWithNoStrings.array
+      Data: 263 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 232
+      ID: 214
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 233 StructureType main.structWithNoStrings
+      Pointee: 215 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 233
+      ID: 215
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -5652,7 +5476,7 @@ Types:
           Offset: 1
           Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 216
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -5660,16 +5484,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *bool
+          Type: 206 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 285 GoSliceDataType []bool.array
+      Data: 265 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 235
+      ID: 217
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477504
@@ -5677,23 +5501,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 236 PointerType *uint16
+          Type: 218 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 287 GoSliceDataType []uint16.array
+      Data: 267 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 236
+      ID: 218
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385472
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 237
+      ID: 219
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -5708,19 +5532,19 @@ Types:
           Offset: 32
           Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 238
+      ID: 220
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 237 StructureType main.threeStringStruct
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 239
+      ID: 221
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 240 StructureType main.oneStringStruct
+      Pointee: 222 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 240
+      ID: 222
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -5729,7 +5553,7 @@ Types:
           Offset: 0
           Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 241
+      ID: 223
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5745,243 +5569,233 @@ Types:
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 100 StructureType main.nestedStruct
+          Type: 82 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 242
+      ID: 224
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 243
+      ID: 225
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 244
+      ID: 226
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 243 GoStringDataType string.str
+      Pointee: 225 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 227
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 246
+      ID: 228
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []*string.array
+      Pointee: 227 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 53 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 248
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 249
+      ID: 229
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 82 PointerType *table<int,int>
+      Element: 64 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 230
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 86 StructureType noalg.map.group[int]int
+      Element: 68 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 231
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 232
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 97 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 233
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 105 PointerType *table<string,int>
+      Element: 87 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 234
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 109 StructureType noalg.map.group[string]int
+      Element: 91 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 235
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 116 PointerType *table<string,[]string>
+      Element: 98 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 120 StructureType noalg.map.group[string][]string
+      Element: 102 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 237
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 258
+      ID: 238
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []string.array
+      Pointee: 237 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 239
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<[4]string,[2]int>
+      Element: 110 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[[4]string][2]int
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 241
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 142 PointerType *table<string,[]main.structWithMap>
+      Element: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 146 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 243
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 77 StructureType main.structWithMap
+      Element: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 264
+      ID: 244
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []main.structWithMap.array
+      Pointee: 243 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 245
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 155 PointerType *table<bool,main.node>
+      Element: 137 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 159 StructureType noalg.map.group[bool]main.node
+      Element: 141 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 247
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 168 PointerType *table<int,uint8>
+      Element: 150 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 248
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 172 StructureType noalg.map.group[int]uint8
+      Element: 154 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 249
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 179 PointerType *table<uint8,uint8>
+      Element: 161 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 250
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 183 StructureType noalg.map.group[uint8]uint8
+      Element: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 251
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 190 PointerType *table<uint8,[4]int>
+      Element: 172 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 252
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[uint8][4]int
+      Element: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 253
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 202 PointerType *table<[4]int,uint8>
+      Element: 184 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 254
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 255
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 213 PointerType *table<[4]int,[4]int>
+      Element: 195 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 256
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[[4]int][4]int
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 257
       Name: main.t.array
       ByteSize: 2048
-      Element: 225 PointerType *main.t
+      Element: 207 PointerType *main.t
     - __kind: PointerType
-      ID: 278
+      ID: 258
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType main.t.array
+      Pointee: 257 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 259
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 280
+      ID: 260
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []uint.array
+      Pointee: 259 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 261
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 228 GoSliceHeaderType []uint
+      Element: 210 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 282
+      ID: 262
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType [][]uint.array
+      Pointee: 261 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 263
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 233 StructureType main.structWithNoStrings
+      Element: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 284
+      ID: 264
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 263 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 265
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 286
+      ID: 266
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType []bool.array
+      Pointee: 265 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 267
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 288
+      ID: 268
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []uint16.array
+      Pointee: 267 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 289
+      ID: 269
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5996,7 +5810,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 290
+      ID: 270
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6011,7 +5825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 271
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6026,7 +5840,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 292
+      ID: 272
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6041,7 +5855,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 273
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6056,7 +5870,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 274
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6071,7 +5885,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 295
+      ID: 275
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6086,7 +5900,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 296
+      ID: 276
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6101,7 +5915,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 277
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6116,7 +5930,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 278
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6131,7 +5945,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 279
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6146,7 +5960,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 300
+      ID: 280
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6161,7 +5975,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 301
+      ID: 281
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6176,7 +5990,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 282
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6191,7 +6005,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 283
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6206,7 +6020,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6221,7 +6035,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6236,7 +6050,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 306
+      ID: 286
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -6251,7 +6065,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 307
+      ID: 287
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6266,7 +6080,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 288
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6281,7 +6095,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 309
+      ID: 289
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6296,7 +6110,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 310
+      ID: 290
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6311,7 +6125,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 291
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6326,7 +6140,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 312
+      ID: 292
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6341,7 +6155,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 313
+      ID: 293
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6356,7 +6170,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 294
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6371,7 +6185,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 295
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6386,7 +6200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 296
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6401,7 +6215,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 317
+      ID: 297
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6416,7 +6230,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 318
+      ID: 298
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6431,7 +6245,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 319
+      ID: 299
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6446,7 +6260,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 300
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6461,7 +6275,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 321
+      ID: 301
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6476,7 +6290,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 302
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6491,7 +6305,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 323
+      ID: 303
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6506,7 +6320,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 324
+      ID: 304
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6514,14 +6328,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 StructureType main.esotericStack
+            Type: 39 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 325
+      ID: 305
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6529,14 +6343,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 63 PointerType *main.esotericHeap
+            Type: 44 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 306
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6551,7 +6365,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 307
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6575,7 +6389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 308
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6590,10 +6404,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 309
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 330
+      ID: 310
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,7 +6422,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 311
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6623,7 +6437,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 332
+      ID: 312
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6631,14 +6445,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType main.behavior
+            Type: 56 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 333
+      ID: 313
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6646,14 +6460,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 59 GoEmptyInterfaceType interface {}
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 314
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6661,14 +6475,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 76 GoInterfaceType error
+            Type: 57 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 315
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6676,14 +6490,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 77 StructureType main.structWithMap
+            Type: 58 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 316
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6691,14 +6505,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 317
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6706,14 +6520,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 83 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 318
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6721,14 +6535,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[string][]string
+            Type: 94 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 319
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6736,14 +6550,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 124 GoMapType map[[4]string][2]int
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 320
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6751,14 +6565,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 83 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 321
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6766,14 +6580,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 322
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6781,14 +6595,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 323
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6796,14 +6610,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[int]int
+            Type: 59 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 324
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6811,14 +6625,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 325
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6826,14 +6640,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 326
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6841,14 +6655,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 151 GoMapType map[bool]main.node
+            Type: 133 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 327
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6856,14 +6670,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[int]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 328
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6871,14 +6685,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[int]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 329
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6886,14 +6700,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 330
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6901,14 +6715,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 331
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6916,14 +6730,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 332
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6931,14 +6745,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 186 GoMapType map[uint8][4]int
+            Type: 168 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 333
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6946,14 +6760,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 198 GoMapType map[[4]int]uint8
+            Type: 180 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 334
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6961,14 +6775,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 209 GoMapType map[[4]int][4]int
+            Type: 191 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 335
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7001,7 +6815,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 356
+      ID: 336
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7052,7 +6866,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 337
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7060,14 +6874,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 220 GoChannelType chan bool
+            Type: 202 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 358
+      ID: 338
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7075,14 +6889,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.structWithTwoValues
+            Type: 203 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 339
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7090,14 +6904,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 162 StructureType main.node
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 360
+      ID: 340
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7105,14 +6919,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 163 PointerType *main.node
+            Type: 145 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 341
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7120,14 +6934,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 56 VoidPointerType unsafe.Pointer
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 342
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7135,14 +6949,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 PointerType *uint
+            Type: 205 PointerType *uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 343
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7157,7 +6971,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 344
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7165,7 +6979,7 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 224 PointerType *bool
+            Type: 206 PointerType *bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: z}
@@ -7181,7 +6995,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 345
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7189,14 +7003,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 225 PointerType *main.t
+            Type: 207 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 346
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7204,14 +7018,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 367
+      ID: 347
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7219,14 +7033,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
+      ID: 348
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7234,14 +7048,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 229 GoSliceHeaderType [][]uint
+            Type: 211 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 369
+      ID: 349
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7249,7 +7063,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -7265,7 +7079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 350
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7273,7 +7087,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 88, index: 0, name: xs}
@@ -7289,7 +7103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 371
+      ID: 351
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7297,7 +7111,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 89, index: 0, name: xs}
@@ -7313,7 +7127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 352
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7321,14 +7135,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 123 GoSliceHeaderType []string
+            Type: 105 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 373
+      ID: 353
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7345,7 +7159,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 234 GoSliceHeaderType []bool
+            Type: 216 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 1, name: s}
@@ -7361,7 +7175,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 354
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7369,14 +7183,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 235 GoSliceHeaderType []uint16
+            Type: 217 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 375
+      ID: 355
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7384,17 +7198,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 356
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 377
+      ID: 357
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7409,7 +7223,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 378
+      ID: 358
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7442,7 +7256,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 359
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7450,14 +7264,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 237 StructureType main.threeStringStruct
+            Type: 219 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 380
+      ID: 360
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7465,14 +7279,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 238 PointerType *main.threeStringStruct
+            Type: 220 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 361
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7480,14 +7294,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 239 PointerType *main.oneStringStruct
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 362
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7502,7 +7316,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 383
+      ID: 363
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7517,7 +7331,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 384
+      ID: 364
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7532,7 +7346,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 385
+      ID: 365
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7540,14 +7354,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 241 StructureType main.aStruct
+            Type: 223 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 386
+      ID: 366
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7555,14 +7369,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 242 StructureType main.emptyStruct
+            Type: 224 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 387
+      ID: 367
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7577,16 +7391,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 388
+      ID: 368
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 389
+      ID: 369
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 390
+      ID: 370
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 391
+      ID: 371
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7601,7 +7415,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 392
+      ID: 372
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7615,5 +7429,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 392
+MaxTypeID: 372
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -7520,3 +7520,4 @@ Types:
                   ByteSize: 40
 MaxTypeID: 385
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x17f5360", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 315 EventRootType Probe[main.stackC]
+          Type: 295 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x88f5fc", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 272 EventRootType Probe[main.testAny]
+          Type: 252 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88d16c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 242 EventRootType Probe[main.testArrayOfArrays]
+          Type: 222 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 224 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 280 EventRootType Probe[main.testArrayOfMaps]
+          Type: 260 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88d650", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 243 EventRootType Probe[main.testArrayOfStrings]
+          Type: 223 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 262 EventRootType Probe[main.testBigStruct]
+          Type: 242 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c460", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 231 EventRootType Probe[main.testBoolArray]
+          Type: 211 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88be30", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 228 EventRootType Probe[main.testByteArray]
+          Type: 208 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88be00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 296 EventRootType Probe[main.testChannel]
+          Type: 276 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88ec00", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 294 EventRootType Probe[main.testCombinedByte]
+          Type: 274 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88e980", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 304 EventRootType Probe[main.testCycle]
+          Type: 284 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88eea0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 306 EventRootType Probe[main.testEmptySlice]
+          Type: 286 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x88f2a0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 309 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 289 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x88f2d0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 323 EventRootType Probe[main.testEmptyString]
+          Type: 303 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x88f6e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 325 EventRootType Probe[main.testEmptyStruct]
+          Type: 305 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 273 EventRootType Probe[main.testError]
+          Type: 253 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 264 EventRootType Probe[main.testEsotericHeap]
+          Type: 244 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 263 EventRootType Probe[main.testEsotericStack]
+          Type: 243 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88c62c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 269 EventRootType Probe[main.testFrameless]
+          Type: 249 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88ce50", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 270 EventRootType Probe[main.testFramelessArray]
+          Type: 250 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88ce60", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 265 EventRootType Probe[main.testInlinedBA]
+          Type: 245 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88cb5c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 266 EventRootType Probe[main.testInlinedBB]
+          Type: 246 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88cbec", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 267 EventRootType Probe[main.testInlinedBBA]
+          Type: 247 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88ccbc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 327 EventRootType Probe[main.testInlinedBBB]
+          Type: 307 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88cc48", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 268 EventRootType Probe[main.testInlinedBC]
+          Type: 248 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88cd3c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 328 EventRootType Probe[main.testInlinedBCA]
+          Type: 308 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88cd4c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 329 EventRootType Probe[main.testInlinedBCB]
+          Type: 309 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88ce00", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 326 EventRootType Probe[main.testInlinedPrint]
+          Type: 306 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88c9bc"
               Frameless: true
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 330 EventRootType Probe[main.testInlinedSq]
+          Type: 310 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88ce54", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 331 EventRootType Probe[main.testInlinedSumArray]
+          Type: 311 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88ce84"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 234 EventRootType Probe[main.testInt16Array]
+          Type: 214 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88be60", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 235 EventRootType Probe[main.testInt32Array]
+          Type: 215 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88be70", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 236 EventRootType Probe[main.testInt64Array]
+          Type: 216 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88be80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 233 EventRootType Probe[main.testInt8Array]
+          Type: 213 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88be50", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 232 EventRootType Probe[main.testIntArray]
+          Type: 212 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88be40", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 271 EventRootType Probe[main.testInterface]
+          Type: 251 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88d10c", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 298 EventRootType Probe[main.testLinkedList]
+          Type: 278 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88edb0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 278 EventRootType Probe[main.testMapArrayToArray]
+          Type: 258 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88d630", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 284 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 264 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88d690", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 282 EventRootType Probe[main.testMapIntToInt]
+          Type: 262 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88d670", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 293 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 273 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88d720", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 292 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 272 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88d710", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 283 EventRootType Probe[main.testMapMassive]
+          Type: 263 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88d680", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 291 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 271 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88d700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 290 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 270 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88d6f0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 276 EventRootType Probe[main.testMapStringToInt]
+          Type: 256 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88d610", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 277 EventRootType Probe[main.testMapStringToSlice]
+          Type: 257 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88d620", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 275 EventRootType Probe[main.testMapStringToStruct]
+          Type: 255 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88d600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 285 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 265 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 268 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 289 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 269 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88d6e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 286 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 266 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 287 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 267 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 321 EventRootType Probe[main.testMassiveString]
+          Type: 301 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x88f6c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 295 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 275 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88ea60", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 303 EventRootType Probe[main.testNilPointer]
+          Type: 283 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 313 EventRootType Probe[main.testNilSlice]
+          Type: 293 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x88f310", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 310 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 290 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x88f2e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 312 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 292 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x88f300", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 320 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 300 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x88f6b0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 299 EventRootType Probe[main.testPointerLoop]
+          Type: 279 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 281 EventRootType Probe[main.testPointerToMap]
+          Type: 261 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88d660", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 297 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 277 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 229 EventRootType Probe[main.testRuneArray]
+          Type: 209 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88be10", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 248 EventRootType Probe[main.testSingleBool]
+          Type: 228 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 246 EventRootType Probe[main.testSingleByte]
+          Type: 226 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 259 EventRootType Probe[main.testSingleFloat32]
+          Type: 239 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 260 EventRootType Probe[main.testSingleFloat64]
+          Type: 240 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 249 EventRootType Probe[main.testSingleInt]
+          Type: 229 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 251 EventRootType Probe[main.testSingleInt16]
+          Type: 231 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 252 EventRootType Probe[main.testSingleInt32]
+          Type: 232 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 253 EventRootType Probe[main.testSingleInt64]
+          Type: 233 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 250 EventRootType Probe[main.testSingleInt8]
+          Type: 230 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 247 EventRootType Probe[main.testSingleRune]
+          Type: 227 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 316 EventRootType Probe[main.testSingleString]
+          Type: 296 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x88f660", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 254 EventRootType Probe[main.testSingleUint]
+          Type: 234 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 256 EventRootType Probe[main.testSingleUint16]
+          Type: 236 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 257 EventRootType Probe[main.testSingleUint32]
+          Type: 237 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 258 EventRootType Probe[main.testSingleUint64]
+          Type: 238 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 255 EventRootType Probe[main.testSingleUint8]
+          Type: 235 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 307 EventRootType Probe[main.testSliceOfSlices]
+          Type: 287 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x88f2b0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 279 EventRootType Probe[main.testSmallMap]
+          Type: 259 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88d640", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 230 EventRootType Probe[main.testStringArray]
+          Type: 210 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88be20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 302 EventRootType Probe[main.testStringPointer]
+          Type: 282 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88ee60", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 311 EventRootType Probe[main.testStringSlice]
+          Type: 291 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x88f2f0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 324 EventRootType Probe[main.testStruct]
+          Type: 304 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 308 EventRootType Probe[main.testStructSlice]
+          Type: 288 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x88f2c0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 274 EventRootType Probe[main.testStructWithMap]
+          Type: 254 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 317 EventRootType Probe[main.testThreeStrings]
+          Type: 297 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x88f670", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 318 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 298 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x88f680", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 319 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 299 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x88f6a0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 261 EventRootType Probe[main.testTypeAlias]
+          Type: 241 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 239 EventRootType Probe[main.testUint16Array]
+          Type: 219 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 240 EventRootType Probe[main.testUint32Array]
+          Type: 220 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 241 EventRootType Probe[main.testUint64Array]
+          Type: 221 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 238 EventRootType Probe[main.testUint8Array]
+          Type: 218 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 237 EventRootType Probe[main.testUintArray]
+          Type: 217 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88be90", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 301 EventRootType Probe[main.testUintPointer]
+          Type: 281 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 305 EventRootType Probe[main.testUintSlice]
+          Type: 285 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x88f290", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 322 EventRootType Probe[main.testUnitializedString]
+          Type: 302 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x88f6d0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 300 EventRootType Probe[main.testUnsafePointer]
+          Type: 280 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 245 EventRootType Probe[main.testVeryLargeArray]
+          Type: 225 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88bf30", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 314 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 294 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88f320", Frameless: true}]
           Condition: null
 Subprograms:
@@ -1911,7 +1911,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
           Locations:
             - Range: 0x88c620..0x88c668
               Pieces:
@@ -1981,7 +1981,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 63 PointerType *main.esotericHeap
+          Type: 44 PointerType *main.esotericHeap
           Locations:
             - Range: 0x88c710..0x88c748
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 74 GoInterfaceType main.behavior
+          Type: 55 GoInterfaceType main.behavior
           Locations:
             - Range: 0x88d100..0x88d128
               Pieces:
@@ -2133,7 +2133,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0x88d160..0x88d190
               Pieces:
@@ -2160,7 +2160,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 75 GoInterfaceType error
+          Type: 56 GoInterfaceType error
           Locations:
             - Range: 0x88d1d0..0x88d1e0
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 76 StructureType main.structWithMap
+          Type: 57 StructureType main.structWithMap
           Locations:
             - Range: 0x88d5f0..0x88d600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 92 GoMapType map[string]main.nestedStruct
+          Type: 74 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x88d600..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[string]int
+          Type: 82 GoMapType map[string]int
           Locations:
             - Range: 0x88d610..0x88d620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 105 GoMapType map[string][]string
+          Type: 87 GoMapType map[string][]string
           Locations:
             - Range: 0x88d620..0x88d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
+          Type: 94 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x88d630..0x88d640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 100 GoMapType map[string]int
+          Type: 82 GoMapType map[string]int
           Locations:
             - Range: 0x88d640..0x88d650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 120 ArrayType [2]map[string]int
+          Type: 102 ArrayType [2]map[string]int
           Locations:
             - Range: 0x88d650..0x88d660
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 121 PointerType *map[string]int
+          Type: 103 PointerType *map[string]int
           Locations:
             - Range: 0x88d660..0x88d670
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 77 GoMapType map[int]int
+          Type: 58 GoMapType map[int]int
           Locations:
             - Range: 0x88d670..0x88d680
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 122 GoMapType map[string][]main.structWithMap
+          Type: 104 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d680..0x88d690
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 122 GoMapType map[string][]main.structWithMap
+          Type: 104 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88d690..0x88d6a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 130 GoMapType map[bool]main.node
+          Type: 112 GoMapType map[bool]main.node
           Locations:
             - Range: 0x88d6a0..0x88d6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 139 GoMapType map[int]uint8
+          Type: 121 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6b0..0x88d6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 139 GoMapType map[int]uint8
+          Type: 121 GoMapType map[int]uint8
           Locations:
             - Range: 0x88d6c0..0x88d6d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6d0..0x88d6e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6e0..0x88d6f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 145 GoMapType map[uint8]uint8
+          Type: 127 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x88d6f0..0x88d700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[uint8][4]int
+          Type: 133 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x88d700..0x88d710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 158 GoMapType map[[4]int]uint8
+          Type: 140 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x88d710..0x88d720
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[[4]int][4]int
+          Type: 146 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x88d720..0x88d730
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 169 GoChannelType chan bool
+          Type: 151 GoChannelType chan bool
           Locations:
             - Range: 0x88ec00..0x88ec10
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 170 PointerType *main.structWithTwoValues
+          Type: 152 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x88eda0..0x88edb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 137 StructureType main.node
+          Type: 119 StructureType main.node
           Locations:
             - Range: 0x88edb0..0x88edc0
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 138 PointerType *main.node
+          Type: 120 PointerType *main.node
           Locations:
             - Range: 0x88edc0..0x88edd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2538,7 +2538,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x88edd0..0x88ede0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2550,7 +2550,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 172 PointerType *uint
+          Type: 154 PointerType *uint
           Locations:
             - Range: 0x88edf0..0x88ee00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2574,7 +2574,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 173 PointerType *bool
+          Type: 155 PointerType *bool
           Locations:
             - Range: 0x88ee80..0x88ee90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 174 PointerType *main.t
+          Type: 156 PointerType *main.t
           Locations:
             - Range: 0x88eea0..0x88eeb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f290..0x88f2a0
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f2a0..0x88f2b0
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 178 GoSliceHeaderType [][]uint
+          Type: 160 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x88f2b0..0x88f2c0
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2c0..0x88f2d0
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2d0..0x88f2e0
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Type: 162 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x88f2e0..0x88f2f0
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 111 GoSliceHeaderType []string
+          Type: 93 GoSliceHeaderType []string
           Locations:
             - Range: 0x88f2f0..0x88f300
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 183 GoSliceHeaderType []bool
+          Type: 165 GoSliceHeaderType []bool
           Locations:
             - Range: 0x88f300..0x88f310
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 184 GoSliceHeaderType []uint16
+          Type: 166 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x88f310..0x88f320
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 177 GoSliceHeaderType []uint
+          Type: 159 GoSliceHeaderType []uint
           Locations:
             - Range: 0x88f320..0x88f330
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 186 StructureType main.threeStringStruct
+          Type: 168 StructureType main.threeStringStruct
           Locations:
             - Range: 0x88f680..0x88f6a0
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 187 PointerType *main.threeStringStruct
+          Type: 169 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x88f6a0..0x88f6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 188 PointerType *main.oneStringStruct
+          Type: 170 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x88f6b0..0x88f6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 190 StructureType main.aStruct
+          Type: 172 StructureType main.aStruct
           Locations:
             - Range: 0x88f8f0..0x88f910
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 191 StructureType main.emptyStruct
+          Type: 173 StructureType main.emptyStruct
           Locations: [{Range: 0x88f9f0..0x88fa00, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 193 PointerType *string.str
+          Type: 175 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 192 GoStringDataType string.str
+      Data: 174 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 194 GoSliceDataType []*string.array
+      Data: 176 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3383,215 +3383,21 @@ Types:
       ByteSize: 16
       GoRuntimeType: 973952
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 38
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 39 PointerType *internal/abi.ITab
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 39
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 383392
-      GoKind: 22
-      Pointee: 40 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 40
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.627712e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 41 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 54 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 55 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 41
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.054848e+06
-      GoKind: 22
-      Pointee: 42 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 42
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.437568e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 43 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 50 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 51 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 43
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 1.981664e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 44 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 44 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 45 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 4 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 4 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 46 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 9 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 44
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 527744
-      GoKind: 12
-    - __kind: BaseType
-      ID: 45
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 530752
-      GoKind: 8
-    - __kind: BaseType
-      ID: 46
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 759328
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 47
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 773344
-      GoKind: 19
-    - __kind: BaseType
-      ID: 48
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 530816
-      GoKind: 5
-    - __kind: BaseType
-      ID: 49
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 530880
-      GoKind: 5
-    - __kind: StructureType
-      ID: 50
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.829216e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 9 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 51
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 468512
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 52 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 196 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 52
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 383328
-      GoKind: 22
-      Pointee: 53 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 53
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.296288e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: PointerType
-      ID: 54
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.055296e+06
-      GoKind: 22
-      Pointee: 43 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 55
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 618784
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 44 BaseType uintptr
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 56
+      ID: 38
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 528128
       GoKind: 26
     - __kind: StructureType
-      ID: 57
+      ID: 39
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.819424e+06
@@ -3605,65 +3411,65 @@ Types:
           Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 58 GoChannelType chan struct {}
+          Type: 40 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 61 GoInterfaceType main.something
+          Type: 42 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 62 GoSubroutineType func()
+          Type: 43 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 58
+      ID: 40
       Name: chan struct {}
       GoRuntimeType: 538240
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 59
+      ID: 41
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 772480
       GoKind: 20
-      UnderlyingStructure: 60 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 60
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 54 PointerType *internal/abi.Type
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 42
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 973696
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 62
+      ID: 43
       Name: func()
       ByteSize: 8
       GoRuntimeType: 441952
       GoKind: 19
     - __kind: PointerType
-      ID: 63
+      ID: 44
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 354208
       GoKind: 22
-      Pointee: 64 StructureType main.esotericHeap
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 64
+      ID: 45
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.69296e+06
@@ -3671,21 +3477,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 66 StructureType sync.Once
+          Type: 47 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 69 StructureType sync.WaitGroup
+          Type: 50 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 73 StructureType sync/atomic.Int32
+          Type: 54 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 65
+      ID: 46
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.271488e+06
@@ -3698,7 +3504,7 @@ Types:
           Offset: 4
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 66
+      ID: 47
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.272608e+06
@@ -3706,12 +3512,12 @@ Types:
       RawFields:
         - Name: done
           Offset: 0
-          Type: 67 StructureType sync/atomic.Uint32
+          Type: 48 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 67
+      ID: 48
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.273088e+06
@@ -3719,18 +3525,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 49
       Name: sync/atomic.noCopy
       GoRuntimeType: 940800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 69
+      ID: 50
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.411456e+06
@@ -3738,21 +3544,21 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 70 StructureType sync.noCopy
+          Type: 51 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 71 StructureType sync/atomic.Uint64
+          Type: 52 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 51
       Name: sync.noCopy
       GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 52
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.41184e+06
@@ -3760,21 +3566,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 72 StructureType sync/atomic.align64
+          Type: 53 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 72
+      ID: 53
       Name: sync/atomic.align64
       GoRuntimeType: 940896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 73
+      ID: 54
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.272928e+06
@@ -3782,26 +3588,38 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 68 StructureType sync/atomic.noCopy
+          Type: 49 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 74
+      ID: 55
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 973568
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 56
       Name: error
       ByteSize: 16
       GoRuntimeType: 978048
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 76
+      ID: 57
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.09264e+06
@@ -3809,21 +3627,21 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 77 GoMapType map[int]int
+          Type: 58 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 77
+      ID: 58
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 872992
       GoKind: 21
-      HeaderType: 79 GoHMapHeaderType hash<int,int>
+      HeaderType: 60 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
-      ID: 78
+      ID: 59
       Name: '*hash<int,int>'
       ByteSize: 8
-      Pointee: 79 GoHMapHeaderType hash<int,int>
+      Pointee: 60 GoHMapHeaderType hash<int,int>
     - __kind: GoHMapHeaderType
-      ID: 79
+      ID: 60
       Name: hash<int,int>
       ByteSize: 48
       RawFields:
@@ -3844,44 +3662,44 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 81 GoHMapBucketType bucket<int,int>
-      BucketsType: 198 GoSliceDataType []bucket<int,int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 62 GoHMapBucketType bucket<int,int>
+      BucketsType: 178 GoSliceDataType []bucket<int,int>.array
     - __kind: PointerType
-      ID: 80
+      ID: 61
       Name: '*bucket<int,int>'
       ByteSize: 8
-      Pointee: 81 GoHMapBucketType bucket<int,int>
+      Pointee: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoHMapBucketType
-      ID: 81
+      ID: 62
       Name: bucket<int,int>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 83 ArrayType []key<int>
+          Type: 64 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 84 ArrayType []val<int>
+          Type: 65 ArrayType []val<int>
         - Name: overflow
           Offset: 136
-          Type: 80 PointerType *bucket<int,int>
+          Type: 61 PointerType *bucket<int,int>
       KeyType: 1 BaseType int
       ValueType: 1 BaseType int
     - __kind: ArrayType
-      ID: 82
+      ID: 63
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 615616
@@ -3890,28 +3708,34 @@ Types:
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 83
+      ID: 64
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 1 BaseType int
     - __kind: ArrayType
-      ID: 84
+      ID: 65
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 1 BaseType int
+    - __kind: BaseType
+      ID: 66
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 527744
+      GoKind: 12
     - __kind: PointerType
-      ID: 85
+      ID: 67
       Name: '*runtime.mapextra'
       ByteSize: 8
       GoRuntimeType: 363168
       GoKind: 22
-      Pointee: 86 StructureType runtime.mapextra
+      Pointee: 68 StructureType runtime.mapextra
     - __kind: StructureType
-      ID: 86
+      ID: 68
       Name: runtime.mapextra
       ByteSize: 24
       GoRuntimeType: 1.417408e+06
@@ -3919,22 +3743,22 @@ Types:
       RawFields:
         - Name: overflow
           Offset: 0
-          Type: 87 PointerType *[]*runtime.bmap
+          Type: 69 PointerType *[]*runtime.bmap
         - Name: oldoverflow
           Offset: 8
-          Type: 87 PointerType *[]*runtime.bmap
+          Type: 69 PointerType *[]*runtime.bmap
         - Name: nextOverflow
           Offset: 16
-          Type: 90 PointerType *runtime.bmap
+          Type: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 87
+      ID: 69
       Name: '*[]*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 451808
       GoKind: 22
-      Pointee: 88 GoSliceHeaderType []*runtime.bmap
+      Pointee: 70 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
-      ID: 88
+      ID: 70
       Name: '[]*runtime.bmap'
       ByteSize: 24
       GoRuntimeType: 451744
@@ -3942,28 +3766,28 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 89 PointerType **runtime.bmap
+          Type: 71 PointerType **runtime.bmap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 199 GoSliceDataType []*runtime.bmap.array
+      Data: 179 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
-      ID: 89
+      ID: 71
       Name: '**runtime.bmap'
       ByteSize: 8
-      Pointee: 90 PointerType *runtime.bmap
+      Pointee: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*runtime.bmap'
       ByteSize: 8
       GoRuntimeType: 1.101088e+06
       GoKind: 22
-      Pointee: 91 StructureType runtime.bmap
+      Pointee: 73 StructureType runtime.bmap
     - __kind: StructureType
-      ID: 91
+      ID: 73
       Name: runtime.bmap
       ByteSize: 8
       GoRuntimeType: 1.10096e+06
@@ -3971,21 +3795,21 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
     - __kind: GoMapType
-      ID: 92
+      ID: 74
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 874720
       GoKind: 21
-      HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+      HeaderType: 76 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*hash<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 GoHMapHeaderType hash<string,main.nestedStruct>
+      Pointee: 76 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: GoHMapHeaderType
-      ID: 94
+      ID: 76
       Name: hash<string,main.nestedStruct>
       ByteSize: 48
       RawFields:
@@ -4006,58 +3830,58 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
         - Name: oldbuckets
           Offset: 24
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 96 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 201 GoSliceDataType []bucket<string,main.nestedStruct>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
+      BucketsType: 181 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: PointerType
-      ID: 95
+      ID: 77
       Name: '*bucket<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      Pointee: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoHMapBucketType
-      ID: 96
+      ID: 78
       Name: bucket<string,main.nestedStruct>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 98 ArrayType []val<main.nestedStruct>
+          Type: 80 ArrayType []val<main.nestedStruct>
         - Name: overflow
           Offset: 328
-          Type: 95 PointerType *bucket<string,main.nestedStruct>
+          Type: 77 PointerType *bucket<string,main.nestedStruct>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 99 StructureType main.nestedStruct
+      ValueType: 81 StructureType main.nestedStruct
     - __kind: ArrayType
-      ID: 97
+      ID: 79
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 98
+      ID: 80
       Name: '[]val<main.nestedStruct>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 99 StructureType main.nestedStruct
+      Element: 81 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 99
+      ID: 81
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.270208e+06
@@ -4070,19 +3894,19 @@ Types:
           Offset: 8
           Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 100
+      ID: 82
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 874624
       GoKind: 21
-      HeaderType: 102 GoHMapHeaderType hash<string,int>
+      HeaderType: 84 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
-      ID: 101
+      ID: 83
       Name: '*hash<string,int>'
       ByteSize: 8
-      Pointee: 102 GoHMapHeaderType hash<string,int>
+      Pointee: 84 GoHMapHeaderType hash<string,int>
     - __kind: GoHMapHeaderType
-      ID: 102
+      ID: 84
       Name: hash<string,int>
       ByteSize: 48
       RawFields:
@@ -4103,56 +3927,56 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
         - Name: oldbuckets
           Offset: 24
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 104 GoHMapBucketType bucket<string,int>
-      BucketsType: 202 GoSliceDataType []bucket<string,int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 86 GoHMapBucketType bucket<string,int>
+      BucketsType: 182 GoSliceDataType []bucket<string,int>.array
     - __kind: PointerType
-      ID: 103
+      ID: 85
       Name: '*bucket<string,int>'
       ByteSize: 8
-      Pointee: 104 GoHMapBucketType bucket<string,int>
+      Pointee: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoHMapBucketType
-      ID: 104
+      ID: 86
       Name: bucket<string,int>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 84 ArrayType []val<int>
+          Type: 65 ArrayType []val<int>
         - Name: overflow
           Offset: 200
-          Type: 103 PointerType *bucket<string,int>
+          Type: 85 PointerType *bucket<string,int>
       KeyType: 8 GoStringHeaderType string
       ValueType: 1 BaseType int
     - __kind: GoMapType
-      ID: 105
+      ID: 87
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 874528
       GoKind: 21
-      HeaderType: 107 GoHMapHeaderType hash<string,[]string>
+      HeaderType: 89 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
-      ID: 106
+      ID: 88
       Name: '*hash<string,[]string>'
       ByteSize: 8
-      Pointee: 107 GoHMapHeaderType hash<string,[]string>
+      Pointee: 89 GoHMapHeaderType hash<string,[]string>
     - __kind: GoHMapHeaderType
-      ID: 107
+      ID: 89
       Name: hash<string,[]string>
       ByteSize: 48
       RawFields:
@@ -4173,51 +3997,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
         - Name: oldbuckets
           Offset: 24
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 109 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 203 GoSliceDataType []bucket<string,[]string>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 91 GoHMapBucketType bucket<string,[]string>
+      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*bucket<string,[]string>'
       ByteSize: 8
-      Pointee: 109 GoHMapBucketType bucket<string,[]string>
+      Pointee: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoHMapBucketType
-      ID: 109
+      ID: 91
       Name: bucket<string,[]string>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 110 ArrayType []val<[]string>
+          Type: 92 ArrayType []val<[]string>
         - Name: overflow
           Offset: 328
-          Type: 108 PointerType *bucket<string,[]string>
+          Type: 90 PointerType *bucket<string,[]string>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 111 GoSliceHeaderType []string
+      ValueType: 93 GoSliceHeaderType []string
     - __kind: ArrayType
-      ID: 110
+      ID: 92
       Name: '[]val<[]string>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 111 GoSliceHeaderType []string
+      Element: 93 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 111
+      ID: 93
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 450016
@@ -4232,21 +4056,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 204 GoSliceDataType []string.array
+      Data: 184 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 112
+      ID: 94
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 874144
       GoKind: 21
-      HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      HeaderType: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
-      ID: 113
+      ID: 95
       Name: '*hash<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 114 GoHMapHeaderType hash<[4]string,[2]int>
+      Pointee: 96 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: GoHMapHeaderType
-      ID: 114
+      ID: 96
       Name: hash<[4]string,[2]int>
       ByteSize: 48
       RawFields:
@@ -4267,51 +4091,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 97 PointerType *bucket<[4]string,[2]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 115 PointerType *bucket<[4]string,[2]int>
+          Type: 97 PointerType *bucket<[4]string,[2]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 116 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 206 GoSliceDataType []bucket<[4]string,[2]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
+      BucketsType: 186 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: PointerType
-      ID: 115
+      ID: 97
       Name: '*bucket<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Pointee: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoHMapBucketType
-      ID: 116
+      ID: 98
       Name: bucket<[4]string,[2]int>
       ByteSize: 656
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 117 ArrayType []key<[4]string>
+          Type: 99 ArrayType []key<[4]string>
         - Name: values
           Offset: 520
-          Type: 119 ArrayType []val<[2]int>
+          Type: 101 ArrayType []val<[2]int>
         - Name: overflow
           Offset: 648
-          Type: 115 PointerType *bucket<[4]string,[2]int>
-      KeyType: 118 ArrayType [4]string
+          Type: 97 PointerType *bucket<[4]string,[2]int>
+      KeyType: 100 ArrayType [4]string
       ValueType: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 117
+      ID: 99
       Name: '[]key<[4]string>'
       ByteSize: 512
       Count: 8
       HasCount: true
-      Element: 118 ArrayType [4]string
+      Element: 100 ArrayType [4]string
     - __kind: ArrayType
-      ID: 118
+      ID: 100
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 617824
@@ -4320,40 +4144,40 @@ Types:
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 119
+      ID: 101
       Name: '[]val<[2]int>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 120
+      ID: 102
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 100 GoMapType map[string]int
+      Element: 82 GoMapType map[string]int
     - __kind: PointerType
-      ID: 121
+      ID: 103
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 100 GoMapType map[string]int
+      Pointee: 82 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 122
+      ID: 104
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 874432
       GoKind: 21
-      HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+      HeaderType: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 123
+      ID: 105
       Name: '*hash<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
+      Pointee: 106 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: GoHMapHeaderType
-      ID: 124
+      ID: 106
       Name: hash<string,[]main.structWithMap>
       ByteSize: 48
       RawFields:
@@ -4374,51 +4198,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
         - Name: oldbuckets
           Offset: 24
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 207 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
+      BucketsType: 187 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: PointerType
-      ID: 125
+      ID: 107
       Name: '*bucket<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Pointee: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoHMapBucketType
-      ID: 126
+      ID: 108
       Name: bucket<string,[]main.structWithMap>
       ByteSize: 336
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 97 ArrayType []key<string>
+          Type: 79 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 127 ArrayType []val<[]main.structWithMap>
+          Type: 109 ArrayType []val<[]main.structWithMap>
         - Name: overflow
           Offset: 328
-          Type: 125 PointerType *bucket<string,[]main.structWithMap>
+          Type: 107 PointerType *bucket<string,[]main.structWithMap>
       KeyType: 8 GoStringHeaderType string
-      ValueType: 128 GoSliceHeaderType []main.structWithMap
+      ValueType: 110 GoSliceHeaderType []main.structWithMap
     - __kind: ArrayType
-      ID: 127
+      ID: 109
       Name: '[]val<[]main.structWithMap>'
       ByteSize: 192
       Count: 8
       HasCount: true
-      Element: 128 GoSliceHeaderType []main.structWithMap
+      Element: 110 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 128
+      ID: 110
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 442848
@@ -4426,35 +4250,35 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 129 PointerType *main.structWithMap
+          Type: 111 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 208 GoSliceDataType []main.structWithMap.array
+      Data: 188 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 129
+      ID: 111
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 354144
       GoKind: 22
-      Pointee: 76 StructureType main.structWithMap
+      Pointee: 57 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 130
+      ID: 112
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 874240
       GoKind: 21
-      HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
+      HeaderType: 114 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
-      ID: 131
+      ID: 113
       Name: '*hash<bool,main.node>'
       ByteSize: 8
-      Pointee: 132 GoHMapHeaderType hash<bool,main.node>
+      Pointee: 114 GoHMapHeaderType hash<bool,main.node>
     - __kind: GoHMapHeaderType
-      ID: 132
+      ID: 114
       Name: hash<bool,main.node>
       ByteSize: 48
       RawFields:
@@ -4475,58 +4299,58 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
         - Name: oldbuckets
           Offset: 24
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 134 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 210 GoSliceDataType []bucket<bool,main.node>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 116 GoHMapBucketType bucket<bool,main.node>
+      BucketsType: 190 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: PointerType
-      ID: 133
+      ID: 115
       Name: '*bucket<bool,main.node>'
       ByteSize: 8
-      Pointee: 134 GoHMapBucketType bucket<bool,main.node>
+      Pointee: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoHMapBucketType
-      ID: 134
+      ID: 116
       Name: bucket<bool,main.node>
       ByteSize: 152
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 135 ArrayType []key<bool>
+          Type: 117 ArrayType []key<bool>
         - Name: values
           Offset: 16
-          Type: 136 ArrayType []val<main.node>
+          Type: 118 ArrayType []val<main.node>
         - Name: overflow
           Offset: 144
-          Type: 133 PointerType *bucket<bool,main.node>
+          Type: 115 PointerType *bucket<bool,main.node>
       KeyType: 11 BaseType bool
-      ValueType: 137 StructureType main.node
+      ValueType: 119 StructureType main.node
     - __kind: ArrayType
-      ID: 135
+      ID: 117
       Name: '[]key<bool>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 11 BaseType bool
     - __kind: ArrayType
-      ID: 136
+      ID: 118
       Name: '[]val<main.node>'
       ByteSize: 128
       Count: 8
       HasCount: true
-      Element: 137 StructureType main.node
+      Element: 119 StructureType main.node
     - __kind: StructureType
-      ID: 137
+      ID: 119
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.270048e+06
@@ -4537,28 +4361,28 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 138 PointerType *main.node
+          Type: 120 PointerType *main.node
     - __kind: PointerType
-      ID: 138
+      ID: 120
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 354272
       GoKind: 22
-      Pointee: 137 StructureType main.node
+      Pointee: 119 StructureType main.node
     - __kind: GoMapType
-      ID: 139
+      ID: 121
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 874336
       GoKind: 21
-      HeaderType: 141 GoHMapHeaderType hash<int,uint8>
+      HeaderType: 123 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
-      ID: 140
+      ID: 122
       Name: '*hash<int,uint8>'
       ByteSize: 8
-      Pointee: 141 GoHMapHeaderType hash<int,uint8>
+      Pointee: 123 GoHMapHeaderType hash<int,uint8>
     - __kind: GoHMapHeaderType
-      ID: 141
+      ID: 123
       Name: hash<int,uint8>
       ByteSize: 48
       RawFields:
@@ -4579,63 +4403,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 143 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 211 GoSliceDataType []bucket<int,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 125 GoHMapBucketType bucket<int,uint8>
+      BucketsType: 191 GoSliceDataType []bucket<int,uint8>.array
     - __kind: PointerType
-      ID: 142
+      ID: 124
       Name: '*bucket<int,uint8>'
       ByteSize: 8
-      Pointee: 143 GoHMapBucketType bucket<int,uint8>
+      Pointee: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoHMapBucketType
-      ID: 143
+      ID: 125
       Name: bucket<int,uint8>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 83 ArrayType []key<int>
+          Type: 64 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 80
-          Type: 142 PointerType *bucket<int,uint8>
+          Type: 124 PointerType *bucket<int,uint8>
       KeyType: 1 BaseType int
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 144
+      ID: 126
       Name: '[]val<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 145
+      ID: 127
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 874912
       GoKind: 21
-      HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
+      HeaderType: 129 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
-      ID: 146
+      ID: 128
       Name: '*hash<uint8,uint8>'
       ByteSize: 8
-      Pointee: 147 GoHMapHeaderType hash<uint8,uint8>
+      Pointee: 129 GoHMapHeaderType hash<uint8,uint8>
     - __kind: GoHMapHeaderType
-      ID: 147
+      ID: 129
       Name: hash<uint8,uint8>
       ByteSize: 48
       RawFields:
@@ -4656,63 +4480,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 149 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 212 GoSliceDataType []bucket<uint8,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
+      BucketsType: 192 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: PointerType
-      ID: 148
+      ID: 130
       Name: '*bucket<uint8,uint8>'
       ByteSize: 8
-      Pointee: 149 GoHMapBucketType bucket<uint8,uint8>
+      Pointee: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoHMapBucketType
-      ID: 149
+      ID: 131
       Name: bucket<uint8,uint8>
       ByteSize: 32
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 132 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 24
-          Type: 148 PointerType *bucket<uint8,uint8>
+          Type: 130 PointerType *bucket<uint8,uint8>
       KeyType: 4 BaseType uint8
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 150
+      ID: 132
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
       HasCount: true
       Element: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 874816
       GoKind: 21
-      HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
+      HeaderType: 135 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*hash<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 153 GoHMapHeaderType hash<uint8,[4]int>
+      Pointee: 135 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: GoHMapHeaderType
-      ID: 153
+      ID: 135
       Name: hash<uint8,[4]int>
       ByteSize: 48
       RawFields:
@@ -4733,51 +4557,51 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 155 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 213 GoSliceDataType []bucket<uint8,[4]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
+      BucketsType: 193 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '*bucket<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 155 GoHMapBucketType bucket<uint8,[4]int>
+      Pointee: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoHMapBucketType
-      ID: 155
+      ID: 137
       Name: bucket<uint8,[4]int>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 132 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 156 ArrayType []val<[4]int>
+          Type: 138 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 272
-          Type: 154 PointerType *bucket<uint8,[4]int>
+          Type: 136 PointerType *bucket<uint8,[4]int>
       KeyType: 4 BaseType uint8
-      ValueType: 157 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
     - __kind: ArrayType
-      ID: 156
+      ID: 138
       Name: '[]val<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 157 ArrayType [4]int
+      Element: 139 ArrayType [4]int
     - __kind: ArrayType
-      ID: 157
+      ID: 139
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 617536
@@ -4786,19 +4610,19 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 158
+      ID: 140
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 874048
       GoKind: 21
-      HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
+      HeaderType: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
-      ID: 159
+      ID: 141
       Name: '*hash<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 160 GoHMapHeaderType hash<[4]int,uint8>
+      Pointee: 142 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: GoHMapHeaderType
-      ID: 160
+      ID: 142
       Name: hash<[4]int,uint8>
       ByteSize: 48
       RawFields:
@@ -4819,63 +4643,63 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 161 PointerType *bucket<[4]int,uint8>
+          Type: 143 PointerType *bucket<[4]int,uint8>
         - Name: oldbuckets
           Offset: 24
-          Type: 161 PointerType *bucket<[4]int,uint8>
+          Type: 143 PointerType *bucket<[4]int,uint8>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 162 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 214 GoSliceDataType []bucket<[4]int,uint8>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
+      BucketsType: 194 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: PointerType
-      ID: 161
+      ID: 143
       Name: '*bucket<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 162 GoHMapBucketType bucket<[4]int,uint8>
+      Pointee: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoHMapBucketType
-      ID: 162
+      ID: 144
       Name: bucket<[4]int,uint8>
       ByteSize: 280
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<[4]int>
+          Type: 145 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 144 ArrayType []val<uint8>
+          Type: 126 ArrayType []val<uint8>
         - Name: overflow
           Offset: 272
-          Type: 161 PointerType *bucket<[4]int,uint8>
-      KeyType: 157 ArrayType [4]int
+          Type: 143 PointerType *bucket<[4]int,uint8>
+      KeyType: 139 ArrayType [4]int
       ValueType: 4 BaseType uint8
     - __kind: ArrayType
-      ID: 163
+      ID: 145
       Name: '[]key<[4]int>'
       ByteSize: 256
       Count: 8
       HasCount: true
-      Element: 157 ArrayType [4]int
+      Element: 139 ArrayType [4]int
     - __kind: GoMapType
-      ID: 164
+      ID: 146
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 873952
       GoKind: 21
-      HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
+      HeaderType: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*hash<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 166 GoHMapHeaderType hash<[4]int,[4]int>
+      Pointee: 148 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: GoHMapHeaderType
-      ID: 166
+      ID: 148
       Name: hash<[4]int,[4]int>
       ByteSize: 48
       RawFields:
@@ -4896,55 +4720,55 @@ Types:
           Type: 24 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 167 PointerType *bucket<[4]int,[4]int>
+          Type: 149 PointerType *bucket<[4]int,[4]int>
         - Name: oldbuckets
           Offset: 24
-          Type: 167 PointerType *bucket<[4]int,[4]int>
+          Type: 149 PointerType *bucket<[4]int,[4]int>
         - Name: nevacuate
           Offset: 32
-          Type: 44 BaseType uintptr
+          Type: 66 BaseType uintptr
         - Name: extra
           Offset: 40
-          Type: 85 PointerType *runtime.mapextra
-      BucketType: 168 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 215 GoSliceDataType []bucket<[4]int,[4]int>.array
+          Type: 67 PointerType *runtime.mapextra
+      BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
+      BucketsType: 195 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: PointerType
-      ID: 167
+      ID: 149
       Name: '*bucket<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      Pointee: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoHMapBucketType
-      ID: 168
+      ID: 150
       Name: bucket<[4]int,[4]int>
       ByteSize: 528
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 82 ArrayType [8]uint8
+          Type: 63 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 163 ArrayType []key<[4]int>
+          Type: 145 ArrayType []key<[4]int>
         - Name: values
           Offset: 264
-          Type: 156 ArrayType []val<[4]int>
+          Type: 138 ArrayType []val<[4]int>
         - Name: overflow
           Offset: 520
-          Type: 167 PointerType *bucket<[4]int,[4]int>
-      KeyType: 157 ArrayType [4]int
-      ValueType: 157 ArrayType [4]int
+          Type: 149 PointerType *bucket<[4]int,[4]int>
+      KeyType: 139 ArrayType [4]int
+      ValueType: 139 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 169
+      ID: 151
       Name: chan bool
       GoRuntimeType: 539328
       GoKind: 18
     - __kind: PointerType
-      ID: 170
+      ID: 152
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 171 StructureType main.structWithTwoValues
+      Pointee: 153 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 171
+      ID: 153
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -4956,48 +4780,48 @@ Types:
           Offset: 8
           Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 172
+      ID: 154
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 359904
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 173
+      ID: 155
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 360288
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 174
+      ID: 156
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 175 GoSliceHeaderType main.t
+      Pointee: 157 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 175
+      ID: 157
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 176 PointerType **main.t
+          Type: 158 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 216 GoSliceDataType main.t.array
+      Data: 196 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 174 PointerType *main.t
+      Pointee: 156 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 177
+      ID: 159
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 449504
@@ -5005,58 +4829,58 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 172 PointerType *uint
+          Type: 154 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 218 GoSliceDataType []uint.array
+      Data: 198 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 178
+      ID: 160
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 179 PointerType *[]uint
+          Type: 161 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 220 GoSliceDataType [][]uint.array
+      Data: 200 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 177 GoSliceHeaderType []uint
+      Pointee: 159 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 180
+      ID: 162
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 181 PointerType *main.structWithNoStrings
+          Type: 163 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 222 GoSliceDataType []main.structWithNoStrings.array
+      Data: 202 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 181
+      ID: 163
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 182 StructureType main.structWithNoStrings
+      Pointee: 164 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 182
+      ID: 164
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -5068,7 +4892,7 @@ Types:
           Offset: 1
           Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 183
+      ID: 165
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 449888
@@ -5076,16 +4900,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 173 PointerType *bool
+          Type: 155 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 224 GoSliceDataType []bool.array
+      Data: 204 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 184
+      ID: 166
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 448864
@@ -5093,23 +4917,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 185 PointerType *uint16
+          Type: 167 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 226 GoSliceDataType []uint16.array
+      Data: 206 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 185
+      ID: 167
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 359520
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 186
+      ID: 168
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -5124,19 +4948,19 @@ Types:
           Offset: 32
           Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 186 StructureType main.threeStringStruct
+      Pointee: 168 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 188
+      ID: 170
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 189 StructureType main.oneStringStruct
+      Pointee: 171 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 189
+      ID: 171
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -5145,7 +4969,7 @@ Types:
           Offset: 0
           Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 190
+      ID: 172
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5161,193 +4985,183 @@ Types:
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 99 StructureType main.nestedStruct
+          Type: 81 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 191
+      ID: 173
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 192
+      ID: 174
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 192 GoStringDataType string.str
+      Pointee: 174 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 176
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 195
+      ID: 177
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 194 GoSliceDataType []*string.array
+      Pointee: 176 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 196
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 53 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 197
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 196 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 198
+      ID: 178
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
-      Element: 81 GoHMapBucketType bucket<int,int>
+      Element: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 199
+      ID: 179
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
-      Element: 90 PointerType *runtime.bmap
+      Element: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 200
+      ID: 180
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 199 GoSliceDataType []*runtime.bmap.array
+      Pointee: 179 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 201
+      ID: 181
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
-      Element: 96 GoHMapBucketType bucket<string,main.nestedStruct>
+      Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 182
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
-      Element: 104 GoHMapBucketType bucket<string,int>
+      Element: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 203
+      ID: 183
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
-      Element: 109 GoHMapBucketType bucket<string,[]string>
+      Element: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 184
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 205
+      ID: 185
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []string.array
+      Pointee: 184 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 186
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
-      Element: 116 GoHMapBucketType bucket<[4]string,[2]int>
+      Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 207
+      ID: 187
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
-      Element: 126 GoHMapBucketType bucket<string,[]main.structWithMap>
+      Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 208
+      ID: 188
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 76 StructureType main.structWithMap
+      Element: 57 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 209
+      ID: 189
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 208 GoSliceDataType []main.structWithMap.array
+      Pointee: 188 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 210
+      ID: 190
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
-      Element: 134 GoHMapBucketType bucket<bool,main.node>
+      Element: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 211
+      ID: 191
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
-      Element: 143 GoHMapBucketType bucket<int,uint8>
+      Element: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 212
+      ID: 192
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
-      Element: 149 GoHMapBucketType bucket<uint8,uint8>
+      Element: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 213
+      ID: 193
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
-      Element: 155 GoHMapBucketType bucket<uint8,[4]int>
+      Element: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 214
+      ID: 194
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
-      Element: 162 GoHMapBucketType bucket<[4]int,uint8>
+      Element: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 215
+      ID: 195
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
-      Element: 168 GoHMapBucketType bucket<[4]int,[4]int>
+      Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 216
+      ID: 196
       Name: main.t.array
       ByteSize: 2048
-      Element: 174 PointerType *main.t
+      Element: 156 PointerType *main.t
     - __kind: PointerType
-      ID: 217
+      ID: 197
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 216 GoSliceDataType main.t.array
+      Pointee: 196 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 218
+      ID: 198
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 219
+      ID: 199
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 218 GoSliceDataType []uint.array
+      Pointee: 198 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 220
+      ID: 200
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 177 GoSliceHeaderType []uint
+      Element: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 221
+      ID: 201
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 220 GoSliceDataType [][]uint.array
+      Pointee: 200 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 222
+      ID: 202
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 182 StructureType main.structWithNoStrings
+      Element: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 223
+      ID: 203
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 222 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 202 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 224
+      ID: 204
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 205
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 224 GoSliceDataType []bool.array
+      Pointee: 204 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 226
+      ID: 206
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 227
+      ID: 207
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 226 GoSliceDataType []uint16.array
+      Pointee: 206 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 228
+      ID: 208
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5362,7 +5176,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 229
+      ID: 209
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5377,7 +5191,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 230
+      ID: 210
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5392,7 +5206,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 231
+      ID: 211
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5407,7 +5221,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 212
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5422,7 +5236,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 233
+      ID: 213
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5437,7 +5251,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 234
+      ID: 214
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5452,7 +5266,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 235
+      ID: 215
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5467,7 +5281,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 236
+      ID: 216
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5482,7 +5296,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 217
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5497,7 +5311,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 238
+      ID: 218
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5512,7 +5326,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 239
+      ID: 219
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5527,7 +5341,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 240
+      ID: 220
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5542,7 +5356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 221
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5557,7 +5371,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 222
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5572,7 +5386,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 243
+      ID: 223
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5587,7 +5401,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 244
+      ID: 224
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5602,7 +5416,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 245
+      ID: 225
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5617,7 +5431,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 246
+      ID: 226
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5632,7 +5446,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 247
+      ID: 227
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5647,7 +5461,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 248
+      ID: 228
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5662,7 +5476,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 249
+      ID: 229
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5677,7 +5491,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 250
+      ID: 230
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5692,7 +5506,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 251
+      ID: 231
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5707,7 +5521,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 252
+      ID: 232
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5722,7 +5536,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 253
+      ID: 233
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5737,7 +5551,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 254
+      ID: 234
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5752,7 +5566,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 255
+      ID: 235
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5767,7 +5581,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 256
+      ID: 236
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5782,7 +5596,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 257
+      ID: 237
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5797,7 +5611,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 258
+      ID: 238
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5812,7 +5626,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 259
+      ID: 239
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5827,7 +5641,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 260
+      ID: 240
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5842,7 +5656,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 241
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5857,7 +5671,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 262
+      ID: 242
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5872,7 +5686,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 263
+      ID: 243
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5880,14 +5694,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 StructureType main.esotericStack
+            Type: 39 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 264
+      ID: 244
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5895,14 +5709,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 63 PointerType *main.esotericHeap
+            Type: 44 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 245
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5917,7 +5731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 246
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5941,7 +5755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 247
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5956,10 +5770,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 248
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 269
+      ID: 249
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5974,7 +5788,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 250
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5989,7 +5803,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 271
+      ID: 251
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5997,14 +5811,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 74 GoInterfaceType main.behavior
+            Type: 55 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 252
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6012,14 +5826,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 59 GoEmptyInterfaceType interface {}
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 253
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6027,14 +5841,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType error
+            Type: 56 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 254
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6042,14 +5856,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 76 StructureType main.structWithMap
+            Type: 57 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 255
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6057,14 +5871,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 92 GoMapType map[string]main.nestedStruct
+            Type: 74 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 256
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6072,14 +5886,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 82 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 257
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6087,14 +5901,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 105 GoMapType map[string][]string
+            Type: 87 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 258
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6102,14 +5916,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[[4]string][2]int
+            Type: 94 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 259
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6117,14 +5931,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 100 GoMapType map[string]int
+            Type: 82 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 260
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6132,14 +5946,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 120 ArrayType [2]map[string]int
+            Type: 102 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 261
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6147,14 +5961,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 121 PointerType *map[string]int
+            Type: 103 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 262
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6162,14 +5976,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 77 GoMapType map[int]int
+            Type: 58 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 263
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6177,14 +5991,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[string][]main.structWithMap
+            Type: 104 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 264
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6192,14 +6006,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 122 GoMapType map[string][]main.structWithMap
+            Type: 104 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 265
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6207,14 +6021,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 130 GoMapType map[bool]main.node
+            Type: 112 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 266
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6222,14 +6036,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[int]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 287
+      ID: 267
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6237,14 +6051,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 139 GoMapType map[int]uint8
+            Type: 121 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 288
+      ID: 268
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6252,14 +6066,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 269
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6267,14 +6081,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 270
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6282,14 +6096,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 145 GoMapType map[uint8]uint8
+            Type: 127 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 271
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6297,14 +6111,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 151 GoMapType map[uint8][4]int
+            Type: 133 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 272
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6312,14 +6126,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 158 GoMapType map[[4]int]uint8
+            Type: 140 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 273
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6327,14 +6141,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[[4]int][4]int
+            Type: 146 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 294
+      ID: 274
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6367,7 +6181,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 295
+      ID: 275
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6418,7 +6232,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 276
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6426,14 +6240,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 169 GoChannelType chan bool
+            Type: 151 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 297
+      ID: 277
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6441,14 +6255,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 170 PointerType *main.structWithTwoValues
+            Type: 152 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 278
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6456,14 +6270,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 137 StructureType main.node
+            Type: 119 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 279
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6471,14 +6285,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 138 PointerType *main.node
+            Type: 120 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 280
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6486,14 +6300,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 56 VoidPointerType unsafe.Pointer
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 281
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6501,14 +6315,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 172 PointerType *uint
+            Type: 154 PointerType *uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 282
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6523,7 +6337,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 283
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6531,7 +6345,7 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 173 PointerType *bool
+            Type: 155 PointerType *bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: z}
@@ -6547,7 +6361,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6555,14 +6369,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 174 PointerType *main.t
+            Type: 156 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6570,14 +6384,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 306
+      ID: 286
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6585,14 +6399,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 307
+      ID: 287
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6600,14 +6414,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 178 GoSliceHeaderType [][]uint
+            Type: 160 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 308
+      ID: 288
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6615,7 +6429,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -6631,7 +6445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 289
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6639,7 +6453,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 88, index: 0, name: xs}
@@ -6655,7 +6469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 310
+      ID: 290
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6663,7 +6477,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Type: 162 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 89, index: 0, name: xs}
@@ -6679,7 +6493,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 291
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6687,14 +6501,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 111 GoSliceHeaderType []string
+            Type: 93 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 312
+      ID: 292
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6711,7 +6525,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 183 GoSliceHeaderType []bool
+            Type: 165 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 1, name: s}
@@ -6727,7 +6541,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 293
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6735,14 +6549,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 184 GoSliceHeaderType []uint16
+            Type: 166 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 314
+      ID: 294
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6750,17 +6564,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 177 GoSliceHeaderType []uint
+            Type: 159 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 315
+      ID: 295
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 316
+      ID: 296
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6775,7 +6589,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
+      ID: 297
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6808,7 +6622,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 298
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6816,14 +6630,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 186 StructureType main.threeStringStruct
+            Type: 168 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 319
+      ID: 299
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6831,14 +6645,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 187 PointerType *main.threeStringStruct
+            Type: 169 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 300
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6846,14 +6660,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 188 PointerType *main.oneStringStruct
+            Type: 170 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 301
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6868,7 +6682,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
+      ID: 302
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6883,7 +6697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 303
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6898,7 +6712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 324
+      ID: 304
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6906,14 +6720,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 190 StructureType main.aStruct
+            Type: 172 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 325
+      ID: 305
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6921,14 +6735,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 191 StructureType main.emptyStruct
+            Type: 173 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 326
+      ID: 306
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6943,16 +6757,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 307
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 328
+      ID: 308
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 329
+      ID: 309
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 330
+      ID: 310
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6967,7 +6781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 311
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6981,5 +6795,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 331
+MaxTypeID: 311
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,11 +8,25 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 87
-          Type: 314 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x88f4fc", Frameless: true}]
+        - ID: 88
+          Type: 315 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x88f5fc", Frameless: true}]
+          Condition: null
+    - id: testAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAny}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 272 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x88d16c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -26,7 +40,7 @@ Probes:
       events:
         - ID: 15
           Type: 242 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x88be70", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -40,7 +54,7 @@ Probes:
       events:
         - ID: 17
           Type: 244 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x88be90", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -50,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 52
-          Type: 279 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88d550", Frameless: true}]
+        - ID: 53
+          Type: 280 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x88d650", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -68,7 +82,7 @@ Probes:
       events:
         - ID: 16
           Type: 243 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x88be80", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -82,7 +96,7 @@ Probes:
       events:
         - ID: 35
           Type: 262 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x88c3f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c460", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -96,7 +110,7 @@ Probes:
       events:
         - ID: 4
           Type: 231 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x88bdc0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be30", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -110,7 +124,7 @@ Probes:
       events:
         - ID: 1
           Type: 228 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x88bd90", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be00", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -120,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 68
-          Type: 295 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88eb00", Frameless: true}]
+        - ID: 69
+          Type: 296 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88ec00", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 66
-          Type: 293 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88e880", Frameless: true}]
+        - ID: 67
+          Type: 294 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x88e980", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 76
-          Type: 303 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
+        - ID: 77
+          Type: 304 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88eea0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 78
-          Type: 305 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x88f1a0", Frameless: true}]
+        - ID: 79
+          Type: 306 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x88f2a0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 81
-          Type: 308 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x88f1d0", Frameless: true}]
+        - ID: 82
+          Type: 309 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x88f2d0", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 95
-          Type: 322 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x88f5e0", Frameless: true}]
+        - ID: 96
+          Type: 323 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x88f6e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 97
-          Type: 324 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
+        - ID: 98
+          Type: 325 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +232,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 45
-          Type: 272 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88d290", Frameless: true}]
+        - ID: 46
+          Type: 273 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -236,7 +250,7 @@ Probes:
       events:
         - ID: 37
           Type: 264 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x88c6ac", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -250,7 +264,7 @@ Probes:
       events:
         - ID: 36
           Type: 263 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x88c5bc", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c62c", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -264,7 +278,7 @@ Probes:
       events:
         - ID: 42
           Type: 269 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x88cde0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ce50", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -278,7 +292,7 @@ Probes:
       events:
         - ID: 43
           Type: 270 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x88cdf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ce60", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -292,7 +306,7 @@ Probes:
       events:
         - ID: 38
           Type: 265 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x88caec", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cb5c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -306,7 +320,7 @@ Probes:
       events:
         - ID: 39
           Type: 266 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x88cb7c", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cbec", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -320,7 +334,7 @@ Probes:
       events:
         - ID: 40
           Type: 267 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x88cc4c", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ccbc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -332,9 +346,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 99
-          Type: 326 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x88cbd8", Frameless: false}]
+        - ID: 100
+          Type: 327 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x88cc48", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -348,7 +362,7 @@ Probes:
       events:
         - ID: 41
           Type: 268 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x88cccc", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cd3c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -360,9 +374,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 100
-          Type: 327 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x88ccdc", Frameless: false}]
+        - ID: 101
+          Type: 328 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x88cd4c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -374,9 +388,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 101
-          Type: 328 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x88cd90", Frameless: false}]
+        - ID: 102
+          Type: 329 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x88ce00", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -389,18 +403,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 98
-          Type: 325 EventRootType Probe[main.testInlinedPrint]
+        - ID: 99
+          Type: 326 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x88c94c"
+            - PC: "0x88c9bc"
               Frameless: true
-            - PC: "0x88c9cc"
+            - PC: "0x88ca3c"
               Frameless: false
-            - PC: "0x88cb18"
+            - PC: "0x88cb88"
               Frameless: false
-            - PC: "0x88cb94"
+            - PC: "0x88cc04"
               Frameless: false
-            - PC: "0x88cc5c"
+            - PC: "0x88cccc"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -413,9 +427,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 102
-          Type: 329 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x88cde4", Frameless: true}]
+        - ID: 103
+          Type: 330 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x88ce54", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -428,12 +442,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 103
-          Type: 330 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 104
+          Type: 331 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x88ce14"
+            - PC: "0x88ce84"
               Frameless: false
-            - PC: "0x88ceac"
+            - PC: "0x88cf1c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -448,7 +462,7 @@ Probes:
       events:
         - ID: 7
           Type: 234 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x88bdf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be60", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -462,7 +476,7 @@ Probes:
       events:
         - ID: 8
           Type: 235 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x88be00", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be70", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -476,7 +490,7 @@ Probes:
       events:
         - ID: 9
           Type: 236 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x88be10", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be80", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -490,7 +504,7 @@ Probes:
       events:
         - ID: 6
           Type: 233 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x88bde0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be50", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -504,13 +518,13 @@ Probes:
       events:
         - ID: 5
           Type: 232 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x88bdd0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be40", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInterface}
-      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
@@ -518,7 +532,7 @@ Probes:
       events:
         - ID: 44
           Type: 271 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88d0a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88d10c", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -528,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 70
-          Type: 297 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88ecb0", Frameless: true}]
+        - ID: 71
+          Type: 298 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88edb0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -542,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 50
-          Type: 277 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88d530", Frameless: true}]
+        - ID: 51
+          Type: 278 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x88d630", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -556,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 56
-          Type: 283 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88d590", Frameless: true}]
+        - ID: 57
+          Type: 284 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x88d690", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -570,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 54
-          Type: 281 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88d570", Frameless: true}]
+        - ID: 55
+          Type: 282 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x88d670", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -584,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 65
-          Type: 292 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88d620", Frameless: true}]
+        - ID: 66
+          Type: 293 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x88d720", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -598,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 64
-          Type: 291 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88d610", Frameless: true}]
+        - ID: 65
+          Type: 292 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x88d710", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -612,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 55
-          Type: 282 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88d580", Frameless: true}]
+        - ID: 56
+          Type: 283 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x88d680", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -626,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 63
-          Type: 290 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88d600", Frameless: true}]
+        - ID: 64
+          Type: 291 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x88d700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -640,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 62
-          Type: 289 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
+        - ID: 63
+          Type: 290 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x88d6f0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -654,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 48
-          Type: 275 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88d510", Frameless: true}]
+        - ID: 49
+          Type: 276 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x88d610", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -668,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 49
-          Type: 276 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88d520", Frameless: true}]
+        - ID: 50
+          Type: 277 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x88d620", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -682,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 47
-          Type: 274 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88d500", Frameless: true}]
+        - ID: 48
+          Type: 275 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x88d600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -696,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 57
-          Type: 284 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88d5a0", Frameless: true}]
+        - ID: 58
+          Type: 285 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -710,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 60
-          Type: 287 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88d5d0", Frameless: true}]
+        - ID: 61
+          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -724,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 61
-          Type: 288 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88d5e0", Frameless: true}]
+        - ID: 62
+          Type: 289 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x88d6e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -738,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 58
-          Type: 285 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88d5b0", Frameless: true}]
+        - ID: 59
+          Type: 286 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -752,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 59
-          Type: 286 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88d5c0", Frameless: true}]
+        - ID: 60
+          Type: 287 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -766,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 93
-          Type: 320 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x88f5c0", Frameless: true}]
+        - ID: 94
+          Type: 321 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x88f6c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -780,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 67
-          Type: 294 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88e960", Frameless: true}]
+        - ID: 68
+          Type: 295 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x88ea60", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -794,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 75
-          Type: 302 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88ed80", Frameless: true}]
+        - ID: 76
+          Type: 303 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -808,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 85
-          Type: 312 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x88f210", Frameless: true}]
+        - ID: 86
+          Type: 313 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x88f310", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -822,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 82
-          Type: 309 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x88f1e0", Frameless: true}]
+        - ID: 83
+          Type: 310 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x88f2e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -836,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 84
-          Type: 311 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x88f200", Frameless: true}]
+        - ID: 85
+          Type: 312 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x88f300", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -850,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 92
-          Type: 319 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x88f5b0", Frameless: true}]
+        - ID: 93
+          Type: 320 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x88f6b0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -864,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 71
-          Type: 298 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88ecc0", Frameless: true}]
+        - ID: 72
+          Type: 299 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -878,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 53
-          Type: 280 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88d560", Frameless: true}]
+        - ID: 54
+          Type: 281 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x88d660", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -892,11 +906,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 69
-          Type: 296 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88eca0", Frameless: true}]
+        - ID: 70
+          Type: 297 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -910,7 +924,7 @@ Probes:
       events:
         - ID: 2
           Type: 229 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x88bda0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be10", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -924,7 +938,7 @@ Probes:
       events:
         - ID: 21
           Type: 248 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x88c210", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -938,7 +952,7 @@ Probes:
       events:
         - ID: 19
           Type: 246 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x88c1f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -952,7 +966,7 @@ Probes:
       events:
         - ID: 32
           Type: 259 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -966,7 +980,7 @@ Probes:
       events:
         - ID: 33
           Type: 260 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -980,7 +994,7 @@ Probes:
       events:
         - ID: 22
           Type: 249 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x88c220", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -994,7 +1008,7 @@ Probes:
       events:
         - ID: 24
           Type: 251 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x88c240", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1008,7 +1022,7 @@ Probes:
       events:
         - ID: 25
           Type: 252 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x88c250", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1022,7 +1036,7 @@ Probes:
       events:
         - ID: 26
           Type: 253 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1036,7 +1050,7 @@ Probes:
       events:
         - ID: 23
           Type: 250 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x88c230", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1050,7 +1064,7 @@ Probes:
       events:
         - ID: 20
           Type: 247 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x88c200", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1060,11 +1074,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 88
-          Type: 315 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x88f560", Frameless: true}]
+        - ID: 89
+          Type: 316 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x88f660", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1078,7 +1092,7 @@ Probes:
       events:
         - ID: 27
           Type: 254 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1092,7 +1106,7 @@ Probes:
       events:
         - ID: 29
           Type: 256 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1106,7 +1120,7 @@ Probes:
       events:
         - ID: 30
           Type: 257 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1120,7 +1134,7 @@ Probes:
       events:
         - ID: 31
           Type: 258 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1134,7 +1148,7 @@ Probes:
       events:
         - ID: 28
           Type: 255 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1144,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 79
-          Type: 306 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x88f1b0", Frameless: true}]
+        - ID: 80
+          Type: 307 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x88f2b0", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1158,11 +1172,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 51
-          Type: 278 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88d540", Frameless: true}]
+        - ID: 52
+          Type: 279 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x88d640", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1176,7 +1190,7 @@ Probes:
       events:
         - ID: 3
           Type: 230 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x88bdb0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be20", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1186,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 74
-          Type: 301 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88ed60", Frameless: true}]
+        - ID: 75
+          Type: 302 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88ee60", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1200,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 83
-          Type: 310 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x88f1f0", Frameless: true}]
+        - ID: 84
+          Type: 311 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x88f2f0", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1214,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 96
-          Type: 323 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x88f7f0", Frameless: true}]
+        - ID: 97
+          Type: 324 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1228,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 80
-          Type: 307 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x88f1c0", Frameless: true}]
+        - ID: 81
+          Type: 308 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x88f2c0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1242,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 46
-          Type: 273 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88d4f0", Frameless: true}]
+        - ID: 47
+          Type: 274 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1256,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 89
-          Type: 316 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x88f570", Frameless: true}]
+        - ID: 90
+          Type: 317 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x88f670", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1270,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 90
-          Type: 317 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x88f580", Frameless: true}]
+        - ID: 91
+          Type: 318 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x88f680", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1284,11 +1298,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 91
-          Type: 318 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x88f5a0", Frameless: true}]
+        - ID: 92
+          Type: 319 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x88f6a0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1302,7 +1316,7 @@ Probes:
       events:
         - ID: 34
           Type: 261 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1316,7 +1330,7 @@ Probes:
       events:
         - ID: 12
           Type: 239 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x88be40", Frameless: true}]
+          InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1330,7 +1344,7 @@ Probes:
       events:
         - ID: 13
           Type: 240 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x88be50", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1344,7 +1358,7 @@ Probes:
       events:
         - ID: 14
           Type: 241 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x88be60", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1358,7 +1372,7 @@ Probes:
       events:
         - ID: 11
           Type: 238 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x88be30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1372,7 +1386,7 @@ Probes:
       events:
         - ID: 10
           Type: 237 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x88be20", Frameless: true}]
+          InjectionPoints: [{PC: "0x88be90", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1382,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 73
-          Type: 300 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88ecf0", Frameless: true}]
+        - ID: 74
+          Type: 301 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1396,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 77
-          Type: 304 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x88f190", Frameless: true}]
+        - ID: 78
+          Type: 305 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x88f290", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1410,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 94
-          Type: 321 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x88f5d0", Frameless: true}]
+        - ID: 95
+          Type: 322 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x88f6d0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1424,11 +1438,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 72
-          Type: 299 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88ecd0", Frameless: true}]
+        - ID: 73
+          Type: 300 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1442,7 +1456,7 @@ Probes:
       events:
         - ID: 18
           Type: 245 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88bf30", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1452,430 +1466,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 86
-          Type: 313 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x88f220", Frameless: true}]
+        - ID: 87
+          Type: 314 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x88f320", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88bd90..0x88bda0]
+      OutOfLinePCRanges: [0x88be00..0x88be10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0x88bd90..0x88bda0
+            - Range: 0x88be00..0x88be10
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88bda0..0x88bdb0]
+      OutOfLinePCRanges: [0x88be10..0x88be20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
-            - Range: 0x88bda0..0x88bdb0
+            - Range: 0x88be10..0x88be20
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88bdb0..0x88bdc0]
+      OutOfLinePCRanges: [0x88be20..0x88be30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0x88bdb0..0x88bdc0
+            - Range: 0x88be20..0x88be30
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88bdc0..0x88bdd0]
+      OutOfLinePCRanges: [0x88be30..0x88be40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 ArrayType [2]bool
           Locations:
-            - Range: 0x88bdc0..0x88bdd0
+            - Range: 0x88be30..0x88be40
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88bdd0..0x88bde0]
+      OutOfLinePCRanges: [0x88be40..0x88be50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 ArrayType [2]int
           Locations:
-            - Range: 0x88bdd0..0x88bde0
+            - Range: 0x88be40..0x88be50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88bde0..0x88bdf0]
+      OutOfLinePCRanges: [0x88be50..0x88be60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 ArrayType [2]int8
           Locations:
-            - Range: 0x88bde0..0x88bdf0
+            - Range: 0x88be50..0x88be60
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88bdf0..0x88be00]
+      OutOfLinePCRanges: [0x88be60..0x88be70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 ArrayType [2]int16
           Locations:
-            - Range: 0x88bdf0..0x88be00
+            - Range: 0x88be60..0x88be70
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88be00..0x88be10]
+      OutOfLinePCRanges: [0x88be70..0x88be80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
-            - Range: 0x88be00..0x88be10
+            - Range: 0x88be70..0x88be80
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88be10..0x88be20]
+      OutOfLinePCRanges: [0x88be80..0x88be90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 ArrayType [2]int64
           Locations:
-            - Range: 0x88be10..0x88be20
+            - Range: 0x88be80..0x88be90
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x88be20..0x88be30]
+      OutOfLinePCRanges: [0x88be90..0x88bea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 ArrayType [2]uint
           Locations:
-            - Range: 0x88be20..0x88be30
+            - Range: 0x88be90..0x88bea0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88be30..0x88be40]
+      OutOfLinePCRanges: [0x88bea0..0x88beb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0x88be30..0x88be40
+            - Range: 0x88bea0..0x88beb0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88be40..0x88be50]
+      OutOfLinePCRanges: [0x88beb0..0x88bec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 ArrayType [2]uint16
           Locations:
-            - Range: 0x88be40..0x88be50
+            - Range: 0x88beb0..0x88bec0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88be50..0x88be60]
+      OutOfLinePCRanges: [0x88bec0..0x88bed0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 ArrayType [2]uint32
           Locations:
-            - Range: 0x88be50..0x88be60
+            - Range: 0x88bec0..0x88bed0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88be60..0x88be70]
+      OutOfLinePCRanges: [0x88bed0..0x88bee0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 25 ArrayType [2]uint64
           Locations:
-            - Range: 0x88be60..0x88be70
+            - Range: 0x88bed0..0x88bee0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88be70..0x88be80]
+      OutOfLinePCRanges: [0x88bee0..0x88bef0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 27 ArrayType [2][2]int
           Locations:
-            - Range: 0x88be70..0x88be80
+            - Range: 0x88bee0..0x88bef0
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x88be80..0x88be90]
+      OutOfLinePCRanges: [0x88bef0..0x88bf00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0x88be80..0x88be90
+            - Range: 0x88bef0..0x88bf00
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88be90..0x88bea0]
+      OutOfLinePCRanges: [0x88bf00..0x88bf10]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 28 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88be90..0x88bea0
+            - Range: 0x88bf00..0x88bf10
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88bec0..0x88bed0]
+      OutOfLinePCRanges: [0x88bf30..0x88bf40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 29 ArrayType [100]uint
           Locations:
-            - Range: 0x88bec0..0x88bed0
+            - Range: 0x88bf30..0x88bf40
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88c1f0..0x88c200]
+      OutOfLinePCRanges: [0x88c260..0x88c270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88c1f0..0x88c200
+            - Range: 0x88c260..0x88c270
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88c200..0x88c210]
+      OutOfLinePCRanges: [0x88c270..0x88c280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x88c200..0x88c210
+            - Range: 0x88c270..0x88c280
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88c210..0x88c220]
+      OutOfLinePCRanges: [0x88c280..0x88c290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType bool
           Locations:
-            - Range: 0x88c210..0x88c220
+            - Range: 0x88c280..0x88c290
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88c220..0x88c230]
+      OutOfLinePCRanges: [0x88c290..0x88c2a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88c220..0x88c230
+            - Range: 0x88c290..0x88c2a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88c230..0x88c240]
+      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x88c230..0x88c240
+            - Range: 0x88c2a0..0x88c2b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88c240..0x88c250]
+      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int16
           Locations:
-            - Range: 0x88c240..0x88c250
+            - Range: 0x88c2b0..0x88c2c0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88c250..0x88c260]
+      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x88c250..0x88c260
+            - Range: 0x88c2c0..0x88c2d0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88c260..0x88c270]
+      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int64
           Locations:
-            - Range: 0x88c260..0x88c270
+            - Range: 0x88c2d0..0x88c2e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88c270..0x88c280]
+      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x88c270..0x88c280
+            - Range: 0x88c2e0..0x88c2f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88c280..0x88c290]
+      OutOfLinePCRanges: [0x88c2f0..0x88c300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88c280..0x88c290
+            - Range: 0x88c2f0..0x88c300
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88c290..0x88c2a0]
+      OutOfLinePCRanges: [0x88c300..0x88c310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 22 BaseType uint16
           Locations:
-            - Range: 0x88c290..0x88c2a0
+            - Range: 0x88c300..0x88c310
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 36
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
+      OutOfLinePCRanges: [0x88c310..0x88c320]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 24 BaseType uint32
           Locations:
-            - Range: 0x88c2a0..0x88c2b0
+            - Range: 0x88c310..0x88c320
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 37
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
+      OutOfLinePCRanges: [0x88c320..0x88c330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 26 BaseType uint64
           Locations:
-            - Range: 0x88c2b0..0x88c2c0
+            - Range: 0x88c320..0x88c330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 38
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
+      OutOfLinePCRanges: [0x88c330..0x88c340]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 30 BaseType float32
           Locations:
-            - Range: 0x88c2c0..0x88c2d0
+            - Range: 0x88c330..0x88c340
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 39
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
+      OutOfLinePCRanges: [0x88c340..0x88c350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType float64
           Locations:
-            - Range: 0x88c2d0..0x88c2e0
+            - Range: 0x88c340..0x88c350
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 40
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
+      OutOfLinePCRanges: [0x88c350..0x88c360]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 32 BaseType main.typeAlias
           Locations:
-            - Range: 0x88c2e0..0x88c2f0
+            - Range: 0x88c350..0x88c360
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 41
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88c3f0..0x88c410]
+      OutOfLinePCRanges: [0x88c460..0x88c480]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 33 StructureType main.bigStruct
           Locations:
-            - Range: 0x88c3f0..0x88c410
+            - Range: 0x88c460..0x88c480
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1893,13 +1907,13 @@ Subprograms:
           IsReturn: false
     - ID: 42
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88c5b0..0x88c6a0]
+      OutOfLinePCRanges: [0x88c620..0x88c710]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 57 StructureType main.esotericStack
           Locations:
-            - Range: 0x88c5b0..0x88c5f8
+            - Range: 0x88c620..0x88c668
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1919,7 +1933,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88c5f8..0x88c5fc
+            - Range: 0x88c668..0x88c66c
               Pieces:
                 - Size: 4
                   Op: null
@@ -1939,7 +1953,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88c5fc..0x88c600
+            - Range: 0x88c66c..0x88c670
               Pieces:
                 - Size: 4
                   Op: null
@@ -1963,281 +1977,192 @@ Subprograms:
           IsReturn: false
     - ID: 43
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88c6a0..0x88c720]
+      OutOfLinePCRanges: [0x88c710..0x88c790]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 63 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88c6a0..0x88c6d8
+            - Range: 0x88c710..0x88c748
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 44
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88cae0..0x88cb70]
+      OutOfLinePCRanges: [0x88cb50..0x88cbe0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cae0..0x88cb18
+            - Range: 0x88cb50..0x88cb88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 45
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88cb70..0x88cc40]
+      OutOfLinePCRanges: [0x88cbe0..0x88ccb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cb70..0x88cb8c
+            - Range: 0x88cbe0..0x88cbfc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cb70..0x88cb9c
+            - Range: 0x88cbe0..0x88cc0c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cb8c..0x88cb9c
+            - Range: 0x88cbfc..0x88cc0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cb9c..0x88cc40
+            - Range: 0x88cc0c..0x88ccb0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
     - ID: 46
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88cc40..0x88ccc0]
+      OutOfLinePCRanges: [0x88ccb0..0x88cd30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cc40..0x88cc64
+            - Range: 0x88ccb0..0x88ccd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88ccc0..0x88cde0]
+      OutOfLinePCRanges: [0x88cd30..0x88ce50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cd28..0x88cd30
+            - Range: 0x88cd98..0x88cda0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88cd30..0x88cd48
+            - Range: 0x88cda0..0x88cdb8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88cd48..0x88cd5c
+            - Range: 0x88cdb8..0x88cdcc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cd24..0x88cd2c
+            - Range: 0x88cd94..0x88cd9c
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88cd2c..0x88cd48
+            - Range: 0x88cd9c..0x88cdb8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88cd48..0x88cd58
+            - Range: 0x88cdb8..0x88cdc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
     - ID: 48
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88cde0..0x88cdf0]
+      OutOfLinePCRanges: [0x88ce50..0x88ce60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cde0..0x88cde8
+            - Range: 0x88ce50..0x88ce58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0x88cde0..0x88cdf0, Pieces: []}]
+          Locations: [{Range: 0x88ce50..0x88ce60, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 49
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88cdf0..0x88ce50]
+      OutOfLinePCRanges: [0x88ce60..0x88cec0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0x88cdf0..0x88ce50
+            - Range: 0x88ce60..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0x88cdf0..0x88ce50, Pieces: []}]
+          Locations: [{Range: 0x88ce60..0x88cec0, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88d090..0x88d290]
+      OutOfLinePCRanges: [0x88d100..0x88d160]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 74 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88d090..0x88d0bc
+            - Range: 0x88d100..0x88d128
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d0bc..0x88d0c0
+            - Range: 0x88d128..0x88d12c
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0x88d090..0x88d290, Pieces: []}]
+          Locations: [{Range: 0x88d100..0x88d160, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: hash
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x88d0f0..0x88d0f4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x88d0f4..0x88d108
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d108..0x88d10c
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-            - Range: 0x88d10c..0x88d290
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-          IsParameter: false
-          IsReturn: false
-        - Name: inter
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x88d138..0x88d13c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x88d13c..0x88d150
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d150..0x88d154
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-            - Range: 0x88d154..0x88d290
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-          IsParameter: false
-          IsReturn: false
-        - Name: iType
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x88d180..0x88d184
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x88d184..0x88d1a0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d1a0..0x88d1a4
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-            - Range: 0x88d1a4..0x88d290
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-          IsParameter: false
-          IsReturn: false
-        - Name: iFun
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x88d1d0..0x88d1d4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x88d1d4..0x88d1ec
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88d1ec..0x88d1f0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-            - Range: 0x88d1f0..0x88d290
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-          IsParameter: false
-          IsReturn: false
     - ID: 51
+      Name: main.testAny
+      OutOfLinePCRanges: [0x88d160..0x88d1d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x88d160..0x88d190
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x88d190..0x88d194
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x88d160..0x88d1d0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 52
       Name: main.testError
-      OutOfLinePCRanges: [0x88d290..0x88d2a0]
+      OutOfLinePCRanges: [0x88d1d0..0x88d1e0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 75 GoInterfaceType error
           Locations:
-            - Range: 0x88d290..0x88d2a0
+            - Range: 0x88d1d0..0x88d1e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2245,309 +2170,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 52
+    - ID: 53
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88d4f0..0x88d500]
+      OutOfLinePCRanges: [0x88d5f0..0x88d600]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 76 StructureType main.structWithMap
           Locations:
-            - Range: 0x88d4f0..0x88d500
+            - Range: 0x88d5f0..0x88d600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88d500..0x88d510]
+      OutOfLinePCRanges: [0x88d600..0x88d610]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 92 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88d500..0x88d510
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88d510..0x88d520]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x88d510..0x88d520
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88d520..0x88d530]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 105 GoMapType map[string][]string
-          Locations:
-            - Range: 0x88d520..0x88d530
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88d530..0x88d540]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x88d530..0x88d540
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88d540..0x88d550]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 100 GoMapType map[string]int
-          Locations:
-            - Range: 0x88d540..0x88d550
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88d550..0x88d560]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 120 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x88d550..0x88d560
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88d560..0x88d570]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 121 PointerType *map[string]int
-          Locations:
-            - Range: 0x88d560..0x88d570
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88d570..0x88d580]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 77 GoMapType map[int]int
-          Locations:
-            - Range: 0x88d570..0x88d580
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88d580..0x88d590]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 122 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x88d580..0x88d590
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x88d590..0x88d5a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 122 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x88d590..0x88d5a0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88d5a0..0x88d5b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 130 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x88d5a0..0x88d5b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88d5b0..0x88d5c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 139 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x88d5b0..0x88d5c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x88d5c0..0x88d5d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 139 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x88d5c0..0x88d5d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x88d5d0..0x88d5e0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 145 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x88d5d0..0x88d5e0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x88d5e0..0x88d5f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 145 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x88d5e0..0x88d5f0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x88d5f0..0x88d600]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 145 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x88d5f0..0x88d600
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88d600..0x88d610]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 151 GoMapType map[uint8][4]int
-          Locations:
             - Range: 0x88d600..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 55
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x88d610..0x88d620]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 158 GoMapType map[[4]int]uint8
+          Type: 100 GoMapType map[string]int
           Locations:
             - Range: 0x88d610..0x88d620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 56
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x88d620..0x88d630]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[[4]int][4]int
+          Type: 105 GoMapType map[string][]string
           Locations:
             - Range: 0x88d620..0x88d630
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 57
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x88d630..0x88d640]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 112 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x88d630..0x88d640
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 58
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x88d640..0x88d650]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 100 GoMapType map[string]int
+          Locations:
+            - Range: 0x88d640..0x88d650
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 59
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x88d650..0x88d660]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 120 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x88d650..0x88d660
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 60
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x88d660..0x88d670]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 121 PointerType *map[string]int
+          Locations:
+            - Range: 0x88d660..0x88d670
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 61
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x88d670..0x88d680]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 77 GoMapType map[int]int
+          Locations:
+            - Range: 0x88d670..0x88d680
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 62
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x88d680..0x88d690]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x88d680..0x88d690
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x88d690..0x88d6a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 122 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x88d690..0x88d6a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 64
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x88d6a0..0x88d6b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 130 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x88d6a0..0x88d6b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x88d6b0..0x88d6c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88d6b0..0x88d6c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x88d6c0..0x88d6d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 139 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x88d6c0..0x88d6d0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x88d6d0..0x88d6e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d6d0..0x88d6e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x88d6e0..0x88d6f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d6e0..0x88d6f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88d6f0..0x88d700]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 145 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88d6f0..0x88d700
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x88d700..0x88d710]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 151 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x88d700..0x88d710
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x88d710..0x88d720]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 158 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x88d710..0x88d720
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x88d720..0x88d730]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x88d720..0x88d730
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88e880..0x88e890]
+      OutOfLinePCRanges: [0x88e980..0x88e990]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88e880..0x88e890
+            - Range: 0x88e980..0x88e990
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88e880..0x88e890
+            - Range: 0x88e980..0x88e990
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0x88e880..0x88e890
+            - Range: 0x88e980..0x88e990
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 74
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88e960..0x88e970]
+      OutOfLinePCRanges: [0x88ea60..0x88ea70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0x88e960..0x88e970
+            - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x88e960..0x88e970
+            - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x88e960..0x88e970
+            - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x88e960..0x88e970
+            - Range: 0x88ea60..0x88ea70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88e960..0x88e970
+            - Range: 0x88ea60..0x88ea70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2555,39 +2480,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 75
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88eb00..0x88eb10]
+      OutOfLinePCRanges: [0x88ec00..0x88ec10]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 169 GoChannelType chan bool
           Locations:
-            - Range: 0x88eb00..0x88eb10
+            - Range: 0x88ec00..0x88ec10
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88eca0..0x88ecb0]
+      OutOfLinePCRanges: [0x88eda0..0x88edb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 170 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88eca0..0x88ecb0
+            - Range: 0x88eda0..0x88edb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88ecb0..0x88ecc0]
+      OutOfLinePCRanges: [0x88edb0..0x88edc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 137 StructureType main.node
           Locations:
-            - Range: 0x88ecb0..0x88ecc0
+            - Range: 0x88edb0..0x88edc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2595,112 +2520,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88ecc0..0x88ecd0]
+      OutOfLinePCRanges: [0x88edc0..0x88edd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 138 PointerType *main.node
           Locations:
-            - Range: 0x88ecc0..0x88ecd0
+            - Range: 0x88edc0..0x88edd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88ecd0..0x88ece0]
+      OutOfLinePCRanges: [0x88edd0..0x88ede0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88ecd0..0x88ece0
+            - Range: 0x88edd0..0x88ede0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88ecf0..0x88ed00]
+      OutOfLinePCRanges: [0x88edf0..0x88ee00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 172 PointerType *uint
           Locations:
-            - Range: 0x88ecf0..0x88ed00
+            - Range: 0x88edf0..0x88ee00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88ed60..0x88ed70]
+      OutOfLinePCRanges: [0x88ee60..0x88ee70]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0x88ed60..0x88ed70
+            - Range: 0x88ee60..0x88ee70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88ed80..0x88ed90]
+      OutOfLinePCRanges: [0x88ee80..0x88ee90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 173 PointerType *bool
           Locations:
-            - Range: 0x88ed80..0x88ed90
+            - Range: 0x88ee80..0x88ee90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x88ed80..0x88ed90
+            - Range: 0x88ee80..0x88ee90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88eda0..0x88edb0]
+      OutOfLinePCRanges: [0x88eea0..0x88eeb0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 174 PointerType *main.t
           Locations:
-            - Range: 0x88eda0..0x88edb0
+            - Range: 0x88eea0..0x88eeb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x88f190..0x88f1a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 177 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88f190..0x88f1a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 84
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x88f1a0..0x88f1b0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x88f290..0x88f2a0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 177 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88f1a0..0x88f1b0
+            - Range: 0x88f290..0x88f2a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2711,14 +2618,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 85
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x88f1b0..0x88f1c0]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x88f2a0..0x88f2b0]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 178 GoSliceHeaderType [][]uint
+          Type: 177 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x88f1b0..0x88f1c0
+            - Range: 0x88f2a0..0x88f2b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2729,14 +2636,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 86
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x88f1c0..0x88f1d0]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x88f2b0..0x88f2c0]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 178 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x88f1c0..0x88f1d0
+            - Range: 0x88f2b0..0x88f2c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2744,24 +2651,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x88f1c0..0x88f1d0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x88f1d0..0x88f1e0]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x88f2c0..0x88f2d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 180 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88f1d0..0x88f1e0
+            - Range: 0x88f2c0..0x88f2d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2774,19 +2674,19 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88f1d0..0x88f1e0
+            - Range: 0x88f2c0..0x88f2d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x88f1e0..0x88f1f0]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x88f2d0..0x88f2e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 180 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x88f1e0..0x88f1f0
+            - Range: 0x88f2d0..0x88f2e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2799,19 +2699,44 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88f1e0..0x88f1f0
+            - Range: 0x88f2d0..0x88f2e0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 89
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x88f2e0..0x88f2f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 180 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x88f2e0..0x88f2f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x88f2e0..0x88f2f0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x88f1f0..0x88f200]
+      OutOfLinePCRanges: [0x88f2f0..0x88f300]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 111 GoSliceHeaderType []string
           Locations:
-            - Range: 0x88f1f0..0x88f200
+            - Range: 0x88f2f0..0x88f300
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2821,22 +2746,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x88f200..0x88f210]
+      OutOfLinePCRanges: [0x88f300..0x88f310]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x88f200..0x88f210
+            - Range: 0x88f300..0x88f310
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 183 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x88f200..0x88f210
+            - Range: 0x88f300..0x88f310
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -2849,37 +2774,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x88f200..0x88f210
+            - Range: 0x88f300..0x88f310
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x88f210..0x88f220]
+      OutOfLinePCRanges: [0x88f310..0x88f320]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 184 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x88f210..0x88f220
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x88f220..0x88f230]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 177 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x88f220..0x88f230
+            - Range: 0x88f310..0x88f320
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,24 +2797,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 93
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x88f320..0x88f330]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 177 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x88f320..0x88f330
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.stackC
-      OutOfLinePCRanges: [0x88f4f0..0x88f560]
+      OutOfLinePCRanges: [0x88f5f0..0x88f660]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0x88f4f0..0x88f560, Pieces: []}]
+          Locations: [{Range: 0x88f5f0..0x88f660, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x88f560..0x88f570]
+      OutOfLinePCRanges: [0x88f660..0x88f670]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f560..0x88f570
+            - Range: 0x88f660..0x88f670
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2915,15 +2840,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x88f570..0x88f580]
+      OutOfLinePCRanges: [0x88f670..0x88f680]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f570..0x88f580
+            - Range: 0x88f670..0x88f680
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2859,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f570..0x88f580
+            - Range: 0x88f670..0x88f680
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2870,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f570..0x88f580
+            - Range: 0x88f670..0x88f680
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2953,15 +2878,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 97
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x88f580..0x88f5a0]
+      OutOfLinePCRanges: [0x88f680..0x88f6a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 186 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x88f580..0x88f5a0
+            - Range: 0x88f680..0x88f6a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2977,55 +2902,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 98
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x88f5a0..0x88f5b0]
+      OutOfLinePCRanges: [0x88f6a0..0x88f6b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 187 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x88f5a0..0x88f5b0
+            - Range: 0x88f6a0..0x88f6b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x88f5b0..0x88f5c0]
+      OutOfLinePCRanges: [0x88f6b0..0x88f6c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 188 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x88f5b0..0x88f5c0
+            - Range: 0x88f6b0..0x88f6c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x88f5c0..0x88f5d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x88f5c0..0x88f5d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 100
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x88f5d0..0x88f5e0]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x88f6c0..0x88f6d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f5d0..0x88f5e0
+            - Range: 0x88f6c0..0x88f6d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3034,14 +2943,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x88f5e0..0x88f5f0]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x88f6d0..0x88f6e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x88f5e0..0x88f5f0
+            - Range: 0x88f6d0..0x88f6e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3050,14 +2959,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 102
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x88f6e0..0x88f6f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f6e0..0x88f6f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
       Name: main.testStruct
-      OutOfLinePCRanges: [0x88f7f0..0x88f810]
+      OutOfLinePCRanges: [0x88f8f0..0x88f910]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 190 StructureType main.aStruct
           Locations:
-            - Range: 0x88f7f0..0x88f810
+            - Range: 0x88f8f0..0x88f910
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3075,43 +3000,43 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 104
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x88f8f0..0x88f900]
+      OutOfLinePCRanges: [0x88f9f0..0x88fa00]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 191 StructureType main.emptyStruct
-          Locations: [{Range: 0x88f8f0..0x88f900, Pieces: []}]
+          Locations: [{Range: 0x88f9f0..0x88fa00, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88c940..0x88c9b0]
+      OutOfLinePCRanges: [0x88c9b0..0x88ca20]
       InlinePCRanges:
-        - Ranges: [0x88c9cc..0x88ca04]
-          RootRanges: [0x88c9b0..0x88ca30]
-        - Ranges: [0x88cb18..0x88cb50]
-          RootRanges: [0x88cae0..0x88cb70]
-        - Ranges: [0x88cb94..0x88cbcc]
-          RootRanges: [0x88cb70..0x88cc40]
-        - Ranges: [0x88cc5c..0x88cc94]
-          RootRanges: [0x88cc40..0x88ccc0]
+        - Ranges: [0x88ca3c..0x88ca74]
+          RootRanges: [0x88ca20..0x88caa0]
+        - Ranges: [0x88cb88..0x88cbc0]
+          RootRanges: [0x88cb50..0x88cbe0]
+        - Ranges: [0x88cc04..0x88cc3c]
+          RootRanges: [0x88cbe0..0x88ccb0]
+        - Ranges: [0x88cccc..0x88cd04]
+          RootRanges: [0x88ccb0..0x88cd30]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88c940..0x88c960
+            - Range: 0x88c9b0..0x88c9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88c9cc..0x88c9d4
+            - Range: 0x88ca3c..0x88ca44
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cb18..0x88cb20
+            - Range: 0x88cb88..0x88cb90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cb8c..0x88cb9c
+            - Range: 0x88cbfc..0x88cc0c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88cb9c..0x88cc40
+            - Range: 0x88cc0c..0x88ccb0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88cc40..0x88cc64
+            - Range: 0x88ccb0..0x88ccd4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3119,34 +3044,34 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88cbd8..0x88cc10]
-          RootRanges: [0x88cb70..0x88cc40]
+        - Ranges: [0x88cc48..0x88cc80]
+          RootRanges: [0x88cbe0..0x88ccb0]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88ccdc..0x88cd20]
-          RootRanges: [0x88ccc0..0x88cde0]
+        - Ranges: [0x88cd4c..0x88cd90]
+          RootRanges: [0x88cd30..0x88ce50]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88cd90..0x88cdc8]
-          RootRanges: [0x88ccc0..0x88cde0]
+        - Ranges: [0x88ce00..0x88ce38]
+          RootRanges: [0x88cd30..0x88ce50]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88cde4..0x88cde8]
-          RootRanges: [0x88cde0..0x88cdf0]
+        - Ranges: [0x88ce54..0x88ce58]
+          RootRanges: [0x88ce50..0x88ce60]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x88cde0..0x88cde8
+            - Range: 0x88ce50..0x88ce58
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3154,17 +3079,17 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88ce14..0x88ce38]
-          RootRanges: [0x88cdf0..0x88ce50]
-        - Ranges: [0x88ceac..0x88ced4]
-          RootRanges: [0x88ce50..0x88cfa0]
+        - Ranges: [0x88ce84..0x88cea8]
+          RootRanges: [0x88ce60..0x88cec0]
+        - Ranges: [0x88cf1c..0x88cf44]
+          RootRanges: [0x88cec0..0x88d010]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0x88ce00..0x88ce50
+            - Range: 0x88ce70..0x88cec0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88ce98..0x88cfa0
+            - Range: 0x88cf08..0x88d010
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
@@ -3173,7 +3098,7 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 527584
+      GoRuntimeType: 527616
       GoKind: 2
     - __kind: ArrayType
       ID: 2
@@ -3187,7 +3112,7 @@ Types:
       ID: 3
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 618944
+      GoRuntimeType: 618976
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3196,13 +3121,13 @@ Types:
       ID: 4
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 527136
+      GoRuntimeType: 527168
       GoKind: 8
     - __kind: ArrayType
       ID: 5
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 619040
+      GoRuntimeType: 619072
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3211,13 +3136,13 @@ Types:
       ID: 6
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 527328
+      GoRuntimeType: 527360
       GoKind: 5
     - __kind: ArrayType
       ID: 7
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 619136
+      GoRuntimeType: 619168
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3226,7 +3151,7 @@ Types:
       ID: 8
       Name: string
       ByteSize: 16
-      GoRuntimeType: 527008
+      GoRuntimeType: 527040
       GoKind: 24
       RawFields:
         - Name: str
@@ -3240,7 +3165,7 @@ Types:
       ID: 9
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 359360
+      GoRuntimeType: 359392
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: ArrayType
@@ -3255,13 +3180,13 @@ Types:
       ID: 11
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 528032
+      GoRuntimeType: 528064
       GoKind: 1
     - __kind: ArrayType
       ID: 12
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 618080
+      GoRuntimeType: 617920
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3278,7 +3203,7 @@ Types:
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 527072
+      GoRuntimeType: 527104
       GoKind: 3
     - __kind: ArrayType
       ID: 15
@@ -3292,7 +3217,7 @@ Types:
       ID: 16
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 527200
+      GoRuntimeType: 527232
       GoKind: 4
     - __kind: ArrayType
       ID: 17
@@ -3306,7 +3231,7 @@ Types:
       ID: 18
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 527456
+      GoRuntimeType: 527488
       GoKind: 6
     - __kind: ArrayType
       ID: 19
@@ -3320,7 +3245,7 @@ Types:
       ID: 20
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 527648
+      GoRuntimeType: 527680
       GoKind: 7
     - __kind: ArrayType
       ID: 21
@@ -3334,7 +3259,7 @@ Types:
       ID: 22
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 527264
+      GoRuntimeType: 527296
       GoKind: 9
     - __kind: ArrayType
       ID: 23
@@ -3348,13 +3273,13 @@ Types:
       ID: 24
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 527392
+      GoRuntimeType: 527424
       GoKind: 10
     - __kind: ArrayType
       ID: 25
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 619232
+      GoRuntimeType: 619264
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3363,7 +3288,7 @@ Types:
       ID: 26
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 527520
+      GoRuntimeType: 527552
       GoKind: 11
     - __kind: ArrayType
       ID: 27
@@ -3393,13 +3318,13 @@ Types:
       ID: 30
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 527904
+      GoRuntimeType: 527936
       GoKind: 13
     - __kind: BaseType
       ID: 31
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 527968
+      GoRuntimeType: 528000
       GoKind: 14
     - __kind: BaseType
       ID: 32
@@ -3425,7 +3350,7 @@ Types:
       ID: 34
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 443328
+      GoRuntimeType: 443360
       GoKind: 23
       RawFields:
         - Name: array
@@ -3442,21 +3367,21 @@ Types:
       ID: 35
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 486112
+      GoRuntimeType: 486144
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
       ID: 36
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 359232
+      GoRuntimeType: 359264
       GoKind: 22
       Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
       ID: 37
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 973664
+      GoRuntimeType: 973952
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
@@ -3475,14 +3400,14 @@ Types:
       ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
-      GoRuntimeType: 383360
+      GoRuntimeType: 383392
       GoKind: 22
       Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
       ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
-      GoRuntimeType: 1.627424e+06
+      GoRuntimeType: 1.627712e+06
       GoKind: 25
       RawFields:
         - Name: Inter
@@ -3501,14 +3426,14 @@ Types:
       ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
-      GoRuntimeType: 2.05456e+06
+      GoRuntimeType: 2.054848e+06
       GoKind: 22
       Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
       ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
-      GoRuntimeType: 1.43728e+06
+      GoRuntimeType: 1.437568e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -3524,7 +3449,7 @@ Types:
       ID: 43
       Name: internal/abi.Type
       ByteSize: 48
-      GoRuntimeType: 1.981376e+06
+      GoRuntimeType: 1.981664e+06
       GoKind: 25
       RawFields:
         - Name: Size_
@@ -3564,43 +3489,43 @@ Types:
       ID: 44
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 527712
+      GoRuntimeType: 527744
       GoKind: 12
     - __kind: BaseType
       ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
-      GoRuntimeType: 530720
+      GoRuntimeType: 530752
       GoKind: 8
     - __kind: BaseType
       ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
-      GoRuntimeType: 759232
+      GoRuntimeType: 759328
       GoKind: 8
     - __kind: GoSubroutineType
       ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 773248
+      GoRuntimeType: 773344
       GoKind: 19
     - __kind: BaseType
       ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
-      GoRuntimeType: 530784
+      GoRuntimeType: 530816
       GoKind: 5
     - __kind: BaseType
       ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
-      GoRuntimeType: 530848
+      GoRuntimeType: 530880
       GoKind: 5
     - __kind: StructureType
       ID: 50
       Name: internal/abi.Name
       ByteSize: 8
-      GoRuntimeType: 1.828928e+06
+      GoRuntimeType: 1.829216e+06
       GoKind: 25
       RawFields:
         - Name: Bytes
@@ -3610,7 +3535,7 @@ Types:
       ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
-      GoRuntimeType: 468480
+      GoRuntimeType: 468512
       GoKind: 23
       RawFields:
         - Name: array
@@ -3627,14 +3552,14 @@ Types:
       ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
-      GoRuntimeType: 383296
+      GoRuntimeType: 383328
       GoKind: 22
       Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
       ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
-      GoRuntimeType: 1.296e+06
+      GoRuntimeType: 1.296288e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -3647,14 +3572,14 @@ Types:
       ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.055008e+06
+      GoRuntimeType: 2.055296e+06
       GoKind: 22
       Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
       ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
-      GoRuntimeType: 617120
+      GoRuntimeType: 618784
       GoKind: 17
       Count: 1
       HasCount: true
@@ -3663,13 +3588,13 @@ Types:
       ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 528096
+      GoRuntimeType: 528128
       GoKind: 26
     - __kind: StructureType
       ID: 57
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.819136e+06
+      GoRuntimeType: 1.819424e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3696,13 +3621,13 @@ Types:
     - __kind: GoChannelType
       ID: 58
       Name: chan struct {}
-      GoRuntimeType: 538208
+      GoRuntimeType: 538240
       GoKind: 18
     - __kind: GoEmptyInterfaceType
       ID: 59
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 772384
+      GoRuntimeType: 772480
       GoKind: 20
       UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
@@ -3721,27 +3646,27 @@ Types:
       ID: 61
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 973408
+      GoRuntimeType: 973696
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
       ID: 62
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 441920
+      GoRuntimeType: 441952
       GoKind: 19
     - __kind: PointerType
       ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 354176
+      GoRuntimeType: 354208
       GoKind: 22
       Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
       ID: 64
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.692672e+06
+      GoRuntimeType: 1.69296e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -3763,7 +3688,7 @@ Types:
       ID: 65
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.2712e+06
+      GoRuntimeType: 1.271488e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -3776,7 +3701,7 @@ Types:
       ID: 66
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.27232e+06
+      GoRuntimeType: 1.272608e+06
       GoKind: 25
       RawFields:
         - Name: done
@@ -3789,7 +3714,7 @@ Types:
       ID: 67
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.2728e+06
+      GoRuntimeType: 1.273088e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3801,14 +3726,14 @@ Types:
     - __kind: StructureType
       ID: 68
       Name: sync/atomic.noCopy
-      GoRuntimeType: 940608
+      GoRuntimeType: 940800
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 69
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.411168e+06
+      GoRuntimeType: 1.411456e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -3823,14 +3748,14 @@ Types:
     - __kind: StructureType
       ID: 70
       Name: sync.noCopy
-      GoRuntimeType: 940512
+      GoRuntimeType: 940704
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 71
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.411552e+06
+      GoRuntimeType: 1.41184e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3845,14 +3770,14 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: sync/atomic.align64
-      GoRuntimeType: 940704
+      GoRuntimeType: 940896
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 73
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.27264e+06
+      GoRuntimeType: 1.272928e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3865,21 +3790,21 @@ Types:
       ID: 74
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 973280
+      GoRuntimeType: 973568
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
       ID: 75
       Name: error
       ByteSize: 16
-      GoRuntimeType: 977760
+      GoRuntimeType: 978048
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
       ID: 76
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.092352e+06
+      GoRuntimeType: 1.09264e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -3889,7 +3814,7 @@ Types:
       ID: 77
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 872800
+      GoRuntimeType: 872992
       GoKind: 21
       HeaderType: 79 GoHMapHeaderType hash<int,int>
     - __kind: PointerType
@@ -3959,7 +3884,7 @@ Types:
       ID: 82
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 615584
+      GoRuntimeType: 615616
       GoKind: 17
       Count: 8
       HasCount: true
@@ -3982,14 +3907,14 @@ Types:
       ID: 85
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 363136
+      GoRuntimeType: 363168
       GoKind: 22
       Pointee: 86 StructureType runtime.mapextra
     - __kind: StructureType
       ID: 86
       Name: runtime.mapextra
       ByteSize: 24
-      GoRuntimeType: 1.41712e+06
+      GoRuntimeType: 1.417408e+06
       GoKind: 25
       RawFields:
         - Name: overflow
@@ -4005,14 +3930,14 @@ Types:
       ID: 87
       Name: '*[]*runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 451776
+      GoRuntimeType: 451808
       GoKind: 22
       Pointee: 88 GoSliceHeaderType []*runtime.bmap
     - __kind: GoSliceHeaderType
       ID: 88
       Name: '[]*runtime.bmap'
       ByteSize: 24
-      GoRuntimeType: 451712
+      GoRuntimeType: 451744
       GoKind: 23
       RawFields:
         - Name: array
@@ -4034,14 +3959,14 @@ Types:
       ID: 90
       Name: '*runtime.bmap'
       ByteSize: 8
-      GoRuntimeType: 1.1008e+06
+      GoRuntimeType: 1.101088e+06
       GoKind: 22
       Pointee: 91 StructureType runtime.bmap
     - __kind: StructureType
       ID: 91
       Name: runtime.bmap
       ByteSize: 8
-      GoRuntimeType: 1.100672e+06
+      GoRuntimeType: 1.10096e+06
       GoKind: 25
       RawFields:
         - Name: tophash
@@ -4051,7 +3976,7 @@ Types:
       ID: 92
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 874528
+      GoRuntimeType: 874720
       GoKind: 21
       HeaderType: 94 GoHMapHeaderType hash<string,main.nestedStruct>
     - __kind: PointerType
@@ -4135,7 +4060,7 @@ Types:
       ID: 99
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.26992e+06
+      GoRuntimeType: 1.270208e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -4148,7 +4073,7 @@ Types:
       ID: 100
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 874432
+      GoRuntimeType: 874624
       GoKind: 21
       HeaderType: 102 GoHMapHeaderType hash<string,int>
     - __kind: PointerType
@@ -4218,7 +4143,7 @@ Types:
       ID: 105
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 874336
+      GoRuntimeType: 874528
       GoKind: 21
       HeaderType: 107 GoHMapHeaderType hash<string,[]string>
     - __kind: PointerType
@@ -4295,7 +4220,7 @@ Types:
       ID: 111
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 449984
+      GoRuntimeType: 450016
       GoKind: 23
       RawFields:
         - Name: array
@@ -4312,7 +4237,7 @@ Types:
       ID: 112
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 873952
+      GoRuntimeType: 874144
       GoKind: 21
       HeaderType: 114 GoHMapHeaderType hash<[4]string,[2]int>
     - __kind: PointerType
@@ -4389,7 +4314,7 @@ Types:
       ID: 118
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 617984
+      GoRuntimeType: 617824
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4419,7 +4344,7 @@ Types:
       ID: 122
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 874240
+      GoRuntimeType: 874432
       GoKind: 21
       HeaderType: 124 GoHMapHeaderType hash<string,[]main.structWithMap>
     - __kind: PointerType
@@ -4496,7 +4421,7 @@ Types:
       ID: 128
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 442816
+      GoRuntimeType: 442848
       GoKind: 23
       RawFields:
         - Name: array
@@ -4513,14 +4438,14 @@ Types:
       ID: 129
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 354112
+      GoRuntimeType: 354144
       GoKind: 22
       Pointee: 76 StructureType main.structWithMap
     - __kind: GoMapType
       ID: 130
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 874048
+      GoRuntimeType: 874240
       GoKind: 21
       HeaderType: 132 GoHMapHeaderType hash<bool,main.node>
     - __kind: PointerType
@@ -4604,7 +4529,7 @@ Types:
       ID: 137
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.26976e+06
+      GoRuntimeType: 1.270048e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -4617,14 +4542,14 @@ Types:
       ID: 138
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 354240
+      GoRuntimeType: 354272
       GoKind: 22
       Pointee: 137 StructureType main.node
     - __kind: GoMapType
       ID: 139
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 874144
+      GoRuntimeType: 874336
       GoKind: 21
       HeaderType: 141 GoHMapHeaderType hash<int,uint8>
     - __kind: PointerType
@@ -4701,7 +4626,7 @@ Types:
       ID: 145
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 874720
+      GoRuntimeType: 874912
       GoKind: 21
       HeaderType: 147 GoHMapHeaderType hash<uint8,uint8>
     - __kind: PointerType
@@ -4778,7 +4703,7 @@ Types:
       ID: 151
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 874624
+      GoRuntimeType: 874816
       GoKind: 21
       HeaderType: 153 GoHMapHeaderType hash<uint8,[4]int>
     - __kind: PointerType
@@ -4855,7 +4780,7 @@ Types:
       ID: 157
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 617696
+      GoRuntimeType: 617536
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4864,7 +4789,7 @@ Types:
       ID: 158
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 873856
+      GoRuntimeType: 874048
       GoKind: 21
       HeaderType: 160 GoHMapHeaderType hash<[4]int,uint8>
     - __kind: PointerType
@@ -4941,7 +4866,7 @@ Types:
       ID: 164
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 873760
+      GoRuntimeType: 873952
       GoKind: 21
       HeaderType: 166 GoHMapHeaderType hash<[4]int,[4]int>
     - __kind: PointerType
@@ -5010,7 +4935,7 @@ Types:
     - __kind: GoChannelType
       ID: 169
       Name: chan bool
-      GoRuntimeType: 539296
+      GoRuntimeType: 539328
       GoKind: 18
     - __kind: PointerType
       ID: 170
@@ -5034,14 +4959,14 @@ Types:
       ID: 172
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 359872
+      GoRuntimeType: 359904
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
       ID: 173
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 360256
+      GoRuntimeType: 360288
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
@@ -5075,7 +5000,7 @@ Types:
       ID: 177
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 449472
+      GoRuntimeType: 449504
       GoKind: 23
       RawFields:
         - Name: array
@@ -5146,7 +5071,7 @@ Types:
       ID: 183
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 449856
+      GoRuntimeType: 449888
       GoKind: 23
       RawFields:
         - Name: array
@@ -5163,7 +5088,7 @@ Types:
       ID: 184
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 448832
+      GoRuntimeType: 448864
       GoKind: 23
       RawFields:
         - Name: array
@@ -5180,7 +5105,7 @@ Types:
       ID: 185
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 359488
+      GoRuntimeType: 359520
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
@@ -6080,6 +6005,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 272
+      Name: Probe[main.testAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6090,11 +6030,11 @@ Types:
             Type: 75 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: e}
+                  Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 274
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6105,11 +6045,11 @@ Types:
             Type: 76 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 275
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6120,11 +6060,11 @@ Types:
             Type: 92 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 275
+      ID: 276
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6135,11 +6075,11 @@ Types:
             Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 276
+      ID: 277
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6150,11 +6090,11 @@ Types:
             Type: 105 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 278
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6165,11 +6105,11 @@ Types:
             Type: 112 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 279
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6180,11 +6120,11 @@ Types:
             Type: 100 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 280
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6195,11 +6135,11 @@ Types:
             Type: 120 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 281
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6210,11 +6150,11 @@ Types:
             Type: 121 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 282
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6225,11 +6165,11 @@ Types:
             Type: 77 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 283
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6240,11 +6180,11 @@ Types:
             Type: 122 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 284
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6255,11 +6195,11 @@ Types:
             Type: 122 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 285
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6270,11 +6210,11 @@ Types:
             Type: 130 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 286
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6285,11 +6225,11 @@ Types:
             Type: 139 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 287
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6300,27 +6240,12 @@ Types:
             Type: 139 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 145 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 288
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6335,7 +6260,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 289
-      Name: Probe[main.testMapSmallKeySmallValue]
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6350,6 +6275,21 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 290
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 145 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6360,11 +6300,11 @@ Types:
             Type: 151 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 292
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6375,11 +6315,11 @@ Types:
             Type: 158 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 293
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6390,11 +6330,11 @@ Types:
             Type: 164 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 294
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6405,7 +6345,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: w}
+                  Variable: {subprogram: 73, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -6414,7 +6354,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: x}
+                  Variable: {subprogram: 73, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -6423,11 +6363,11 @@ Types:
             Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: y}
+                  Variable: {subprogram: 73, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 295
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6438,7 +6378,7 @@ Types:
             Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: a}
+                  Variable: {subprogram: 74, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -6447,7 +6387,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: b}
+                  Variable: {subprogram: 74, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -6456,7 +6396,7 @@ Types:
             Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: c}
+                  Variable: {subprogram: 74, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -6465,7 +6405,7 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 3, name: d}
+                  Variable: {subprogram: 74, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -6474,11 +6414,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 4, name: e}
+                  Variable: {subprogram: 74, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 296
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6489,11 +6429,11 @@ Types:
             Type: 169 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: c}
+                  Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 296
+      ID: 297
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6504,11 +6444,11 @@ Types:
             Type: 170 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 298
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6519,11 +6459,11 @@ Types:
             Type: 137 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 299
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6534,11 +6474,11 @@ Types:
             Type: 138 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 300
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6549,11 +6489,11 @@ Types:
             Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 301
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6564,11 +6504,11 @@ Types:
             Type: 172 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 302
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6579,11 +6519,11 @@ Types:
             Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 303
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6594,7 +6534,7 @@ Types:
             Type: 173 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 82, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -6603,11 +6543,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 304
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6618,27 +6558,12 @@ Types:
             Type: 174 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: t}
+                  Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 177 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 305
-      Name: Probe[main.testEmptySlice]
+      Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
@@ -6653,6 +6578,21 @@ Types:
                   ByteSize: 24
     - __kind: EventRootType
       ID: 306
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 177 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 307
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6663,36 +6603,12 @@ Types:
             Type: 178 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 180 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 308
-      Name: Probe[main.testEmptySliceOfStructs]
+      Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -6716,7 +6632,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 309
-      Name: Probe[main.testNilSliceOfStructs]
+      Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -6740,6 +6656,30 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 310
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 180 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6750,11 +6690,11 @@ Types:
             Type: 111 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: s}
+                  Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 311
+      ID: 312
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6765,7 +6705,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -6774,7 +6714,7 @@ Types:
             Type: 183 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: s}
+                  Variable: {subprogram: 91, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -6783,11 +6723,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: x}
+                  Variable: {subprogram: 91, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 313
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6798,11 +6738,11 @@ Types:
             Type: 184 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 313
+      ID: 314
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6813,31 +6753,16 @@ Types:
             Type: 177 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 314
+      ID: 315
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 315
+      ID: 316
       Name: Probe[main.testSingleString]
       ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.testThreeStrings]
-      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -6849,13 +6774,28 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: y}
+                  Variable: {subprogram: 96, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -6864,11 +6804,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 2, name: z}
+                  Variable: {subprogram: 96, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
+      ID: 318
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6879,11 +6819,11 @@ Types:
             Type: 186 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 318
+      ID: 319
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6894,11 +6834,11 @@ Types:
             Type: 187 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 320
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6909,27 +6849,12 @@ Types:
             Type: 188 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.testMassiveString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
       ID: 321
-      Name: Probe[main.testUnitializedString]
+      Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -6944,7 +6869,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 322
-      Name: Probe[main.testEmptyString]
+      Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -6959,6 +6884,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 323
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 324
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6969,11 +6909,11 @@ Types:
             Type: 190 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 324
+      ID: 325
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6984,11 +6924,11 @@ Types:
             Type: 191 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: e}
+                  Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 325
+      ID: 326
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7003,16 +6943,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 327
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 327
+      ID: 328
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 328
+      ID: 329
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 329
+      ID: 330
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7027,7 +6967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 331
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7041,5 +6981,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 330
+MaxTypeID: 331
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 295 EventRootType Probe[main.stackC]
+          Type: 308 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x88f5fc", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 252 EventRootType Probe[main.testAny]
+          Type: 265 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x88d16c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 222 EventRootType Probe[main.testArrayOfArrays]
+          Type: 235 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x88bee0", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 224 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 237 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x88bf00", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 260 EventRootType Probe[main.testArrayOfMaps]
+          Type: 273 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x88d650", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 223 EventRootType Probe[main.testArrayOfStrings]
+          Type: 236 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x88bef0", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 242 EventRootType Probe[main.testBigStruct]
+          Type: 255 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x88c460", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 211 EventRootType Probe[main.testBoolArray]
+          Type: 224 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x88be30", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 208 EventRootType Probe[main.testByteArray]
+          Type: 221 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x88be00", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 276 EventRootType Probe[main.testChannel]
+          Type: 289 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88ec00", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 274 EventRootType Probe[main.testCombinedByte]
+          Type: 287 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x88e980", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 284 EventRootType Probe[main.testCycle]
+          Type: 297 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88eea0", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 286 EventRootType Probe[main.testEmptySlice]
+          Type: 299 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x88f2a0", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 289 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 302 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x88f2d0", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 303 EventRootType Probe[main.testEmptyString]
+          Type: 316 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x88f6e0", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 305 EventRootType Probe[main.testEmptyStruct]
+          Type: 318 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x88f9f0", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 253 EventRootType Probe[main.testError]
+          Type: 266 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x88d1d0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 244 EventRootType Probe[main.testEsotericHeap]
+          Type: 257 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x88c71c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 243 EventRootType Probe[main.testEsotericStack]
+          Type: 256 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x88c62c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 249 EventRootType Probe[main.testFrameless]
+          Type: 262 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x88ce50", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 250 EventRootType Probe[main.testFramelessArray]
+          Type: 263 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x88ce60", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 245 EventRootType Probe[main.testInlinedBA]
+          Type: 258 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x88cb5c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 246 EventRootType Probe[main.testInlinedBB]
+          Type: 259 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x88cbec", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 247 EventRootType Probe[main.testInlinedBBA]
+          Type: 260 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x88ccbc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 307 EventRootType Probe[main.testInlinedBBB]
+          Type: 320 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88cc48", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 248 EventRootType Probe[main.testInlinedBC]
+          Type: 261 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x88cd3c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 308 EventRootType Probe[main.testInlinedBCA]
+          Type: 321 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88cd4c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 309 EventRootType Probe[main.testInlinedBCB]
+          Type: 322 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88ce00", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 306 EventRootType Probe[main.testInlinedPrint]
+          Type: 319 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88c9bc"
               Frameless: true
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 310 EventRootType Probe[main.testInlinedSq]
+          Type: 323 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88ce54", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 311 EventRootType Probe[main.testInlinedSumArray]
+          Type: 324 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88ce84"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 214 EventRootType Probe[main.testInt16Array]
+          Type: 227 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x88be60", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 215 EventRootType Probe[main.testInt32Array]
+          Type: 228 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x88be70", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 216 EventRootType Probe[main.testInt64Array]
+          Type: 229 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x88be80", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 213 EventRootType Probe[main.testInt8Array]
+          Type: 226 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x88be50", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 212 EventRootType Probe[main.testIntArray]
+          Type: 225 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x88be40", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 251 EventRootType Probe[main.testInterface]
+          Type: 264 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x88d10c", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 278 EventRootType Probe[main.testLinkedList]
+          Type: 291 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88edb0", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 258 EventRootType Probe[main.testMapArrayToArray]
+          Type: 271 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x88d630", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 264 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 277 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x88d690", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 262 EventRootType Probe[main.testMapIntToInt]
+          Type: 275 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x88d670", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 273 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 286 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x88d720", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 272 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 285 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x88d710", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 263 EventRootType Probe[main.testMapMassive]
+          Type: 276 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x88d680", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 271 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 284 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x88d700", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 270 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 283 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x88d6f0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 256 EventRootType Probe[main.testMapStringToInt]
+          Type: 269 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x88d610", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 257 EventRootType Probe[main.testMapStringToSlice]
+          Type: 270 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x88d620", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 255 EventRootType Probe[main.testMapStringToStruct]
+          Type: 268 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x88d600", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 265 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 278 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x88d6a0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 268 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 281 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x88d6d0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 269 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 282 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x88d6e0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 266 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 279 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x88d6b0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 267 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 280 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x88d6c0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 301 EventRootType Probe[main.testMassiveString]
+          Type: 314 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x88f6c0", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 275 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 288 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88ea60", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 283 EventRootType Probe[main.testNilPointer]
+          Type: 296 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88ee80", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 293 EventRootType Probe[main.testNilSlice]
+          Type: 306 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x88f310", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 290 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 303 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x88f2e0", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 292 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 305 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x88f300", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 300 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 313 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x88f6b0", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 279 EventRootType Probe[main.testPointerLoop]
+          Type: 292 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88edc0", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 261 EventRootType Probe[main.testPointerToMap]
+          Type: 274 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x88d660", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 277 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 290 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88eda0", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 209 EventRootType Probe[main.testRuneArray]
+          Type: 222 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x88be10", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 228 EventRootType Probe[main.testSingleBool]
+          Type: 241 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 226 EventRootType Probe[main.testSingleByte]
+          Type: 239 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 239 EventRootType Probe[main.testSingleFloat32]
+          Type: 252 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 240 EventRootType Probe[main.testSingleFloat64]
+          Type: 253 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 229 EventRootType Probe[main.testSingleInt]
+          Type: 242 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 231 EventRootType Probe[main.testSingleInt16]
+          Type: 244 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 232 EventRootType Probe[main.testSingleInt32]
+          Type: 245 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 233 EventRootType Probe[main.testSingleInt64]
+          Type: 246 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 230 EventRootType Probe[main.testSingleInt8]
+          Type: 243 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 227 EventRootType Probe[main.testSingleRune]
+          Type: 240 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 296 EventRootType Probe[main.testSingleString]
+          Type: 309 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x88f660", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 234 EventRootType Probe[main.testSingleUint]
+          Type: 247 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 236 EventRootType Probe[main.testSingleUint16]
+          Type: 249 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 237 EventRootType Probe[main.testSingleUint32]
+          Type: 250 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 238 EventRootType Probe[main.testSingleUint64]
+          Type: 251 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 235 EventRootType Probe[main.testSingleUint8]
+          Type: 248 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 287 EventRootType Probe[main.testSliceOfSlices]
+          Type: 300 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x88f2b0", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 259 EventRootType Probe[main.testSmallMap]
+          Type: 272 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x88d640", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 210 EventRootType Probe[main.testStringArray]
+          Type: 223 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x88be20", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 282 EventRootType Probe[main.testStringPointer]
+          Type: 295 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88ee60", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 291 EventRootType Probe[main.testStringSlice]
+          Type: 304 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x88f2f0", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 304 EventRootType Probe[main.testStruct]
+          Type: 317 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x88f8f0", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 288 EventRootType Probe[main.testStructSlice]
+          Type: 301 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x88f2c0", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 254 EventRootType Probe[main.testStructWithMap]
+          Type: 267 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x88d5f0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 297 EventRootType Probe[main.testThreeStrings]
+          Type: 310 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x88f670", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 298 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 311 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x88f680", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 299 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 312 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x88f6a0", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 241 EventRootType Probe[main.testTypeAlias]
+          Type: 254 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 219 EventRootType Probe[main.testUint16Array]
+          Type: 232 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x88beb0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 220 EventRootType Probe[main.testUint32Array]
+          Type: 233 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x88bec0", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 221 EventRootType Probe[main.testUint64Array]
+          Type: 234 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x88bed0", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 218 EventRootType Probe[main.testUint8Array]
+          Type: 231 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x88bea0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 217 EventRootType Probe[main.testUintArray]
+          Type: 230 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x88be90", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 281 EventRootType Probe[main.testUintPointer]
+          Type: 294 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88edf0", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 285 EventRootType Probe[main.testUintSlice]
+          Type: 298 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x88f290", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 302 EventRootType Probe[main.testUnitializedString]
+          Type: 315 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x88f6d0", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 280 EventRootType Probe[main.testUnsafePointer]
+          Type: 293 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88edd0", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 225 EventRootType Probe[main.testVeryLargeArray]
+          Type: 238 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x88bf30", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 294 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 307 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x88f320", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 175 PointerType *string.str
+          Type: 188 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 174 GoStringDataType string.str
+      Data: 187 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 176 GoSliceDataType []*string.array
+      Data: 189 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3673,7 +3673,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 62 GoHMapBucketType bucket<int,int>
-      BucketsType: 178 GoSliceDataType []bucket<int,int>.array
+      BucketsType: 191 GoSliceDataType []bucket<int,int>.array
     - __kind: PointerType
       ID: 61
       Name: '*bucket<int,int>'
@@ -3773,7 +3773,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 179 GoSliceDataType []*runtime.bmap.array
+      Data: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 71
       Name: '**runtime.bmap'
@@ -3841,7 +3841,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 78 GoHMapBucketType bucket<string,main.nestedStruct>
-      BucketsType: 181 GoSliceDataType []bucket<string,main.nestedStruct>.array
+      BucketsType: 194 GoSliceDataType []bucket<string,main.nestedStruct>.array
     - __kind: PointerType
       ID: 77
       Name: '*bucket<string,main.nestedStruct>'
@@ -3938,7 +3938,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 86 GoHMapBucketType bucket<string,int>
-      BucketsType: 182 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 195 GoSliceDataType []bucket<string,int>.array
     - __kind: PointerType
       ID: 85
       Name: '*bucket<string,int>'
@@ -4008,7 +4008,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 91 GoHMapBucketType bucket<string,[]string>
-      BucketsType: 183 GoSliceDataType []bucket<string,[]string>.array
+      BucketsType: 196 GoSliceDataType []bucket<string,[]string>.array
     - __kind: PointerType
       ID: 90
       Name: '*bucket<string,[]string>'
@@ -4056,7 +4056,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 184 GoSliceDataType []string.array
+      Data: 197 GoSliceDataType []string.array
     - __kind: GoMapType
       ID: 94
       Name: map[[4]string][2]int
@@ -4102,7 +4102,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 98 GoHMapBucketType bucket<[4]string,[2]int>
-      BucketsType: 186 GoSliceDataType []bucket<[4]string,[2]int>.array
+      BucketsType: 199 GoSliceDataType []bucket<[4]string,[2]int>.array
     - __kind: PointerType
       ID: 97
       Name: '*bucket<[4]string,[2]int>'
@@ -4209,7 +4209,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
-      BucketsType: 187 GoSliceDataType []bucket<string,[]main.structWithMap>.array
+      BucketsType: 200 GoSliceDataType []bucket<string,[]main.structWithMap>.array
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,[]main.structWithMap>'
@@ -4257,7 +4257,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 188 GoSliceDataType []main.structWithMap.array
+      Data: 201 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 111
       Name: '*main.structWithMap'
@@ -4310,7 +4310,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 116 GoHMapBucketType bucket<bool,main.node>
-      BucketsType: 190 GoSliceDataType []bucket<bool,main.node>.array
+      BucketsType: 203 GoSliceDataType []bucket<bool,main.node>.array
     - __kind: PointerType
       ID: 115
       Name: '*bucket<bool,main.node>'
@@ -4414,7 +4414,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 125 GoHMapBucketType bucket<int,uint8>
-      BucketsType: 191 GoSliceDataType []bucket<int,uint8>.array
+      BucketsType: 204 GoSliceDataType []bucket<int,uint8>.array
     - __kind: PointerType
       ID: 124
       Name: '*bucket<int,uint8>'
@@ -4491,7 +4491,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 131 GoHMapBucketType bucket<uint8,uint8>
-      BucketsType: 192 GoSliceDataType []bucket<uint8,uint8>.array
+      BucketsType: 205 GoSliceDataType []bucket<uint8,uint8>.array
     - __kind: PointerType
       ID: 130
       Name: '*bucket<uint8,uint8>'
@@ -4568,7 +4568,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 137 GoHMapBucketType bucket<uint8,[4]int>
-      BucketsType: 193 GoSliceDataType []bucket<uint8,[4]int>.array
+      BucketsType: 206 GoSliceDataType []bucket<uint8,[4]int>.array
     - __kind: PointerType
       ID: 136
       Name: '*bucket<uint8,[4]int>'
@@ -4654,7 +4654,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 144 GoHMapBucketType bucket<[4]int,uint8>
-      BucketsType: 194 GoSliceDataType []bucket<[4]int,uint8>.array
+      BucketsType: 207 GoSliceDataType []bucket<[4]int,uint8>.array
     - __kind: PointerType
       ID: 143
       Name: '*bucket<[4]int,uint8>'
@@ -4731,7 +4731,7 @@ Types:
           Offset: 40
           Type: 67 PointerType *runtime.mapextra
       BucketType: 150 GoHMapBucketType bucket<[4]int,[4]int>
-      BucketsType: 195 GoSliceDataType []bucket<[4]int,[4]int>.array
+      BucketsType: 208 GoSliceDataType []bucket<[4]int,[4]int>.array
     - __kind: PointerType
       ID: 149
       Name: '*bucket<[4]int,[4]int>'
@@ -4814,7 +4814,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 196 GoSliceDataType main.t.array
+      Data: 209 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 158
       Name: '**main.t'
@@ -4836,7 +4836,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 198 GoSliceDataType []uint.array
+      Data: 211 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
       ID: 160
       Name: '[][]uint'
@@ -4852,7 +4852,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 200 GoSliceDataType [][]uint.array
+      Data: 213 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 161
       Name: '*[]uint'
@@ -4873,7 +4873,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 202 GoSliceDataType []main.structWithNoStrings.array
+      Data: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 163
       Name: '*main.structWithNoStrings'
@@ -4907,7 +4907,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 204 GoSliceDataType []bool.array
+      Data: 217 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
       ID: 166
       Name: '[]uint16'
@@ -4924,7 +4924,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 206 GoSliceDataType []uint16.array
+      Data: 219 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 167
       Name: '*uint16'
@@ -4991,177 +4991,266 @@ Types:
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 174
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 359968
+      GoKind: 22
+      Pointee: 66 BaseType uintptr
+    - __kind: PointerType
+      ID: 175
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 359584
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 176
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 359648
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 177
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 527808
+      GoKind: 15
+    - __kind: BaseType
+      ID: 178
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 527872
+      GoKind: 16
+    - __kind: PointerType
+      ID: 179
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 360224
+      GoKind: 22
+      Pointee: 31 BaseType float64
+    - __kind: PointerType
+      ID: 180
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 359712
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 181
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 359840
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 182
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 359776
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 183
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 359456
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 184
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 359328
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 185
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 359200
+      GoKind: 22
+      Pointee: 56 GoInterfaceType error
+    - __kind: PointerType
+      ID: 186
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 360160
+      GoKind: 22
+      Pointee: 30 BaseType float32
+    - __kind: GoStringDataType
+      ID: 187
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 175
+      ID: 188
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 174 GoStringDataType string.str
+      Pointee: 187 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 176
+      ID: 189
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 177
+      ID: 190
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 176 GoSliceDataType []*string.array
+      Pointee: 189 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 191
       Name: '[]bucket<int,int>.array'
       ByteSize: 2048
       Element: 62 GoHMapBucketType bucket<int,int>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 192
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 72 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 180
+      ID: 193
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 179 GoSliceDataType []*runtime.bmap.array
+      Pointee: 192 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 181
+      ID: 194
       Name: '[]bucket<string,main.nestedStruct>.array'
       ByteSize: 2048
       Element: 78 GoHMapBucketType bucket<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 182
+      ID: 195
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 86 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 196
       Name: '[]bucket<string,[]string>.array'
       ByteSize: 2048
       Element: 91 GoHMapBucketType bucket<string,[]string>
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 197
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 185
+      ID: 198
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 184 GoSliceDataType []string.array
+      Pointee: 197 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 186
+      ID: 199
       Name: '[]bucket<[4]string,[2]int>.array'
       ByteSize: 2048
       Element: 98 GoHMapBucketType bucket<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 187
+      ID: 200
       Name: '[]bucket<string,[]main.structWithMap>.array'
       ByteSize: 2048
       Element: 108 GoHMapBucketType bucket<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 201
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 57 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 189
+      ID: 202
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 188 GoSliceDataType []main.structWithMap.array
+      Pointee: 201 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 190
+      ID: 203
       Name: '[]bucket<bool,main.node>.array'
       ByteSize: 2048
       Element: 116 GoHMapBucketType bucket<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 191
+      ID: 204
       Name: '[]bucket<int,uint8>.array'
       ByteSize: 2048
       Element: 125 GoHMapBucketType bucket<int,uint8>
     - __kind: GoSliceDataType
-      ID: 192
+      ID: 205
       Name: '[]bucket<uint8,uint8>.array'
       ByteSize: 2048
       Element: 131 GoHMapBucketType bucket<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 193
+      ID: 206
       Name: '[]bucket<uint8,[4]int>.array'
       ByteSize: 2048
       Element: 137 GoHMapBucketType bucket<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 194
+      ID: 207
       Name: '[]bucket<[4]int,uint8>.array'
       ByteSize: 2048
       Element: 144 GoHMapBucketType bucket<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 195
+      ID: 208
       Name: '[]bucket<[4]int,[4]int>.array'
       ByteSize: 2048
       Element: 150 GoHMapBucketType bucket<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 196
+      ID: 209
       Name: main.t.array
       ByteSize: 2048
       Element: 156 PointerType *main.t
     - __kind: PointerType
-      ID: 197
+      ID: 210
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 196 GoSliceDataType main.t.array
+      Pointee: 209 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 198
+      ID: 211
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 199
+      ID: 212
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 198 GoSliceDataType []uint.array
+      Pointee: 211 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 200
+      ID: 213
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 159 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 201
+      ID: 214
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 200 GoSliceDataType [][]uint.array
+      Pointee: 213 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 202
+      ID: 215
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 164 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 203
+      ID: 216
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 202 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 215 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 204
+      ID: 217
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 205
+      ID: 218
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 204 GoSliceDataType []bool.array
+      Pointee: 217 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 206
+      ID: 219
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 207
+      ID: 220
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 206 GoSliceDataType []uint16.array
+      Pointee: 219 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 208
+      ID: 221
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5176,7 +5265,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 209
+      ID: 222
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5191,7 +5280,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 223
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5206,7 +5295,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 211
+      ID: 224
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5221,7 +5310,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 212
+      ID: 225
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5236,7 +5325,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 213
+      ID: 226
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5251,7 +5340,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 214
+      ID: 227
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5266,7 +5355,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 215
+      ID: 228
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5281,7 +5370,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 216
+      ID: 229
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5296,7 +5385,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 230
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5311,7 +5400,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 218
+      ID: 231
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5326,7 +5415,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 219
+      ID: 232
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5341,7 +5430,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 220
+      ID: 233
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5356,7 +5445,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 221
+      ID: 234
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5371,7 +5460,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 235
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5386,7 +5475,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 223
+      ID: 236
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5401,7 +5490,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 224
+      ID: 237
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5416,7 +5505,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 225
+      ID: 238
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -5431,7 +5520,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 226
+      ID: 239
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5446,7 +5535,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 227
+      ID: 240
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5461,7 +5550,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 228
+      ID: 241
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5476,7 +5565,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 229
+      ID: 242
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5491,7 +5580,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 230
+      ID: 243
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5506,7 +5595,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 231
+      ID: 244
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5521,7 +5610,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 232
+      ID: 245
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5536,7 +5625,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 233
+      ID: 246
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5551,7 +5640,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 247
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5566,7 +5655,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 235
+      ID: 248
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -5581,7 +5670,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 236
+      ID: 249
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5596,7 +5685,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 237
+      ID: 250
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5611,7 +5700,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 238
+      ID: 251
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5626,7 +5715,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 239
+      ID: 252
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5641,7 +5730,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 240
+      ID: 253
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5656,7 +5745,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 241
+      ID: 254
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5671,7 +5760,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 242
+      ID: 255
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -5686,7 +5775,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 243
+      ID: 256
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -5701,7 +5790,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 244
+      ID: 257
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5716,7 +5805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 245
+      ID: 258
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5731,7 +5820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 246
+      ID: 259
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5755,7 +5844,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 247
+      ID: 260
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5770,10 +5859,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 248
+      ID: 261
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 249
+      ID: 262
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5788,7 +5877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 250
+      ID: 263
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5803,7 +5892,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 251
+      ID: 264
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5818,7 +5907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 265
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5833,7 +5922,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 253
+      ID: 266
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5848,7 +5937,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 267
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5863,7 +5952,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 255
+      ID: 268
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5878,7 +5967,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 269
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5893,7 +5982,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 257
+      ID: 270
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5908,7 +5997,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 258
+      ID: 271
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5923,7 +6012,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 259
+      ID: 272
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5938,7 +6027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 260
+      ID: 273
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5953,7 +6042,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 274
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5968,7 +6057,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 262
+      ID: 275
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5983,7 +6072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 263
+      ID: 276
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5998,7 +6087,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 264
+      ID: 277
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6013,7 +6102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 278
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6028,7 +6117,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 279
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6043,7 +6132,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 267
+      ID: 280
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6058,7 +6147,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 281
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6073,7 +6162,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 282
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6088,7 +6177,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 270
+      ID: 283
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6103,7 +6192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 284
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6118,7 +6207,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 272
+      ID: 285
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6133,7 +6222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 273
+      ID: 286
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6148,7 +6237,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 274
+      ID: 287
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6181,7 +6270,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 275
+      ID: 288
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6232,7 +6321,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 276
+      ID: 289
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6247,7 +6336,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 277
+      ID: 290
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6262,7 +6351,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 278
+      ID: 291
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6277,7 +6366,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 292
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6292,7 +6381,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 280
+      ID: 293
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6307,7 +6396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 294
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6322,7 +6411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 295
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6337,7 +6426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 296
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6361,7 +6450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 284
+      ID: 297
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6376,7 +6465,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 298
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6391,7 +6480,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 286
+      ID: 299
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6406,7 +6495,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 287
+      ID: 300
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6421,7 +6510,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 288
+      ID: 301
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6445,7 +6534,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 302
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6469,7 +6558,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 303
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6493,7 +6582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 304
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6508,7 +6597,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 292
+      ID: 305
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -6541,7 +6630,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 306
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6556,7 +6645,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 294
+      ID: 307
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -6571,10 +6660,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 295
+      ID: 308
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 296
+      ID: 309
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6589,7 +6678,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 297
+      ID: 310
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6622,7 +6711,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 311
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6637,7 +6726,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 299
+      ID: 312
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6652,7 +6741,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 313
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6667,7 +6756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 314
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6682,7 +6771,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 302
+      ID: 315
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6697,7 +6786,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 316
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6712,7 +6801,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 304
+      ID: 317
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -6727,7 +6816,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 305
+      ID: 318
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6742,7 +6831,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 306
+      ID: 319
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6757,16 +6846,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 320
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 308
+      ID: 321
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 309
+      ID: 322
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 310
+      ID: 323
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6781,7 +6870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 324
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6795,5 +6884,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 311
+MaxTypeID: 324
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -6886,3 +6886,4 @@ Types:
                   ByteSize: 40
 MaxTypeID: 324
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x12cd8a0", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -7520,3 +7520,4 @@ Types:
                   ByteSize: 40
 MaxTypeID: 385
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x131d320", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,11 +8,25 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
-        - ID: 87
-          Type: 375 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84cc6c", Frameless: true}]
+        - ID: 88
+          Type: 376 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84cd6c", Frameless: true}]
+          Condition: null
+    - id: testAny
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAny}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 51}
+      events:
+        - ID: 45
+          Type: 333 EventRootType Probe[main.testAny]
+          InjectionPoints: [{PC: "0x84a85c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
       version: 0
@@ -26,7 +40,7 @@ Probes:
       events:
         - ID: 15
           Type: 303 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849620", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
       version: 0
@@ -40,7 +54,7 @@ Probes:
       events:
         - ID: 17
           Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849640", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
       version: 0
@@ -50,11 +64,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 58}
+      subprogram: {subprogram: 59}
       events:
-        - ID: 52
-          Type: 340 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x84ac40", Frameless: true}]
+        - ID: 53
+          Type: 341 EventRootType Probe[main.testArrayOfMaps]
+          InjectionPoints: [{PC: "0x84ad40", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
       version: 0
@@ -68,7 +82,7 @@ Probes:
       events:
         - ID: 16
           Type: 304 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849630", Frameless: true}]
           Condition: null
     - id: testBigStruct
       version: 0
@@ -82,7 +96,7 @@ Probes:
       events:
         - ID: 35
           Type: 323 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x849b30", Frameless: true}]
+          InjectionPoints: [{PC: "0x849ba0", Frameless: true}]
           Condition: null
     - id: testBoolArray
       version: 0
@@ -96,7 +110,7 @@ Probes:
       events:
         - ID: 4
           Type: 292 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x849500", Frameless: true}]
+          InjectionPoints: [{PC: "0x849570", Frameless: true}]
           Condition: null
     - id: testByteArray
       version: 0
@@ -110,7 +124,7 @@ Probes:
       events:
         - ID: 1
           Type: 289 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x8494d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849540", Frameless: true}]
           Condition: null
     - id: testChannel
       version: 0
@@ -120,11 +134,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 74}
+      subprogram: {subprogram: 75}
       events:
-        - ID: 68
-          Type: 356 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84c290", Frameless: true}]
+        - ID: 69
+          Type: 357 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84c390", Frameless: true}]
           Condition: null
     - id: testCombinedByte
       version: 0
@@ -134,11 +148,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 72}
+      subprogram: {subprogram: 73}
       events:
-        - ID: 66
-          Type: 354 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x84c010", Frameless: true}]
+        - ID: 67
+          Type: 355 EventRootType Probe[main.testCombinedByte]
+          InjectionPoints: [{PC: "0x84c110", Frameless: true}]
           Condition: null
     - id: testCycle
       version: 0
@@ -148,11 +162,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 82}
+      subprogram: {subprogram: 83}
       events:
-        - ID: 76
-          Type: 364 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
+        - ID: 77
+          Type: 365 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84c630", Frameless: true}]
           Condition: null
     - id: testEmptySlice
       version: 0
@@ -162,11 +176,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
-        - ID: 78
-          Type: 366 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84c910", Frameless: true}]
+        - ID: 79
+          Type: 367 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84ca10", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
       version: 0
@@ -176,11 +190,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
-        - ID: 81
-          Type: 369 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84c940", Frameless: true}]
+        - ID: 82
+          Type: 370 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84ca40", Frameless: true}]
           Condition: null
     - id: testEmptyString
       version: 0
@@ -190,11 +204,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
-        - ID: 95
-          Type: 383 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84cd50", Frameless: true}]
+        - ID: 96
+          Type: 384 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84ce50", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
       version: 0
@@ -204,11 +218,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
-        - ID: 97
-          Type: 385 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x84d060", Frameless: true}]
+        - ID: 98
+          Type: 386 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x84d160", Frameless: true}]
           Condition: null
     - id: testError
       version: 0
@@ -218,11 +232,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 51}
+      subprogram: {subprogram: 52}
       events:
-        - ID: 45
-          Type: 333 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x84a980", Frameless: true}]
+        - ID: 46
+          Type: 334 EventRootType Probe[main.testError]
+          InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
       version: 0
@@ -236,7 +250,7 @@ Probes:
       events:
         - ID: 37
           Type: 325 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x849dcc", Frameless: true}]
+          InjectionPoints: [{PC: "0x849e3c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
       version: 0
@@ -250,7 +264,7 @@ Probes:
       events:
         - ID: 36
           Type: 324 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x849cfc", Frameless: true}]
+          InjectionPoints: [{PC: "0x849d6c", Frameless: true}]
           Condition: null
     - id: testFrameless
       version: 0
@@ -264,7 +278,7 @@ Probes:
       events:
         - ID: 42
           Type: 330 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x84a4f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a560", Frameless: true}]
           Condition: null
     - id: testFramelessArray
       version: 0
@@ -278,7 +292,7 @@ Probes:
       events:
         - ID: 43
           Type: 331 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x84a500", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a570", Frameless: true}]
           Condition: null
     - id: testInlinedBA
       version: 0
@@ -292,7 +306,7 @@ Probes:
       events:
         - ID: 38
           Type: 326 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x84a20c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a27c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
       version: 0
@@ -306,7 +320,7 @@ Probes:
       events:
         - ID: 39
           Type: 327 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x84a29c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a30c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
       version: 0
@@ -320,7 +334,7 @@ Probes:
       events:
         - ID: 40
           Type: 328 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x84a35c", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a3cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
       version: 0
@@ -332,9 +346,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 2}
       events:
-        - ID: 99
-          Type: 387 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x84a2f8", Frameless: false}]
+        - ID: 100
+          Type: 388 EventRootType Probe[main.testInlinedBBB]
+          InjectionPoints: [{PC: "0x84a368", Frameless: false}]
           Condition: null
     - id: testInlinedBC
       version: 0
@@ -348,7 +362,7 @@ Probes:
       events:
         - ID: 41
           Type: 329 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x84a3dc", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a44c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
       version: 0
@@ -360,9 +374,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 3}
       events:
-        - ID: 100
-          Type: 388 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x84a3ec", Frameless: false}]
+        - ID: 101
+          Type: 389 EventRootType Probe[main.testInlinedBCA]
+          InjectionPoints: [{PC: "0x84a45c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
       version: 0
@@ -374,9 +388,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 4}
       events:
-        - ID: 101
-          Type: 389 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x84a4a0", Frameless: false}]
+        - ID: 102
+          Type: 390 EventRootType Probe[main.testInlinedBCB]
+          InjectionPoints: [{PC: "0x84a510", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
       version: 0
@@ -389,18 +403,18 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 1}
       events:
-        - ID: 98
-          Type: 386 EventRootType Probe[main.testInlinedPrint]
+        - ID: 99
+          Type: 387 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x84a06c"
+            - PC: "0x84a0dc"
               Frameless: true
-            - PC: "0x84a0ec"
+            - PC: "0x84a15c"
               Frameless: false
-            - PC: "0x84a238"
+            - PC: "0x84a2a8"
               Frameless: false
-            - PC: "0x84a2b4"
+            - PC: "0x84a324"
               Frameless: false
-            - PC: "0x84a36c"
+            - PC: "0x84a3dc"
               Frameless: false
           Condition: null
     - id: testInlinedSq
@@ -413,9 +427,9 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 5}
       events:
-        - ID: 102
-          Type: 390 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x84a4f4", Frameless: true}]
+        - ID: 103
+          Type: 391 EventRootType Probe[main.testInlinedSq]
+          InjectionPoints: [{PC: "0x84a564", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
       version: 0
@@ -428,12 +442,12 @@ Probes:
       captureSnapshot: true
       subprogram: {subprogram: 6}
       events:
-        - ID: 103
-          Type: 391 EventRootType Probe[main.testInlinedSumArray]
+        - ID: 104
+          Type: 392 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x84a524"
+            - PC: "0x84a594"
               Frameless: false
-            - PC: "0x84a5bc"
+            - PC: "0x84a62c"
               Frameless: false
           Condition: null
     - id: testInt16Array
@@ -448,7 +462,7 @@ Probes:
       events:
         - ID: 7
           Type: 295 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x849530", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
           Condition: null
     - id: testInt32Array
       version: 0
@@ -462,7 +476,7 @@ Probes:
       events:
         - ID: 8
           Type: 296 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x849540", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
           Condition: null
     - id: testInt64Array
       version: 0
@@ -476,7 +490,7 @@ Probes:
       events:
         - ID: 9
           Type: 297 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x849550", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
           Condition: null
     - id: testInt8Array
       version: 0
@@ -490,7 +504,7 @@ Probes:
       events:
         - ID: 6
           Type: 294 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x849520", Frameless: true}]
+          InjectionPoints: [{PC: "0x849590", Frameless: true}]
           Condition: null
     - id: testIntArray
       version: 0
@@ -504,13 +518,13 @@ Probes:
       events:
         - ID: 5
           Type: 293 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x849510", Frameless: true}]
+          InjectionPoints: [{PC: "0x849580", Frameless: true}]
           Condition: null
     - id: testInterface
       version: 0
       type: LOG_PROBE
       where: {methodName: main.testInterface}
-      tags: ['foo:bar']
+      sampling: {snapshotsPerSecond: 10}
       template: ""
       segments: []
       captureSnapshot: true
@@ -518,7 +532,7 @@ Probes:
       events:
         - ID: 44
           Type: 332 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x84a7a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x84a80c", Frameless: true}]
           Condition: null
     - id: testLinkedList
       version: 0
@@ -528,11 +542,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 76}
+      subprogram: {subprogram: 77}
       events:
-        - ID: 70
-          Type: 358 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84c440", Frameless: true}]
+        - ID: 71
+          Type: 359 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84c540", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
       version: 0
@@ -542,11 +556,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 56}
+      subprogram: {subprogram: 57}
       events:
-        - ID: 50
-          Type: 338 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x84ac20", Frameless: true}]
+        - ID: 51
+          Type: 339 EventRootType Probe[main.testMapArrayToArray]
+          InjectionPoints: [{PC: "0x84ad20", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
       version: 0
@@ -556,11 +570,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 62}
+      subprogram: {subprogram: 63}
       events:
-        - ID: 56
-          Type: 344 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x84ac80", Frameless: true}]
+        - ID: 57
+          Type: 345 EventRootType Probe[main.testMapEmbeddedMaps]
+          InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
       version: 0
@@ -570,11 +584,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 60}
+      subprogram: {subprogram: 61}
       events:
-        - ID: 54
-          Type: 342 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x84ac60", Frameless: true}]
+        - ID: 55
+          Type: 343 EventRootType Probe[main.testMapIntToInt]
+          InjectionPoints: [{PC: "0x84ad60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
       version: 0
@@ -584,11 +598,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 71}
+      subprogram: {subprogram: 72}
       events:
-        - ID: 65
-          Type: 353 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
+        - ID: 66
+          Type: 354 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          InjectionPoints: [{PC: "0x84ae10", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
       version: 0
@@ -598,11 +612,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 70}
+      subprogram: {subprogram: 71}
       events:
-        - ID: 64
-          Type: 352 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
+        - ID: 65
+          Type: 353 EventRootType Probe[main.testMapLargeKeySmallValue]
+          InjectionPoints: [{PC: "0x84ae00", Frameless: true}]
           Condition: null
     - id: testMapMassive
       version: 0
@@ -612,11 +626,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 61}
+      subprogram: {subprogram: 62}
       events:
-        - ID: 55
-          Type: 343 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x84ac70", Frameless: true}]
+        - ID: 56
+          Type: 344 EventRootType Probe[main.testMapMassive]
+          InjectionPoints: [{PC: "0x84ad70", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
       version: 0
@@ -626,11 +640,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 69}
+      subprogram: {subprogram: 70}
       events:
-        - ID: 63
-          Type: 351 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
+        - ID: 64
+          Type: 352 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          InjectionPoints: [{PC: "0x84adf0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
       version: 0
@@ -640,11 +654,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 68}
+      subprogram: {subprogram: 69}
       events:
-        - ID: 62
-          Type: 350 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
+        - ID: 63
+          Type: 351 EventRootType Probe[main.testMapSmallKeySmallValue]
+          InjectionPoints: [{PC: "0x84ade0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
       version: 0
@@ -654,11 +668,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 54}
+      subprogram: {subprogram: 55}
       events:
-        - ID: 48
-          Type: 336 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x84ac00", Frameless: true}]
+        - ID: 49
+          Type: 337 EventRootType Probe[main.testMapStringToInt]
+          InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
       version: 0
@@ -668,11 +682,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 55}
+      subprogram: {subprogram: 56}
       events:
-        - ID: 49
-          Type: 337 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x84ac10", Frameless: true}]
+        - ID: 50
+          Type: 338 EventRootType Probe[main.testMapStringToSlice]
+          InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
       version: 0
@@ -682,11 +696,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 53}
+      subprogram: {subprogram: 54}
       events:
-        - ID: 47
-          Type: 335 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x84abf0", Frameless: true}]
+        - ID: 48
+          Type: 336 EventRootType Probe[main.testMapStringToStruct]
+          InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
       version: 0
@@ -696,11 +710,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 63}
+      subprogram: {subprogram: 64}
       events:
-        - ID: 57
-          Type: 345 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x84ac90", Frameless: true}]
+        - ID: 58
+          Type: 346 EventRootType Probe[main.testMapWithLinkedList]
+          InjectionPoints: [{PC: "0x84ad90", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
       version: 0
@@ -710,11 +724,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 66}
+      subprogram: {subprogram: 67}
       events:
-        - ID: 60
-          Type: 348 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x84acc0", Frameless: true}]
+        - ID: 61
+          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          InjectionPoints: [{PC: "0x84adc0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
@@ -724,11 +738,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 67}
+      subprogram: {subprogram: 68}
       events:
-        - ID: 61
-          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x84acd0", Frameless: true}]
+        - ID: 62
+          Type: 350 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          InjectionPoints: [{PC: "0x84add0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
       version: 0
@@ -738,11 +752,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 64}
+      subprogram: {subprogram: 65}
       events:
-        - ID: 58
-          Type: 346 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x84aca0", Frameless: true}]
+        - ID: 59
+          Type: 347 EventRootType Probe[main.testMapWithSmallValue]
+          InjectionPoints: [{PC: "0x84ada0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
       version: 0
@@ -752,11 +766,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 65}
+      subprogram: {subprogram: 66}
       events:
-        - ID: 59
-          Type: 347 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x84acb0", Frameless: true}]
+        - ID: 60
+          Type: 348 EventRootType Probe[main.testMapWithSmallValueMassive]
+          InjectionPoints: [{PC: "0x84adb0", Frameless: true}]
           Condition: null
     - id: testMassiveString
       version: 0
@@ -766,11 +780,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
-        - ID: 93
-          Type: 381 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84cd30", Frameless: true}]
+        - ID: 94
+          Type: 382 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84ce30", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
       version: 0
@@ -780,11 +794,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 73}
+      subprogram: {subprogram: 74}
       events:
-        - ID: 67
-          Type: 355 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x84c0f0", Frameless: true}]
+        - ID: 68
+          Type: 356 EventRootType Probe[main.testMultipleSimpleParams]
+          InjectionPoints: [{PC: "0x84c1f0", Frameless: true}]
           Condition: null
     - id: testNilPointer
       version: 0
@@ -794,11 +808,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 81}
+      subprogram: {subprogram: 82}
       events:
-        - ID: 75
-          Type: 363 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84c510", Frameless: true}]
+        - ID: 76
+          Type: 364 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84c610", Frameless: true}]
           Condition: null
     - id: testNilSlice
       version: 0
@@ -808,11 +822,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
-        - ID: 85
-          Type: 373 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84c980", Frameless: true}]
+        - ID: 86
+          Type: 374 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84ca80", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
       version: 0
@@ -822,11 +836,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
-        - ID: 82
-          Type: 370 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84c950", Frameless: true}]
+        - ID: 83
+          Type: 371 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84ca50", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
       version: 0
@@ -836,11 +850,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
-        - ID: 84
-          Type: 372 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84c970", Frameless: true}]
+        - ID: 85
+          Type: 373 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84ca70", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
       version: 0
@@ -850,11 +864,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
-        - ID: 92
-          Type: 380 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84cd20", Frameless: true}]
+        - ID: 93
+          Type: 381 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84ce20", Frameless: true}]
           Condition: null
     - id: testPointerLoop
       version: 0
@@ -864,11 +878,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 77}
+      subprogram: {subprogram: 78}
       events:
-        - ID: 71
-          Type: 359 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84c450", Frameless: true}]
+        - ID: 72
+          Type: 360 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84c550", Frameless: true}]
           Condition: null
     - id: testPointerToMap
       version: 0
@@ -878,11 +892,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 59}
+      subprogram: {subprogram: 60}
       events:
-        - ID: 53
-          Type: 341 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x84ac50", Frameless: true}]
+        - ID: 54
+          Type: 342 EventRootType Probe[main.testPointerToMap]
+          InjectionPoints: [{PC: "0x84ad50", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
       version: 0
@@ -892,11 +906,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 75}
+      subprogram: {subprogram: 76}
       events:
-        - ID: 69
-          Type: 357 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84c430", Frameless: true}]
+        - ID: 70
+          Type: 358 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84c530", Frameless: true}]
           Condition: null
     - id: testRuneArray
       version: 0
@@ -910,7 +924,7 @@ Probes:
       events:
         - ID: 2
           Type: 290 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x8494e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849550", Frameless: true}]
           Condition: null
     - id: testSingleBool
       version: 0
@@ -924,7 +938,7 @@ Probes:
       events:
         - ID: 21
           Type: 309 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x849950", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
       version: 0
@@ -938,7 +952,7 @@ Probes:
       events:
         - ID: 19
           Type: 307 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x849930", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
       version: 0
@@ -952,7 +966,7 @@ Probes:
       events:
         - ID: 32
           Type: 320 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x849a00", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
       version: 0
@@ -966,7 +980,7 @@ Probes:
       events:
         - ID: 33
           Type: 321 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x849a10", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
     - id: testSingleInt
       version: 0
@@ -980,7 +994,7 @@ Probes:
       events:
         - ID: 22
           Type: 310 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x849960", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
       version: 0
@@ -994,7 +1008,7 @@ Probes:
       events:
         - ID: 24
           Type: 312 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x849980", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
       version: 0
@@ -1008,7 +1022,7 @@ Probes:
       events:
         - ID: 25
           Type: 313 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x849990", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testSingleInt64
       version: 0
@@ -1022,7 +1036,7 @@ Probes:
       events:
         - ID: 26
           Type: 314 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testSingleInt8
       version: 0
@@ -1036,7 +1050,7 @@ Probes:
       events:
         - ID: 23
           Type: 311 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x849970", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testSingleRune
       version: 0
@@ -1050,7 +1064,7 @@ Probes:
       events:
         - ID: 20
           Type: 308 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x849940", Frameless: true}]
+          InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testSingleString
       version: 0
@@ -1060,11 +1074,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
-        - ID: 88
-          Type: 376 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84ccd0", Frameless: true}]
+        - ID: 89
+          Type: 377 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84cdd0", Frameless: true}]
           Condition: null
     - id: testSingleUint
       version: 0
@@ -1078,7 +1092,7 @@ Probes:
       events:
         - ID: 27
           Type: 315 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testSingleUint16
       version: 0
@@ -1092,7 +1106,7 @@ Probes:
       events:
         - ID: 29
           Type: 317 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testSingleUint32
       version: 0
@@ -1106,7 +1120,7 @@ Probes:
       events:
         - ID: 30
           Type: 318 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testSingleUint64
       version: 0
@@ -1120,7 +1134,7 @@ Probes:
       events:
         - ID: 31
           Type: 319 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testSingleUint8
       version: 0
@@ -1134,7 +1148,7 @@ Probes:
       events:
         - ID: 28
           Type: 316 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
       version: 0
@@ -1144,11 +1158,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
-        - ID: 79
-          Type: 367 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84c920", Frameless: true}]
+        - ID: 80
+          Type: 368 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84ca20", Frameless: true}]
           Condition: null
     - id: testSmallMap
       version: 0
@@ -1158,11 +1172,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 57}
+      subprogram: {subprogram: 58}
       events:
-        - ID: 51
-          Type: 339 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x84ac30", Frameless: true}]
+        - ID: 52
+          Type: 340 EventRootType Probe[main.testSmallMap]
+          InjectionPoints: [{PC: "0x84ad30", Frameless: true}]
           Condition: null
     - id: testStringArray
       version: 0
@@ -1176,7 +1190,7 @@ Probes:
       events:
         - ID: 3
           Type: 291 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x8494f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849560", Frameless: true}]
           Condition: null
     - id: testStringPointer
       version: 0
@@ -1186,11 +1200,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 80}
+      subprogram: {subprogram: 81}
       events:
-        - ID: 74
-          Type: 362 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84c4f0", Frameless: true}]
+        - ID: 75
+          Type: 363 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84c5f0", Frameless: true}]
           Condition: null
     - id: testStringSlice
       version: 0
@@ -1200,11 +1214,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
-        - ID: 83
-          Type: 371 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84c960", Frameless: true}]
+        - ID: 84
+          Type: 372 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84ca60", Frameless: true}]
           Condition: null
     - id: testStruct
       version: 0
@@ -1214,11 +1228,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
-        - ID: 96
-          Type: 384 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x84cf60", Frameless: true}]
+        - ID: 97
+          Type: 385 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
     - id: testStructSlice
       version: 0
@@ -1228,11 +1242,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
-        - ID: 80
-          Type: 368 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84c930", Frameless: true}]
+        - ID: 81
+          Type: 369 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84ca30", Frameless: true}]
           Condition: null
     - id: testStructWithMap
       version: 0
@@ -1242,11 +1256,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 52}
+      subprogram: {subprogram: 53}
       events:
-        - ID: 46
-          Type: 334 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x84abe0", Frameless: true}]
+        - ID: 47
+          Type: 335 EventRootType Probe[main.testStructWithMap]
+          InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
       version: 0
@@ -1256,11 +1270,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
-        - ID: 89
-          Type: 377 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84cce0", Frameless: true}]
+        - ID: 90
+          Type: 378 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84cde0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
       version: 0
@@ -1270,11 +1284,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
-        - ID: 90
-          Type: 378 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84ccf0", Frameless: true}]
+        - ID: 91
+          Type: 379 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84cdf0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
       version: 0
@@ -1284,11 +1298,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
-        - ID: 91
-          Type: 379 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84cd10", Frameless: true}]
+        - ID: 92
+          Type: 380 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84ce10", Frameless: true}]
           Condition: null
     - id: testTypeAlias
       version: 0
@@ -1302,7 +1316,7 @@ Probes:
       events:
         - ID: 34
           Type: 322 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x849a20", Frameless: true}]
+          InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
     - id: testUint16Array
       version: 0
@@ -1316,7 +1330,7 @@ Probes:
       events:
         - ID: 12
           Type: 300 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x849580", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495f0", Frameless: true}]
           Condition: null
     - id: testUint32Array
       version: 0
@@ -1330,7 +1344,7 @@ Probes:
       events:
         - ID: 13
           Type: 301 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x849590", Frameless: true}]
+          InjectionPoints: [{PC: "0x849600", Frameless: true}]
           Condition: null
     - id: testUint64Array
       version: 0
@@ -1344,7 +1358,7 @@ Probes:
       events:
         - ID: 14
           Type: 302 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x849610", Frameless: true}]
           Condition: null
     - id: testUint8Array
       version: 0
@@ -1358,7 +1372,7 @@ Probes:
       events:
         - ID: 11
           Type: 299 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x849570", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495e0", Frameless: true}]
           Condition: null
     - id: testUintArray
       version: 0
@@ -1372,7 +1386,7 @@ Probes:
       events:
         - ID: 10
           Type: 298 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x849560", Frameless: true}]
+          InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
           Condition: null
     - id: testUintPointer
       version: 0
@@ -1382,11 +1396,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 79}
+      subprogram: {subprogram: 80}
       events:
-        - ID: 73
-          Type: 361 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84c480", Frameless: true}]
+        - ID: 74
+          Type: 362 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84c580", Frameless: true}]
           Condition: null
     - id: testUintSlice
       version: 0
@@ -1396,11 +1410,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 83}
+      subprogram: {subprogram: 84}
       events:
-        - ID: 77
-          Type: 365 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84c900", Frameless: true}]
+        - ID: 78
+          Type: 366 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84ca00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
       version: 0
@@ -1410,11 +1424,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
-        - ID: 94
-          Type: 382 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84cd40", Frameless: true}]
+        - ID: 95
+          Type: 383 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84ce40", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
       version: 0
@@ -1424,11 +1438,11 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 78}
+      subprogram: {subprogram: 79}
       events:
-        - ID: 72
-          Type: 360 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84c460", Frameless: true}]
+        - ID: 73
+          Type: 361 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84c560", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
       version: 0
@@ -1442,7 +1456,7 @@ Probes:
       events:
         - ID: 18
           Type: 306 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x849600", Frameless: true}]
+          InjectionPoints: [{PC: "0x849670", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
       version: 0
@@ -1452,430 +1466,430 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
-        - ID: 86
-          Type: 374 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84c990", Frameless: true}]
+        - ID: 87
+          Type: 375 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84ca90", Frameless: true}]
           Condition: null
 Subprograms:
     - ID: 7
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x8494d0..0x8494e0]
+      OutOfLinePCRanges: [0x849540..0x849550]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0x8494d0..0x8494e0
+            - Range: 0x849540..0x849550
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 8
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x8494e0..0x8494f0]
+      OutOfLinePCRanges: [0x849550..0x849560]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
-            - Range: 0x8494e0..0x8494f0
+            - Range: 0x849550..0x849560
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 9
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x8494f0..0x849500]
+      OutOfLinePCRanges: [0x849560..0x849570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0x8494f0..0x849500
+            - Range: 0x849560..0x849570
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 10
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x849500..0x849510]
+      OutOfLinePCRanges: [0x849570..0x849580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 ArrayType [2]bool
           Locations:
-            - Range: 0x849500..0x849510
+            - Range: 0x849570..0x849580
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 11
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x849510..0x849520]
+      OutOfLinePCRanges: [0x849580..0x849590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 ArrayType [2]int
           Locations:
-            - Range: 0x849510..0x849520
+            - Range: 0x849580..0x849590
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 12
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x849520..0x849530]
+      OutOfLinePCRanges: [0x849590..0x8495a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 ArrayType [2]int8
           Locations:
-            - Range: 0x849520..0x849530
+            - Range: 0x849590..0x8495a0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 13
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x849530..0x849540]
+      OutOfLinePCRanges: [0x8495a0..0x8495b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 ArrayType [2]int16
           Locations:
-            - Range: 0x849530..0x849540
+            - Range: 0x8495a0..0x8495b0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 14
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x849540..0x849550]
+      OutOfLinePCRanges: [0x8495b0..0x8495c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 5 ArrayType [2]int32
           Locations:
-            - Range: 0x849540..0x849550
+            - Range: 0x8495b0..0x8495c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 15
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x849550..0x849560]
+      OutOfLinePCRanges: [0x8495c0..0x8495d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 ArrayType [2]int64
           Locations:
-            - Range: 0x849550..0x849560
+            - Range: 0x8495c0..0x8495d0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 16
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x849560..0x849570]
+      OutOfLinePCRanges: [0x8495d0..0x8495e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 ArrayType [2]uint
           Locations:
-            - Range: 0x849560..0x849570
+            - Range: 0x8495d0..0x8495e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 17
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x849570..0x849580]
+      OutOfLinePCRanges: [0x8495e0..0x8495f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 ArrayType [2]uint8
           Locations:
-            - Range: 0x849570..0x849580
+            - Range: 0x8495e0..0x8495f0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 18
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x849580..0x849590]
+      OutOfLinePCRanges: [0x8495f0..0x849600]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 21 ArrayType [2]uint16
           Locations:
-            - Range: 0x849580..0x849590
+            - Range: 0x8495f0..0x849600
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 19
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x849590..0x8495a0]
+      OutOfLinePCRanges: [0x849600..0x849610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 23 ArrayType [2]uint32
           Locations:
-            - Range: 0x849590..0x8495a0
+            - Range: 0x849600..0x849610
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 20
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x8495a0..0x8495b0]
+      OutOfLinePCRanges: [0x849610..0x849620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 25 ArrayType [2]uint64
           Locations:
-            - Range: 0x8495a0..0x8495b0
+            - Range: 0x849610..0x849620
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 21
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x8495b0..0x8495c0]
+      OutOfLinePCRanges: [0x849620..0x849630]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 27 ArrayType [2][2]int
           Locations:
-            - Range: 0x8495b0..0x8495c0
+            - Range: 0x849620..0x849630
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 22
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x8495c0..0x8495d0]
+      OutOfLinePCRanges: [0x849630..0x849640]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 ArrayType [2]string
           Locations:
-            - Range: 0x8495c0..0x8495d0
+            - Range: 0x849630..0x849640
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 23
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x8495d0..0x8495e0]
+      OutOfLinePCRanges: [0x849640..0x849650]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 28 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x8495d0..0x8495e0
+            - Range: 0x849640..0x849650
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 24
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x849600..0x849610]
+      OutOfLinePCRanges: [0x849670..0x849680]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 29 ArrayType [100]uint
           Locations:
-            - Range: 0x849600..0x849610
+            - Range: 0x849670..0x849680
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
     - ID: 25
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x849930..0x849940]
+      OutOfLinePCRanges: [0x8499a0..0x8499b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x849930..0x849940
+            - Range: 0x8499a0..0x8499b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 26
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x849940..0x849950]
+      OutOfLinePCRanges: [0x8499b0..0x8499c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x849940..0x849950
+            - Range: 0x8499b0..0x8499c0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 27
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x849950..0x849960]
+      OutOfLinePCRanges: [0x8499c0..0x8499d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType bool
           Locations:
-            - Range: 0x849950..0x849960
+            - Range: 0x8499c0..0x8499d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 28
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x849960..0x849970]
+      OutOfLinePCRanges: [0x8499d0..0x8499e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x849960..0x849970
+            - Range: 0x8499d0..0x8499e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 29
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x849970..0x849980]
+      OutOfLinePCRanges: [0x8499e0..0x8499f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x849970..0x849980
+            - Range: 0x8499e0..0x8499f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 30
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x849980..0x849990]
+      OutOfLinePCRanges: [0x8499f0..0x849a00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int16
           Locations:
-            - Range: 0x849980..0x849990
+            - Range: 0x8499f0..0x849a00
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 31
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x849990..0x8499a0]
+      OutOfLinePCRanges: [0x849a00..0x849a10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x849990..0x8499a0
+            - Range: 0x849a00..0x849a10
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 32
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x8499a0..0x8499b0]
+      OutOfLinePCRanges: [0x849a10..0x849a20]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType int64
           Locations:
-            - Range: 0x8499a0..0x8499b0
+            - Range: 0x849a10..0x849a20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 33
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x8499b0..0x8499c0]
+      OutOfLinePCRanges: [0x849a20..0x849a30]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x8499b0..0x8499c0
+            - Range: 0x849a20..0x849a30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 34
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x8499c0..0x8499d0]
+      OutOfLinePCRanges: [0x849a30..0x849a40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x8499c0..0x8499d0
+            - Range: 0x849a30..0x849a40
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 35
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x8499d0..0x8499e0]
+      OutOfLinePCRanges: [0x849a40..0x849a50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 22 BaseType uint16
           Locations:
-            - Range: 0x8499d0..0x8499e0
+            - Range: 0x849a40..0x849a50
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 36
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x8499e0..0x8499f0]
+      OutOfLinePCRanges: [0x849a50..0x849a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 24 BaseType uint32
           Locations:
-            - Range: 0x8499e0..0x8499f0
+            - Range: 0x849a50..0x849a60
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 37
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x8499f0..0x849a00]
+      OutOfLinePCRanges: [0x849a60..0x849a70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 26 BaseType uint64
           Locations:
-            - Range: 0x8499f0..0x849a00
+            - Range: 0x849a60..0x849a70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 38
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x849a00..0x849a10]
+      OutOfLinePCRanges: [0x849a70..0x849a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 30 BaseType float32
           Locations:
-            - Range: 0x849a00..0x849a10
+            - Range: 0x849a70..0x849a80
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 39
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x849a10..0x849a20]
+      OutOfLinePCRanges: [0x849a80..0x849a90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 31 BaseType float64
           Locations:
-            - Range: 0x849a10..0x849a20
+            - Range: 0x849a80..0x849a90
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 40
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x849a20..0x849a30]
+      OutOfLinePCRanges: [0x849a90..0x849aa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 32 BaseType main.typeAlias
           Locations:
-            - Range: 0x849a20..0x849a30
+            - Range: 0x849a90..0x849aa0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 41
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x849b30..0x849b50]
+      OutOfLinePCRanges: [0x849ba0..0x849bc0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 33 StructureType main.bigStruct
           Locations:
-            - Range: 0x849b30..0x849b50
+            - Range: 0x849ba0..0x849bc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1893,13 +1907,13 @@ Subprograms:
           IsReturn: false
     - ID: 42
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x849cf0..0x849dc0]
+      OutOfLinePCRanges: [0x849d60..0x849e30]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 57 StructureType main.esotericStack
           Locations:
-            - Range: 0x849cf0..0x849d38
+            - Range: 0x849d60..0x849da8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -1919,7 +1933,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x849d38..0x849d3c
+            - Range: 0x849da8..0x849dac
               Pieces:
                 - Size: 4
                   Op: null
@@ -1939,7 +1953,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x849d3c..0x849d40
+            - Range: 0x849dac..0x849db0
               Pieces:
                 - Size: 4
                   Op: null
@@ -1963,281 +1977,192 @@ Subprograms:
           IsReturn: false
     - ID: 43
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x849dc0..0x849e40]
+      OutOfLinePCRanges: [0x849e30..0x849eb0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 63 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x849dc0..0x849df8
+            - Range: 0x849e30..0x849e68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 44
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x84a200..0x84a290]
+      OutOfLinePCRanges: [0x84a270..0x84a300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a200..0x84a238
+            - Range: 0x84a270..0x84a2a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 45
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x84a290..0x84a350]
+      OutOfLinePCRanges: [0x84a300..0x84a3c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a290..0x84a2ac
+            - Range: 0x84a300..0x84a31c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a290..0x84a2bc
+            - Range: 0x84a300..0x84a32c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: z
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a2ac..0x84a2bc
+            - Range: 0x84a31c..0x84a32c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a2bc..0x84a350
+            - Range: 0x84a32c..0x84a3c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           IsParameter: false
           IsReturn: false
     - ID: 46
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x84a350..0x84a3d0]
+      OutOfLinePCRanges: [0x84a3c0..0x84a440]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a350..0x84a374
+            - Range: 0x84a3c0..0x84a3e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 47
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x84a3d0..0x84a4f0]
+      OutOfLinePCRanges: [0x84a440..0x84a560]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a438..0x84a440
+            - Range: 0x84a4a8..0x84a4b0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84a440..0x84a458
+            - Range: 0x84a4b0..0x84a4c8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x84a458..0x84a46c
+            - Range: 0x84a4c8..0x84a4dc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: false
           IsReturn: false
         - Name: i
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a434..0x84a43c
+            - Range: 0x84a4a4..0x84a4ac
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84a43c..0x84a458
+            - Range: 0x84a4ac..0x84a4c8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x84a458..0x84a468
+            - Range: 0x84a4c8..0x84a4d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: false
           IsReturn: false
     - ID: 48
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x84a4f0..0x84a500]
+      OutOfLinePCRanges: [0x84a560..0x84a570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a4f0..0x84a4f8
+            - Range: 0x84a560..0x84a568
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0x84a4f0..0x84a500, Pieces: []}]
+          Locations: [{Range: 0x84a560..0x84a570, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 49
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x84a500..0x84a560]
+      OutOfLinePCRanges: [0x84a570..0x84a5d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0x84a500..0x84a560
+            - Range: 0x84a570..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 1 BaseType int
-          Locations: [{Range: 0x84a500..0x84a560, Pieces: []}]
+          Locations: [{Range: 0x84a570..0x84a5d0, Pieces: []}]
           IsParameter: true
           IsReturn: true
     - ID: 50
       Name: main.testInterface
-      OutOfLinePCRanges: [0x84a790..0x84a980]
+      OutOfLinePCRanges: [0x84a800..0x84a850]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 75 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84a790..0x84a7bc
+            - Range: 0x84a800..0x84a828
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a7bc..0x84a7c0
+            - Range: 0x84a828..0x84a82c
               Pieces:
                 - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
                   Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0x84a790..0x84a980, Pieces: []}]
+          Locations: [{Range: 0x84a800..0x84a850, Pieces: []}]
           IsParameter: true
           IsReturn: true
-        - Name: hash
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x84a7f0..0x84a7f4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x84a7f4..0x84a800
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a800..0x84a804
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-            - Range: 0x84a804..0x84a980
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -96}
-                - Size: 8
-                  Op: {CfaOffset: -136}
-          IsParameter: false
-          IsReturn: false
-        - Name: inter
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x84a834..0x84a838
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x84a838..0x84a844
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a844..0x84a848
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-            - Range: 0x84a848..0x84a980
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -120}
-                - Size: 8
-                  Op: {CfaOffset: -160}
-          IsParameter: false
-          IsReturn: false
-        - Name: iType
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x84a878..0x84a87c
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x84a87c..0x84a888
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a888..0x84a894
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-            - Range: 0x84a894..0x84a980
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -112}
-                - Size: 8
-                  Op: {CfaOffset: -152}
-          IsParameter: false
-          IsReturn: false
-        - Name: iFun
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x84a8c4..0x84a8c8
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: null
-            - Range: 0x84a8c8..0x84a8e0
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84a8e0..0x84a8e4
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-            - Range: 0x84a8e4..0x84a980
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -104}
-                - Size: 8
-                  Op: {CfaOffset: -144}
-          IsParameter: false
-          IsReturn: false
     - ID: 51
+      Name: main.testAny
+      OutOfLinePCRanges: [0x84a850..0x84a8c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 59 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0x84a850..0x84a880
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0x84a880..0x84a884
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: ~r0
+          Type: 8 GoStringHeaderType string
+          Locations: [{Range: 0x84a850..0x84a8c0, Pieces: []}]
+          IsParameter: true
+          IsReturn: true
+    - ID: 52
       Name: main.testError
-      OutOfLinePCRanges: [0x84a980..0x84a990]
+      OutOfLinePCRanges: [0x84a8c0..0x84a8d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 76 GoInterfaceType error
           Locations:
-            - Range: 0x84a980..0x84a990
+            - Range: 0x84a8c0..0x84a8d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2245,309 +2170,309 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 52
+    - ID: 53
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x84abe0..0x84abf0]
+      OutOfLinePCRanges: [0x84ace0..0x84acf0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 77 StructureType main.structWithMap
           Locations:
-            - Range: 0x84abe0..0x84abf0
+            - Range: 0x84ace0..0x84acf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 53
+    - ID: 54
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x84abf0..0x84ac00]
+      OutOfLinePCRanges: [0x84acf0..0x84ad00]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 89 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x84abf0..0x84ac00
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 54
-      Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x84ac00..0x84ac10]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0x84ac00..0x84ac10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 55
-      Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x84ac10..0x84ac20]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 112 GoMapType map[string][]string
-          Locations:
-            - Range: 0x84ac10..0x84ac20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 56
-      Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x84ac20..0x84ac30]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 124 GoMapType map[[4]string][2]int
-          Locations:
-            - Range: 0x84ac20..0x84ac30
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 57
-      Name: main.testSmallMap
-      OutOfLinePCRanges: [0x84ac30..0x84ac40]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 101 GoMapType map[string]int
-          Locations:
-            - Range: 0x84ac30..0x84ac40
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 58
-      Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x84ac40..0x84ac50]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 136 ArrayType [2]map[string]int
-          Locations:
-            - Range: 0x84ac40..0x84ac50
-              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 59
-      Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x84ac50..0x84ac60]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 137 PointerType *map[string]int
-          Locations:
-            - Range: 0x84ac50..0x84ac60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 60
-      Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x84ac60..0x84ac70]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 78 GoMapType map[int]int
-          Locations:
-            - Range: 0x84ac60..0x84ac70
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 61
-      Name: main.testMapMassive
-      OutOfLinePCRanges: [0x84ac70..0x84ac80]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84ac70..0x84ac80
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 62
-      Name: main.testMapEmbeddedMaps
-      OutOfLinePCRanges: [0x84ac80..0x84ac90]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x84ac80..0x84ac90
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 63
-      Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x84ac90..0x84aca0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 151 GoMapType map[bool]main.node
-          Locations:
-            - Range: 0x84ac90..0x84aca0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 64
-      Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x84aca0..0x84acb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 164 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x84aca0..0x84acb0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 65
-      Name: main.testMapWithSmallValueMassive
-      OutOfLinePCRanges: [0x84acb0..0x84acc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x84acb0..0x84acc0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 66
-      Name: main.testMapWithSmallKeyAndValue
-      OutOfLinePCRanges: [0x84acc0..0x84acd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 175 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84acc0..0x84acd0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 67
-      Name: main.testMapWithSmallKeyAndValueMassive
-      OutOfLinePCRanges: [0x84acd0..0x84ace0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 175 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84acd0..0x84ace0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 68
-      Name: main.testMapSmallKeySmallValue
-      OutOfLinePCRanges: [0x84ace0..0x84acf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 175 GoMapType map[uint8]uint8
-          Locations:
-            - Range: 0x84ace0..0x84acf0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          IsParameter: true
-          IsReturn: false
-    - ID: 69
-      Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x84acf0..0x84ad00]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 186 GoMapType map[uint8][4]int
-          Locations:
             - Range: 0x84acf0..0x84ad00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 70
-      Name: main.testMapLargeKeySmallValue
+    - ID: 55
+      Name: main.testMapStringToInt
       OutOfLinePCRanges: [0x84ad00..0x84ad10]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 101 GoMapType map[string]int
           Locations:
             - Range: 0x84ad00..0x84ad10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 71
-      Name: main.testMapLargeKeyLargeValue
+    - ID: 56
+      Name: main.testMapStringToSlice
       OutOfLinePCRanges: [0x84ad10..0x84ad20]
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 112 GoMapType map[string][]string
           Locations:
             - Range: 0x84ad10..0x84ad20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
+    - ID: 57
+      Name: main.testMapArrayToArray
+      OutOfLinePCRanges: [0x84ad20..0x84ad30]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 124 GoMapType map[[4]string][2]int
+          Locations:
+            - Range: 0x84ad20..0x84ad30
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 58
+      Name: main.testSmallMap
+      OutOfLinePCRanges: [0x84ad30..0x84ad40]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 101 GoMapType map[string]int
+          Locations:
+            - Range: 0x84ad30..0x84ad40
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 59
+      Name: main.testArrayOfMaps
+      OutOfLinePCRanges: [0x84ad40..0x84ad50]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 136 ArrayType [2]map[string]int
+          Locations:
+            - Range: 0x84ad40..0x84ad50
+              Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 60
+      Name: main.testPointerToMap
+      OutOfLinePCRanges: [0x84ad50..0x84ad60]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 137 PointerType *map[string]int
+          Locations:
+            - Range: 0x84ad50..0x84ad60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 61
+      Name: main.testMapIntToInt
+      OutOfLinePCRanges: [0x84ad60..0x84ad70]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 78 GoMapType map[int]int
+          Locations:
+            - Range: 0x84ad60..0x84ad70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 62
+      Name: main.testMapMassive
+      OutOfLinePCRanges: [0x84ad70..0x84ad80]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 138 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x84ad70..0x84ad80
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 63
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x84ad80..0x84ad90]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 138 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x84ad80..0x84ad90
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 64
+      Name: main.testMapWithLinkedList
+      OutOfLinePCRanges: [0x84ad90..0x84ada0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 151 GoMapType map[bool]main.node
+          Locations:
+            - Range: 0x84ad90..0x84ada0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 65
+      Name: main.testMapWithSmallValue
+      OutOfLinePCRanges: [0x84ada0..0x84adb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 164 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84ada0..0x84adb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 66
+      Name: main.testMapWithSmallValueMassive
+      OutOfLinePCRanges: [0x84adb0..0x84adc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: redactMyEntries
+          Type: 164 GoMapType map[int]uint8
+          Locations:
+            - Range: 0x84adb0..0x84adc0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 67
+      Name: main.testMapWithSmallKeyAndValue
+      OutOfLinePCRanges: [0x84adc0..0x84add0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84adc0..0x84add0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 68
+      Name: main.testMapWithSmallKeyAndValueMassive
+      OutOfLinePCRanges: [0x84add0..0x84ade0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84add0..0x84ade0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 69
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x84ade0..0x84adf0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 175 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x84ade0..0x84adf0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 70
+      Name: main.testMapSmallKeyLargeValue
+      OutOfLinePCRanges: [0x84adf0..0x84ae00]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 186 GoMapType map[uint8][4]int
+          Locations:
+            - Range: 0x84adf0..0x84ae00
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 71
+      Name: main.testMapLargeKeySmallValue
+      OutOfLinePCRanges: [0x84ae00..0x84ae10]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 198 GoMapType map[[4]int]uint8
+          Locations:
+            - Range: 0x84ae00..0x84ae10
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
     - ID: 72
+      Name: main.testMapLargeKeyLargeValue
+      OutOfLinePCRanges: [0x84ae10..0x84ae20]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 209 GoMapType map[[4]int][4]int
+          Locations:
+            - Range: 0x84ae10..0x84ae20
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 73
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x84c010..0x84c020]
+      OutOfLinePCRanges: [0x84c110..0x84c120]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84c010..0x84c020
+            - Range: 0x84c110..0x84c120
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: x
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84c010..0x84c020
+            - Range: 0x84c110..0x84c120
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: y
           Type: 30 BaseType float32
           Locations:
-            - Range: 0x84c010..0x84c020
+            - Range: 0x84c110..0x84c120
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 73
+    - ID: 74
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x84c0f0..0x84c100]
+      OutOfLinePCRanges: [0x84c1f0..0x84c200]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 BaseType bool
           Locations:
-            - Range: 0x84c0f0..0x84c100
+            - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: b
           Type: 4 BaseType uint8
           Locations:
-            - Range: 0x84c0f0..0x84c100
+            - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: c
           Type: 6 BaseType int32
           Locations:
-            - Range: 0x84c0f0..0x84c100
+            - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: d
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c0f0..0x84c100
+            - Range: 0x84c1f0..0x84c200
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: e
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84c0f0..0x84c100
+            - Range: 0x84c1f0..0x84c200
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2555,39 +2480,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 74
+    - ID: 75
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84c290..0x84c2a0]
+      OutOfLinePCRanges: [0x84c390..0x84c3a0]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 220 GoChannelType chan bool
           Locations:
-            - Range: 0x84c290..0x84c2a0
+            - Range: 0x84c390..0x84c3a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 75
+    - ID: 76
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84c430..0x84c440]
+      OutOfLinePCRanges: [0x84c530..0x84c540]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 221 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84c430..0x84c440
+            - Range: 0x84c530..0x84c540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 76
+    - ID: 77
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84c440..0x84c450]
+      OutOfLinePCRanges: [0x84c540..0x84c550]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 162 StructureType main.node
           Locations:
-            - Range: 0x84c440..0x84c450
+            - Range: 0x84c540..0x84c550
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2595,112 +2520,94 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 77
+    - ID: 78
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84c450..0x84c460]
+      OutOfLinePCRanges: [0x84c550..0x84c560]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 163 PointerType *main.node
           Locations:
-            - Range: 0x84c450..0x84c460
+            - Range: 0x84c550..0x84c560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 78
+    - ID: 79
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84c460..0x84c470]
+      OutOfLinePCRanges: [0x84c560..0x84c570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 56 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84c460..0x84c470
+            - Range: 0x84c560..0x84c570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 79
+    - ID: 80
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84c480..0x84c490]
+      OutOfLinePCRanges: [0x84c580..0x84c590]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 223 PointerType *uint
           Locations:
-            - Range: 0x84c480..0x84c490
+            - Range: 0x84c580..0x84c590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 80
+    - ID: 81
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84c4f0..0x84c500]
+      OutOfLinePCRanges: [0x84c5f0..0x84c600]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 36 PointerType *string
           Locations:
-            - Range: 0x84c4f0..0x84c500
+            - Range: 0x84c5f0..0x84c600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 81
+    - ID: 82
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84c510..0x84c520]
+      OutOfLinePCRanges: [0x84c610..0x84c620]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 224 PointerType *bool
           Locations:
-            - Range: 0x84c510..0x84c520
+            - Range: 0x84c610..0x84c620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: a
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c510..0x84c520
+            - Range: 0x84c610..0x84c620
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 82
+    - ID: 83
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84c530..0x84c540]
+      OutOfLinePCRanges: [0x84c630..0x84c640]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 225 PointerType *main.t
           Locations:
-            - Range: 0x84c530..0x84c540
+            - Range: 0x84c630..0x84c640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 83
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84c900..0x84c910]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 228 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84c900..0x84c910
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 84
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84c910..0x84c920]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84ca00..0x84ca10]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c910..0x84c920
+            - Range: 0x84ca00..0x84ca10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2711,14 +2618,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 85
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84c920..0x84c930]
+      Name: main.testEmptySlice
+      OutOfLinePCRanges: [0x84ca10..0x84ca20]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 229 GoSliceHeaderType [][]uint
+          Type: 228 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84c920..0x84c930
+            - Range: 0x84ca10..0x84ca20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2729,14 +2636,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 86
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84c930..0x84c940]
+      Name: main.testSliceOfSlices
+      OutOfLinePCRanges: [0x84ca20..0x84ca30]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 229 GoSliceHeaderType [][]uint
           Locations:
-            - Range: 0x84c930..0x84c940
+            - Range: 0x84ca20..0x84ca30
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2744,24 +2651,17 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-        - Name: a
-          Type: 1 BaseType int
-          Locations:
-            - Range: 0x84c930..0x84c940
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 87
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84c940..0x84c950]
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84ca30..0x84ca40]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84c940..0x84c950
+            - Range: 0x84ca30..0x84ca40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2774,19 +2674,19 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84c940..0x84c950
+            - Range: 0x84ca30..0x84ca40
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 88
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84c950..0x84c960]
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84ca40..0x84ca50]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 231 GoSliceHeaderType []main.structWithNoStrings
           Locations:
-            - Range: 0x84c950..0x84c960
+            - Range: 0x84ca40..0x84ca50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2799,19 +2699,44 @@ Subprograms:
         - Name: a
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84c950..0x84c960
+            - Range: 0x84ca40..0x84ca50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           IsParameter: true
           IsReturn: false
     - ID: 89
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84ca50..0x84ca60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84ca50..0x84ca60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+        - Name: a
+          Type: 1 BaseType int
+          Locations:
+            - Range: 0x84ca50..0x84ca60
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          IsParameter: true
+          IsReturn: false
+    - ID: 90
       Name: main.testStringSlice
-      OutOfLinePCRanges: [0x84c960..0x84c970]
+      OutOfLinePCRanges: [0x84ca60..0x84ca70]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 123 GoSliceHeaderType []string
           Locations:
-            - Range: 0x84c960..0x84c970
+            - Range: 0x84ca60..0x84ca70
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2821,22 +2746,22 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 90
+    - ID: 91
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x84c970..0x84c980]
+      OutOfLinePCRanges: [0x84ca70..0x84ca80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x84c970..0x84c980
+            - Range: 0x84ca70..0x84ca80
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
         - Name: s
           Type: 234 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84c970..0x84c980
+            - Range: 0x84ca70..0x84ca80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -2849,37 +2774,19 @@ Subprograms:
         - Name: x
           Type: 20 BaseType uint
           Locations:
-            - Range: 0x84c970..0x84c980
+            - Range: 0x84ca70..0x84ca80
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 91
+    - ID: 92
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84c980..0x84c990]
+      OutOfLinePCRanges: [0x84ca80..0x84ca90]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 235 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84c980..0x84c990
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          IsParameter: true
-          IsReturn: false
-    - ID: 92
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84c990..0x84c9a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 228 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84c990..0x84c9a0
+            - Range: 0x84ca80..0x84ca90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2890,24 +2797,42 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 93
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84ca90..0x84caa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 228 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0x84ca90..0x84caa0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 94
       Name: main.stackC
-      OutOfLinePCRanges: [0x84cc60..0x84ccd0]
+      OutOfLinePCRanges: [0x84cd60..0x84cdd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 8 GoStringHeaderType string
-          Locations: [{Range: 0x84cc60..0x84ccd0, Pieces: []}]
+          Locations: [{Range: 0x84cd60..0x84cdd0, Pieces: []}]
           IsParameter: true
           IsReturn: true
-    - ID: 94
+    - ID: 95
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x84ccd0..0x84cce0]
+      OutOfLinePCRanges: [0x84cdd0..0x84cde0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84ccd0..0x84cce0
+            - Range: 0x84cdd0..0x84cde0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2915,15 +2840,15 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 95
+    - ID: 96
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84cce0..0x84ccf0]
+      OutOfLinePCRanges: [0x84cde0..0x84cdf0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84cce0..0x84ccf0
+            - Range: 0x84cde0..0x84cdf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2934,7 +2859,7 @@ Subprograms:
         - Name: y
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84cce0..0x84ccf0
+            - Range: 0x84cde0..0x84cdf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -2945,7 +2870,7 @@ Subprograms:
         - Name: z
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84cce0..0x84ccf0
+            - Range: 0x84cde0..0x84cdf0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -2953,15 +2878,15 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 96
+    - ID: 97
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84ccf0..0x84cd10]
+      OutOfLinePCRanges: [0x84cdf0..0x84ce10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 237 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x84ccf0..0x84cd10
+            - Range: 0x84cdf0..0x84ce10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2977,55 +2902,39 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 97
+    - ID: 98
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84cd10..0x84cd20]
+      OutOfLinePCRanges: [0x84ce10..0x84ce20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 238 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x84cd10..0x84cd20
+            - Range: 0x84ce10..0x84ce20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 98
+    - ID: 99
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x84cd20..0x84cd30]
+      OutOfLinePCRanges: [0x84ce20..0x84ce30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x84cd20..0x84cd30
+            - Range: 0x84ce20..0x84ce30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
-    - ID: 99
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0x84cd30..0x84cd40]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 8 GoStringHeaderType string
-          Locations:
-            - Range: 0x84cd30..0x84cd40
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          IsParameter: true
-          IsReturn: false
     - ID: 100
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84cd40..0x84cd50]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x84ce30..0x84ce40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84cd40..0x84cd50
+            - Range: 0x84ce30..0x84ce40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3034,14 +2943,14 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 101
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84cd50..0x84cd60]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x84ce40..0x84ce50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 GoStringHeaderType string
           Locations:
-            - Range: 0x84cd50..0x84cd60
+            - Range: 0x84ce40..0x84ce50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -3050,14 +2959,30 @@ Subprograms:
           IsParameter: true
           IsReturn: false
     - ID: 102
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x84ce50..0x84ce60]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 GoStringHeaderType string
+          Locations:
+            - Range: 0x84ce50..0x84ce60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          IsParameter: true
+          IsReturn: false
+    - ID: 103
       Name: main.testStruct
-      OutOfLinePCRanges: [0x84cf60..0x84cf80]
+      OutOfLinePCRanges: [0x84d060..0x84d080]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 241 StructureType main.aStruct
           Locations:
-            - Range: 0x84cf60..0x84cf80
+            - Range: 0x84d060..0x84d080
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -3075,43 +3000,43 @@ Subprograms:
                   Op: {RegNo: 6, Shift: 0}
           IsParameter: true
           IsReturn: false
-    - ID: 103
+    - ID: 104
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x84d060..0x84d070]
+      OutOfLinePCRanges: [0x84d160..0x84d170]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 242 StructureType main.emptyStruct
-          Locations: [{Range: 0x84d060..0x84d070, Pieces: []}]
+          Locations: [{Range: 0x84d160..0x84d170, Pieces: []}]
           IsParameter: true
           IsReturn: false
     - ID: 1
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x84a060..0x84a0d0]
+      OutOfLinePCRanges: [0x84a0d0..0x84a140]
       InlinePCRanges:
-        - Ranges: [0x84a0ec..0x84a124]
-          RootRanges: [0x84a0d0..0x84a150]
-        - Ranges: [0x84a238..0x84a270]
-          RootRanges: [0x84a200..0x84a290]
-        - Ranges: [0x84a2b4..0x84a2ec]
-          RootRanges: [0x84a290..0x84a350]
-        - Ranges: [0x84a36c..0x84a3a4]
-          RootRanges: [0x84a350..0x84a3d0]
+        - Ranges: [0x84a15c..0x84a194]
+          RootRanges: [0x84a140..0x84a1c0]
+        - Ranges: [0x84a2a8..0x84a2e0]
+          RootRanges: [0x84a270..0x84a300]
+        - Ranges: [0x84a324..0x84a35c]
+          RootRanges: [0x84a300..0x84a3c0]
+        - Ranges: [0x84a3dc..0x84a414]
+          RootRanges: [0x84a3c0..0x84a440]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a060..0x84a080
+            - Range: 0x84a0d0..0x84a0f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a0ec..0x84a0f4
+            - Range: 0x84a15c..0x84a164
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a238..0x84a240
+            - Range: 0x84a2a8..0x84a2b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a2ac..0x84a2bc
+            - Range: 0x84a31c..0x84a32c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84a2bc..0x84a350
+            - Range: 0x84a32c..0x84a3c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84a350..0x84a374
+            - Range: 0x84a3c0..0x84a3e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3119,34 +3044,34 @@ Subprograms:
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a2f8..0x84a330]
-          RootRanges: [0x84a290..0x84a350]
+        - Ranges: [0x84a368..0x84a3a0]
+          RootRanges: [0x84a300..0x84a3c0]
       Variables: []
     - ID: 3
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a3ec..0x84a430]
-          RootRanges: [0x84a3d0..0x84a4f0]
+        - Ranges: [0x84a45c..0x84a4a0]
+          RootRanges: [0x84a440..0x84a560]
       Variables: []
     - ID: 4
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a4a0..0x84a4d8]
-          RootRanges: [0x84a3d0..0x84a4f0]
+        - Ranges: [0x84a510..0x84a548]
+          RootRanges: [0x84a440..0x84a560]
       Variables: []
     - ID: 5
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a4f4..0x84a4f8]
-          RootRanges: [0x84a4f0..0x84a500]
+        - Ranges: [0x84a564..0x84a568]
+          RootRanges: [0x84a560..0x84a570]
       Variables:
         - Name: x
           Type: 1 BaseType int
           Locations:
-            - Range: 0x84a4f0..0x84a4f8
+            - Range: 0x84a560..0x84a568
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           IsParameter: true
           IsReturn: false
@@ -3154,17 +3079,17 @@ Subprograms:
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x84a524..0x84a548]
-          RootRanges: [0x84a500..0x84a560]
-        - Ranges: [0x84a5bc..0x84a5e4]
-          RootRanges: [0x84a560..0x84a6b0]
+        - Ranges: [0x84a594..0x84a5b8]
+          RootRanges: [0x84a570..0x84a5d0]
+        - Ranges: [0x84a62c..0x84a654]
+          RootRanges: [0x84a5d0..0x84a720]
       Variables:
         - Name: a
           Type: 2 ArrayType [5]int
           Locations:
-            - Range: 0x84a510..0x84a560
+            - Range: 0x84a580..0x84a5d0
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x84a5a8..0x84a6b0
+            - Range: 0x84a618..0x84a720
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           IsParameter: true
           IsReturn: false
@@ -3173,7 +3098,7 @@ Types:
       ID: 1
       Name: int
       ByteSize: 8
-      GoRuntimeType: 575360
+      GoRuntimeType: 575392
       GoKind: 2
     - __kind: ArrayType
       ID: 2
@@ -3187,7 +3112,7 @@ Types:
       ID: 3
       Name: '[2]uint8'
       ByteSize: 2
-      GoRuntimeType: 674304
+      GoRuntimeType: 674336
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3196,13 +3121,13 @@ Types:
       ID: 4
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 574912
+      GoRuntimeType: 574944
       GoKind: 8
     - __kind: ArrayType
       ID: 5
       Name: '[2]int32'
       ByteSize: 8
-      GoRuntimeType: 674400
+      GoRuntimeType: 674432
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3211,13 +3136,13 @@ Types:
       ID: 6
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 575104
+      GoRuntimeType: 575136
       GoKind: 5
     - __kind: ArrayType
       ID: 7
       Name: '[2]string'
       ByteSize: 32
-      GoRuntimeType: 674496
+      GoRuntimeType: 674528
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3226,7 +3151,7 @@ Types:
       ID: 8
       Name: string
       ByteSize: 16
-      GoRuntimeType: 574784
+      GoRuntimeType: 574816
       GoKind: 24
       RawFields:
         - Name: str
@@ -3240,7 +3165,7 @@ Types:
       ID: 9
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 385248
+      GoRuntimeType: 385280
       GoKind: 22
       Pointee: 4 BaseType uint8
     - __kind: ArrayType
@@ -3255,13 +3180,13 @@ Types:
       ID: 11
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 575808
+      GoRuntimeType: 575840
       GoKind: 1
     - __kind: ArrayType
       ID: 12
       Name: '[2]int'
       ByteSize: 16
-      GoRuntimeType: 673248
+      GoRuntimeType: 673088
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3278,7 +3203,7 @@ Types:
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 574848
+      GoRuntimeType: 574880
       GoKind: 3
     - __kind: ArrayType
       ID: 15
@@ -3292,7 +3217,7 @@ Types:
       ID: 16
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 574976
+      GoRuntimeType: 575008
       GoKind: 4
     - __kind: ArrayType
       ID: 17
@@ -3306,7 +3231,7 @@ Types:
       ID: 18
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 575232
+      GoRuntimeType: 575264
       GoKind: 6
     - __kind: ArrayType
       ID: 19
@@ -3320,7 +3245,7 @@ Types:
       ID: 20
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 575424
+      GoRuntimeType: 575456
       GoKind: 7
     - __kind: ArrayType
       ID: 21
@@ -3334,7 +3259,7 @@ Types:
       ID: 22
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 575040
+      GoRuntimeType: 575072
       GoKind: 9
     - __kind: ArrayType
       ID: 23
@@ -3348,13 +3273,13 @@ Types:
       ID: 24
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 575168
+      GoRuntimeType: 575200
       GoKind: 10
     - __kind: ArrayType
       ID: 25
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 674592
+      GoRuntimeType: 674624
       GoKind: 17
       Count: 2
       HasCount: true
@@ -3363,7 +3288,7 @@ Types:
       ID: 26
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 575296
+      GoRuntimeType: 575328
       GoKind: 11
     - __kind: ArrayType
       ID: 27
@@ -3393,13 +3318,13 @@ Types:
       ID: 30
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 575680
+      GoRuntimeType: 575712
       GoKind: 13
     - __kind: BaseType
       ID: 31
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 575744
+      GoRuntimeType: 575776
       GoKind: 14
     - __kind: BaseType
       ID: 32
@@ -3425,7 +3350,7 @@ Types:
       ID: 34
       Name: '[]*string'
       ByteSize: 24
-      GoRuntimeType: 470496
+      GoRuntimeType: 470528
       GoKind: 23
       RawFields:
         - Name: array
@@ -3442,21 +3367,21 @@ Types:
       ID: 35
       Name: '**string'
       ByteSize: 8
-      GoRuntimeType: 520896
+      GoRuntimeType: 520928
       GoKind: 22
       Pointee: 36 PointerType *string
     - __kind: PointerType
       ID: 36
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 385120
+      GoRuntimeType: 385152
       GoKind: 22
       Pointee: 8 GoStringHeaderType string
     - __kind: GoInterfaceType
       ID: 37
       Name: io.Writer
       ByteSize: 16
-      GoRuntimeType: 1.011488e+06
+      GoRuntimeType: 1.011776e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
@@ -3475,14 +3400,14 @@ Types:
       ID: 39
       Name: '*internal/abi.ITab'
       ByteSize: 8
-      GoRuntimeType: 409696
+      GoRuntimeType: 409728
       GoKind: 22
       Pointee: 40 StructureType internal/abi.ITab
     - __kind: StructureType
       ID: 40
       Name: internal/abi.ITab
       ByteSize: 32
-      GoRuntimeType: 1.742176e+06
+      GoRuntimeType: 1.742464e+06
       GoKind: 25
       RawFields:
         - Name: Inter
@@ -3501,14 +3426,14 @@ Types:
       ID: 41
       Name: '*internal/abi.InterfaceType'
       ByteSize: 8
-      GoRuntimeType: 2.188352e+06
+      GoRuntimeType: 2.18864e+06
       GoKind: 22
       Pointee: 42 StructureType internal/abi.InterfaceType
     - __kind: StructureType
       ID: 42
       Name: internal/abi.InterfaceType
       ByteSize: 80
-      GoRuntimeType: 1.619008e+06
+      GoRuntimeType: 1.619296e+06
       GoKind: 25
       RawFields:
         - Name: Type
@@ -3524,7 +3449,7 @@ Types:
       ID: 43
       Name: internal/abi.Type
       ByteSize: 48
-      GoRuntimeType: 2.110144e+06
+      GoRuntimeType: 2.110432e+06
       GoKind: 25
       RawFields:
         - Name: Size_
@@ -3564,43 +3489,43 @@ Types:
       ID: 44
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 575488
+      GoRuntimeType: 575520
       GoKind: 12
     - __kind: BaseType
       ID: 45
       Name: internal/abi.TFlag
       ByteSize: 1
-      GoRuntimeType: 578496
+      GoRuntimeType: 578528
       GoKind: 8
     - __kind: BaseType
       ID: 46
       Name: internal/abi.Kind
       ByteSize: 1
-      GoRuntimeType: 824128
+      GoRuntimeType: 824224
       GoKind: 8
     - __kind: GoSubroutineType
       ID: 47
       Name: func(unsafe.Pointer, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 834208
+      GoRuntimeType: 834304
       GoKind: 19
     - __kind: BaseType
       ID: 48
       Name: internal/abi.NameOff
       ByteSize: 4
-      GoRuntimeType: 578560
+      GoRuntimeType: 578592
       GoKind: 5
     - __kind: BaseType
       ID: 49
       Name: internal/abi.TypeOff
       ByteSize: 4
-      GoRuntimeType: 578624
+      GoRuntimeType: 578656
       GoKind: 5
     - __kind: StructureType
       ID: 50
       Name: internal/abi.Name
       ByteSize: 8
-      GoRuntimeType: 1.953984e+06
+      GoRuntimeType: 1.954272e+06
       GoKind: 25
       RawFields:
         - Name: Bytes
@@ -3610,7 +3535,7 @@ Types:
       ID: 51
       Name: '[]internal/abi.Imethod'
       ByteSize: 24
-      GoRuntimeType: 499136
+      GoRuntimeType: 499168
       GoKind: 23
       RawFields:
         - Name: array
@@ -3627,14 +3552,14 @@ Types:
       ID: 52
       Name: '*internal/abi.Imethod'
       ByteSize: 8
-      GoRuntimeType: 409632
+      GoRuntimeType: 409664
       GoKind: 22
       Pointee: 53 StructureType internal/abi.Imethod
     - __kind: StructureType
       ID: 53
       Name: internal/abi.Imethod
       ByteSize: 8
-      GoRuntimeType: 1.469664e+06
+      GoRuntimeType: 1.469952e+06
       GoKind: 25
       RawFields:
         - Name: Name
@@ -3647,14 +3572,14 @@ Types:
       ID: 54
       Name: '*internal/abi.Type'
       ByteSize: 8
-      GoRuntimeType: 2.1888e+06
+      GoRuntimeType: 2.189088e+06
       GoKind: 22
       Pointee: 43 StructureType internal/abi.Type
     - __kind: ArrayType
       ID: 55
       Name: '[1]uintptr'
       ByteSize: 8
-      GoRuntimeType: 672288
+      GoRuntimeType: 674144
       GoKind: 17
       Count: 1
       HasCount: true
@@ -3663,13 +3588,13 @@ Types:
       ID: 56
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 575872
+      GoRuntimeType: 575904
       GoKind: 26
     - __kind: StructureType
       ID: 57
       Name: main.esotericStack
       ByteSize: 64
-      GoRuntimeType: 1.94448e+06
+      GoRuntimeType: 1.944768e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3696,13 +3621,13 @@ Types:
     - __kind: GoChannelType
       ID: 58
       Name: chan struct {}
-      GoRuntimeType: 586048
+      GoRuntimeType: 586080
       GoKind: 18
     - __kind: GoEmptyInterfaceType
       ID: 59
       Name: interface {}
       ByteSize: 16
-      GoRuntimeType: 837664
+      GoRuntimeType: 837760
       GoKind: 20
       UnderlyingStructure: 60 StructureType runtime.eface
     - __kind: StructureType
@@ -3721,27 +3646,27 @@ Types:
       ID: 61
       Name: main.something
       ByteSize: 16
-      GoRuntimeType: 1.011232e+06
+      GoRuntimeType: 1.01152e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoSubroutineType
       ID: 62
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 468768
+      GoRuntimeType: 468800
       GoKind: 19
     - __kind: PointerType
       ID: 63
       Name: '*main.esotericHeap'
       ByteSize: 8
-      GoRuntimeType: 380128
+      GoRuntimeType: 380160
       GoKind: 22
       Pointee: 64 StructureType main.esotericHeap
     - __kind: StructureType
       ID: 64
       Name: main.esotericHeap
       ByteSize: 112
-      GoRuntimeType: 1.81088e+06
+      GoRuntimeType: 1.811168e+06
       GoKind: 25
       RawFields:
         - Name: esotericStack
@@ -3763,7 +3688,7 @@ Types:
       ID: 65
       Name: sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.444384e+06
+      GoRuntimeType: 1.444672e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3775,14 +3700,14 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: sync.noCopy
-      GoRuntimeType: 976864
+      GoRuntimeType: 977056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 67
       Name: internal/sync.Mutex
       ByteSize: 8
-      GoRuntimeType: 1.453664e+06
+      GoRuntimeType: 1.453952e+06
       GoKind: 25
       RawFields:
         - Name: state
@@ -3795,7 +3720,7 @@ Types:
       ID: 68
       Name: sync.Once
       ByteSize: 12
-      GoRuntimeType: 1.592896e+06
+      GoRuntimeType: 1.593184e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3811,7 +3736,7 @@ Types:
       ID: 69
       Name: sync/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 1.445824e+06
+      GoRuntimeType: 1.446112e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3823,14 +3748,14 @@ Types:
     - __kind: StructureType
       ID: 70
       Name: sync/atomic.noCopy
-      GoRuntimeType: 976960
+      GoRuntimeType: 977152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 71
       Name: sync.WaitGroup
       ByteSize: 16
-      GoRuntimeType: 1.593088e+06
+      GoRuntimeType: 1.593376e+06
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -3846,7 +3771,7 @@ Types:
       ID: 72
       Name: sync/atomic.Uint64
       ByteSize: 8
-      GoRuntimeType: 1.593472e+06
+      GoRuntimeType: 1.59376e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3861,14 +3786,14 @@ Types:
     - __kind: StructureType
       ID: 73
       Name: sync/atomic.align64
-      GoRuntimeType: 977056
+      GoRuntimeType: 977248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 74
       Name: sync/atomic.Int32
       ByteSize: 4
-      GoRuntimeType: 1.445664e+06
+      GoRuntimeType: 1.445952e+06
       GoKind: 25
       RawFields:
         - Name: _
@@ -3881,21 +3806,21 @@ Types:
       ID: 75
       Name: main.behavior
       ByteSize: 16
-      GoRuntimeType: 1.011104e+06
+      GoRuntimeType: 1.011392e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: GoInterfaceType
       ID: 76
       Name: error
       ByteSize: 16
-      GoRuntimeType: 1.015456e+06
+      GoRuntimeType: 1.015744e+06
       GoKind: 20
       UnderlyingStructure: 38 StructureType runtime.iface
     - __kind: StructureType
       ID: 77
       Name: main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.172544e+06
+      GoRuntimeType: 1.172832e+06
       GoKind: 25
       RawFields:
         - Name: m
@@ -3905,7 +3830,7 @@ Types:
       ID: 78
       Name: map[int]int
       ByteSize: 8
-      GoRuntimeType: 1.116224e+06
+      GoRuntimeType: 1.116512e+06
       GoKind: 21
       HeaderType: 80 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
@@ -4002,7 +3927,7 @@ Types:
       ID: 86
       Name: noalg.map.group[int]int
       ByteSize: 136
-      GoRuntimeType: 1.27552e+06
+      GoRuntimeType: 1.275808e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4015,7 +3940,7 @@ Types:
       ID: 87
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
-      GoRuntimeType: 671040
+      GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4024,7 +3949,7 @@ Types:
       ID: 88
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
-      GoRuntimeType: 1.275392e+06
+      GoRuntimeType: 1.27568e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4037,7 +3962,7 @@ Types:
       ID: 89
       Name: map[string]main.nestedStruct
       ByteSize: 8
-      GoRuntimeType: 1.117632e+06
+      GoRuntimeType: 1.11792e+06
       GoKind: 21
       HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
@@ -4134,7 +4059,7 @@ Types:
       ID: 97
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
-      GoRuntimeType: 1.278336e+06
+      GoRuntimeType: 1.278624e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4147,7 +4072,7 @@ Types:
       ID: 98
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
-      GoRuntimeType: 673920
+      GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4156,7 +4081,7 @@ Types:
       ID: 99
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
-      GoRuntimeType: 1.278208e+06
+      GoRuntimeType: 1.278496e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4169,7 +4094,7 @@ Types:
       ID: 100
       Name: main.nestedStruct
       ByteSize: 24
-      GoRuntimeType: 1.443104e+06
+      GoRuntimeType: 1.443392e+06
       GoKind: 25
       RawFields:
         - Name: anotherInt
@@ -4182,7 +4107,7 @@ Types:
       ID: 101
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 1.117504e+06
+      GoRuntimeType: 1.117792e+06
       GoKind: 21
       HeaderType: 103 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
@@ -4279,7 +4204,7 @@ Types:
       ID: 109
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 1.27808e+06
+      GoRuntimeType: 1.278368e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4292,7 +4217,7 @@ Types:
       ID: 110
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 673824
+      GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4301,7 +4226,7 @@ Types:
       ID: 111
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 1.277952e+06
+      GoRuntimeType: 1.27824e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4314,7 +4239,7 @@ Types:
       ID: 112
       Name: map[string][]string
       ByteSize: 8
-      GoRuntimeType: 1.117376e+06
+      GoRuntimeType: 1.117664e+06
       GoKind: 21
       HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
@@ -4411,7 +4336,7 @@ Types:
       ID: 120
       Name: noalg.map.group[string][]string
       ByteSize: 328
-      GoRuntimeType: 1.277824e+06
+      GoRuntimeType: 1.278112e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4424,7 +4349,7 @@ Types:
       ID: 121
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
-      GoRuntimeType: 673728
+      GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4433,7 +4358,7 @@ Types:
       ID: 122
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
-      GoRuntimeType: 1.277696e+06
+      GoRuntimeType: 1.277984e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4446,7 +4371,7 @@ Types:
       ID: 123
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 478496
+      GoRuntimeType: 478528
       GoKind: 23
       RawFields:
         - Name: array
@@ -4463,7 +4388,7 @@ Types:
       ID: 124
       Name: map[[4]string][2]int
       ByteSize: 8
-      GoRuntimeType: 1.116864e+06
+      GoRuntimeType: 1.117152e+06
       GoKind: 21
       HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
@@ -4560,7 +4485,7 @@ Types:
       ID: 132
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
-      GoRuntimeType: 1.2768e+06
+      GoRuntimeType: 1.277088e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4573,7 +4498,7 @@ Types:
       ID: 133
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
-      GoRuntimeType: 673344
+      GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4582,7 +4507,7 @@ Types:
       ID: 134
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
-      GoRuntimeType: 1.276672e+06
+      GoRuntimeType: 1.27696e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4595,7 +4520,7 @@ Types:
       ID: 135
       Name: '[4]string'
       ByteSize: 64
-      GoRuntimeType: 673152
+      GoRuntimeType: 672992
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4618,7 +4543,7 @@ Types:
       ID: 138
       Name: map[string][]main.structWithMap
       ByteSize: 8
-      GoRuntimeType: 1.117248e+06
+      GoRuntimeType: 1.117536e+06
       GoKind: 21
       HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
@@ -4715,7 +4640,7 @@ Types:
       ID: 146
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
-      GoRuntimeType: 1.277568e+06
+      GoRuntimeType: 1.277856e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4728,7 +4653,7 @@ Types:
       ID: 147
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
-      GoRuntimeType: 673632
+      GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4737,7 +4662,7 @@ Types:
       ID: 148
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
-      GoRuntimeType: 1.27744e+06
+      GoRuntimeType: 1.277728e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4750,7 +4675,7 @@ Types:
       ID: 149
       Name: '[]main.structWithMap'
       ByteSize: 24
-      GoRuntimeType: 469728
+      GoRuntimeType: 469760
       GoKind: 23
       RawFields:
         - Name: array
@@ -4767,14 +4692,14 @@ Types:
       ID: 150
       Name: '*main.structWithMap'
       ByteSize: 8
-      GoRuntimeType: 380064
+      GoRuntimeType: 380096
       GoKind: 22
       Pointee: 77 StructureType main.structWithMap
     - __kind: GoMapType
       ID: 151
       Name: map[bool]main.node
       ByteSize: 8
-      GoRuntimeType: 1.116992e+06
+      GoRuntimeType: 1.11728e+06
       GoKind: 21
       HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
@@ -4871,7 +4796,7 @@ Types:
       ID: 159
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
-      GoRuntimeType: 1.277056e+06
+      GoRuntimeType: 1.277344e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4884,7 +4809,7 @@ Types:
       ID: 160
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
-      GoRuntimeType: 673440
+      GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4893,7 +4818,7 @@ Types:
       ID: 161
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
-      GoRuntimeType: 1.276928e+06
+      GoRuntimeType: 1.277216e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -4906,7 +4831,7 @@ Types:
       ID: 162
       Name: main.node
       ByteSize: 16
-      GoRuntimeType: 1.442944e+06
+      GoRuntimeType: 1.443232e+06
       GoKind: 25
       RawFields:
         - Name: val
@@ -4919,14 +4844,14 @@ Types:
       ID: 163
       Name: '*main.node'
       ByteSize: 8
-      GoRuntimeType: 380192
+      GoRuntimeType: 380224
       GoKind: 22
       Pointee: 162 StructureType main.node
     - __kind: GoMapType
       ID: 164
       Name: map[int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.11712e+06
+      GoRuntimeType: 1.117408e+06
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
@@ -5023,7 +4948,7 @@ Types:
       ID: 172
       Name: noalg.map.group[int]uint8
       ByteSize: 136
-      GoRuntimeType: 1.277312e+06
+      GoRuntimeType: 1.2776e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5036,7 +4961,7 @@ Types:
       ID: 173
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
-      GoRuntimeType: 673536
+      GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5045,7 +4970,7 @@ Types:
       ID: 174
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 1.277184e+06
+      GoRuntimeType: 1.277472e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5058,7 +4983,7 @@ Types:
       ID: 175
       Name: map[uint8]uint8
       ByteSize: 8
-      GoRuntimeType: 1.117888e+06
+      GoRuntimeType: 1.118176e+06
       GoKind: 21
       HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
@@ -5155,7 +5080,7 @@ Types:
       ID: 183
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
-      GoRuntimeType: 1.278848e+06
+      GoRuntimeType: 1.279136e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5168,7 +5093,7 @@ Types:
       ID: 184
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
-      GoRuntimeType: 674112
+      GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5177,7 +5102,7 @@ Types:
       ID: 185
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
-      GoRuntimeType: 1.27872e+06
+      GoRuntimeType: 1.279008e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5190,7 +5115,7 @@ Types:
       ID: 186
       Name: map[uint8][4]int
       ByteSize: 8
-      GoRuntimeType: 1.11776e+06
+      GoRuntimeType: 1.118048e+06
       GoKind: 21
       HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
@@ -5287,7 +5212,7 @@ Types:
       ID: 194
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
-      GoRuntimeType: 1.278592e+06
+      GoRuntimeType: 1.27888e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5300,7 +5225,7 @@ Types:
       ID: 195
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
-      GoRuntimeType: 674016
+      GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5309,7 +5234,7 @@ Types:
       ID: 196
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
-      GoRuntimeType: 1.278464e+06
+      GoRuntimeType: 1.278752e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5322,7 +5247,7 @@ Types:
       ID: 197
       Name: '[4]int'
       ByteSize: 32
-      GoRuntimeType: 672864
+      GoRuntimeType: 672704
       GoKind: 17
       Count: 4
       HasCount: true
@@ -5331,7 +5256,7 @@ Types:
       ID: 198
       Name: map[[4]int]uint8
       ByteSize: 8
-      GoRuntimeType: 1.116736e+06
+      GoRuntimeType: 1.117024e+06
       GoKind: 21
       HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
@@ -5428,7 +5353,7 @@ Types:
       ID: 206
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
-      GoRuntimeType: 1.276544e+06
+      GoRuntimeType: 1.276832e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5441,7 +5366,7 @@ Types:
       ID: 207
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
-      GoRuntimeType: 673056
+      GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5450,7 +5375,7 @@ Types:
       ID: 208
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
-      GoRuntimeType: 1.276416e+06
+      GoRuntimeType: 1.276704e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5463,7 +5388,7 @@ Types:
       ID: 209
       Name: map[[4]int][4]int
       ByteSize: 8
-      GoRuntimeType: 1.116608e+06
+      GoRuntimeType: 1.116896e+06
       GoKind: 21
       HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
@@ -5560,7 +5485,7 @@ Types:
       ID: 217
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
-      GoRuntimeType: 1.276288e+06
+      GoRuntimeType: 1.276576e+06
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5573,7 +5498,7 @@ Types:
       ID: 218
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
-      GoRuntimeType: 672960
+      GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5582,7 +5507,7 @@ Types:
       ID: 219
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
-      GoRuntimeType: 1.27616e+06
+      GoRuntimeType: 1.276448e+06
       GoKind: 25
       RawFields:
         - Name: key
@@ -5594,7 +5519,7 @@ Types:
     - __kind: GoChannelType
       ID: 220
       Name: chan bool
-      GoRuntimeType: 587136
+      GoRuntimeType: 587168
       GoKind: 18
     - __kind: PointerType
       ID: 221
@@ -5618,14 +5543,14 @@ Types:
       ID: 223
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 385760
+      GoRuntimeType: 385792
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
       ID: 224
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 386144
+      GoRuntimeType: 386176
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
@@ -5659,7 +5584,7 @@ Types:
       ID: 228
       Name: '[]uint'
       ByteSize: 24
-      GoRuntimeType: 477984
+      GoRuntimeType: 478016
       GoKind: 23
       RawFields:
         - Name: array
@@ -5730,7 +5655,7 @@ Types:
       ID: 234
       Name: '[]bool'
       ByteSize: 24
-      GoRuntimeType: 478368
+      GoRuntimeType: 478400
       GoKind: 23
       RawFields:
         - Name: array
@@ -5747,7 +5672,7 @@ Types:
       ID: 235
       Name: '[]uint16'
       ByteSize: 24
-      GoRuntimeType: 477344
+      GoRuntimeType: 477376
       GoKind: 23
       RawFields:
         - Name: array
@@ -5764,7 +5689,7 @@ Types:
       ID: 236
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 385376
+      GoRuntimeType: 385408
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
@@ -6714,6 +6639,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 333
+      Name: Probe[main.testAny]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: a
+          Offset: 1
+          Expression:
+            Type: 59 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 334
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6724,11 +6664,11 @@ Types:
             Type: 76 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: e}
+                  Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 335
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6739,11 +6679,11 @@ Types:
             Type: 77 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 52, index: 0, name: s}
+                  Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 336
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6754,11 +6694,11 @@ Types:
             Type: 89 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 53, index: 0, name: m}
+                  Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 337
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6769,11 +6709,11 @@ Types:
             Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 54, index: 0, name: m}
+                  Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 338
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6784,11 +6724,11 @@ Types:
             Type: 112 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 55, index: 0, name: m}
+                  Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 339
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6799,11 +6739,11 @@ Types:
             Type: 124 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 56, index: 0, name: m}
+                  Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 340
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6814,11 +6754,11 @@ Types:
             Type: 101 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 57, index: 0, name: m}
+                  Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 341
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6829,11 +6769,11 @@ Types:
             Type: 136 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 58, index: 0, name: m}
+                  Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 341
+      ID: 342
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6844,11 +6784,11 @@ Types:
             Type: 137 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 59, index: 0, name: m}
+                  Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 343
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6859,11 +6799,11 @@ Types:
             Type: 78 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 60, index: 0, name: m}
+                  Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 344
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6874,11 +6814,11 @@ Types:
             Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 61, index: 0, name: redactMyEntries}
+                  Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 345
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6889,11 +6829,11 @@ Types:
             Type: 138 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 62, index: 0, name: m}
+                  Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 346
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6904,11 +6844,11 @@ Types:
             Type: 151 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 63, index: 0, name: m}
+                  Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 347
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6919,11 +6859,11 @@ Types:
             Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 64, index: 0, name: m}
+                  Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 348
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6934,27 +6874,12 @@ Types:
             Type: 164 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 65, index: 0, name: redactMyEntries}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.testMapWithSmallKeyAndValue]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: m
-          Offset: 1
-          Expression:
-            Type: 175 GoMapType map[uint8]uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 66, index: 0, name: m}
+                  Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
       ID: 349
-      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
+      Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6969,7 +6894,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 350
-      Name: Probe[main.testMapSmallKeySmallValue]
+      Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
       Expressions:
@@ -6984,6 +6909,21 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 351
+      Name: Probe[main.testMapSmallKeySmallValue]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Expression:
+            Type: 175 GoMapType map[uint8]uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 69, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 352
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6994,11 +6934,11 @@ Types:
             Type: 186 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 69, index: 0, name: m}
+                  Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 353
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7009,11 +6949,11 @@ Types:
             Type: 198 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 70, index: 0, name: m}
+                  Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 354
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7024,11 +6964,11 @@ Types:
             Type: 209 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 71, index: 0, name: m}
+                  Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 355
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7039,7 +6979,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 0, name: w}
+                  Variable: {subprogram: 73, index: 0, name: w}
                   Offset: 0
                   ByteSize: 1
         - Name: x
@@ -7048,7 +6988,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 1, name: x}
+                  Variable: {subprogram: 73, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
         - Name: y
@@ -7057,11 +6997,11 @@ Types:
             Type: 30 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 72, index: 2, name: y}
+                  Variable: {subprogram: 73, index: 2, name: y}
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 355
+      ID: 356
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7072,7 +7012,7 @@ Types:
             Type: 11 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 0, name: a}
+                  Variable: {subprogram: 74, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -7081,7 +7021,7 @@ Types:
             Type: 4 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 1, name: b}
+                  Variable: {subprogram: 74, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -7090,7 +7030,7 @@ Types:
             Type: 6 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 2, name: c}
+                  Variable: {subprogram: 74, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -7099,7 +7039,7 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 3, name: d}
+                  Variable: {subprogram: 74, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -7108,11 +7048,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 73, index: 4, name: e}
+                  Variable: {subprogram: 74, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 356
+      ID: 357
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7123,11 +7063,11 @@ Types:
             Type: 220 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 74, index: 0, name: c}
+                  Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 357
+      ID: 358
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7138,11 +7078,11 @@ Types:
             Type: 221 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 75, index: 0, name: a}
+                  Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 358
+      ID: 359
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7153,11 +7093,11 @@ Types:
             Type: 162 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 76, index: 0, name: a}
+                  Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 359
+      ID: 360
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7168,11 +7108,11 @@ Types:
             Type: 163 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 77, index: 0, name: a}
+                  Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 361
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7183,11 +7123,11 @@ Types:
             Type: 56 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 78, index: 0, name: x}
+                  Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 362
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7198,11 +7138,11 @@ Types:
             Type: 223 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 79, index: 0, name: x}
+                  Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 363
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7213,11 +7153,11 @@ Types:
             Type: 36 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 80, index: 0, name: z}
+                  Variable: {subprogram: 81, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 364
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7228,7 +7168,7 @@ Types:
             Type: 224 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 0, name: z}
+                  Variable: {subprogram: 82, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -7237,11 +7177,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 81, index: 1, name: a}
+                  Variable: {subprogram: 82, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 365
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7252,27 +7192,12 @@ Types:
             Type: 225 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 82, index: 0, name: t}
+                  Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
-      Name: Probe[main.testUintSlice]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: u
-          Offset: 1
-          Expression:
-            Type: 228 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 83, index: 0, name: u}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
       ID: 366
-      Name: Probe[main.testEmptySlice]
+      Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
@@ -7287,6 +7212,21 @@ Types:
                   ByteSize: 24
     - __kind: EventRootType
       ID: 367
+      Name: Probe[main.testEmptySlice]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: u
+          Offset: 1
+          Expression:
+            Type: 228 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: u}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 368
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7297,36 +7237,12 @@ Types:
             Type: 229 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: u}
+                  Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
-    - __kind: EventRootType
-      ID: 368
-      Name: Probe[main.testStructSlice]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: xs
-          Offset: 1
-          Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: a
-          Offset: 25
-          Expression:
-            Type: 1 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: a}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 369
-      Name: Probe[main.testEmptySliceOfStructs]
+      Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -7350,7 +7266,7 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 370
-      Name: Probe[main.testNilSliceOfStructs]
+      Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -7374,6 +7290,30 @@ Types:
                   ByteSize: 8
     - __kind: EventRootType
       ID: 371
+      Name: Probe[main.testNilSliceOfStructs]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: xs
+          Offset: 1
+          Expression:
+            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: a
+          Offset: 25
+          Expression:
+            Type: 1 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 89, index: 1, name: a}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 372
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7384,11 +7324,11 @@ Types:
             Type: 123 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: s}
+                  Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 372
+      ID: 373
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7399,7 +7339,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: a}
+                  Variable: {subprogram: 91, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -7408,7 +7348,7 @@ Types:
             Type: 234 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 1, name: s}
+                  Variable: {subprogram: 91, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -7417,11 +7357,11 @@ Types:
             Type: 20 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 2, name: x}
+                  Variable: {subprogram: 91, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 373
+      ID: 374
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7432,11 +7372,11 @@ Types:
             Type: 235 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: xs}
+                  Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 374
+      ID: 375
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7447,31 +7387,16 @@ Types:
             Type: 228 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: xs}
+                  Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 375
+      ID: 376
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 376
+      ID: 377
       Name: Probe[main.testSingleString]
       ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 377
-      Name: Probe[main.testThreeStrings]
-      ByteSize: 49
       PresenceBitsetSize: 1
       Expressions:
         - Name: x
@@ -7483,13 +7408,28 @@ Types:
                   Variable: {subprogram: 95, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
+    - __kind: EventRootType
+      ID: 378
+      Name: Probe[main.testThreeStrings]
+      ByteSize: 49
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
         - Name: y
           Offset: 17
           Expression:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: y}
+                  Variable: {subprogram: 96, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -7498,11 +7438,11 @@ Types:
             Type: 8 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 2, name: z}
+                  Variable: {subprogram: 96, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 378
+      ID: 379
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7513,11 +7453,11 @@ Types:
             Type: 237 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: a}
+                  Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 379
+      ID: 380
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7528,11 +7468,11 @@ Types:
             Type: 238 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: a}
+                  Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 380
+      ID: 381
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7543,27 +7483,12 @@ Types:
             Type: 239 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: a}
+                  Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
-      Name: Probe[main.testMassiveString]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Expression:
-            Type: 8 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
       ID: 382
-      Name: Probe[main.testUnitializedString]
+      Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -7578,7 +7503,7 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 383
-      Name: Probe[main.testEmptyString]
+      Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
       Expressions:
@@ -7593,6 +7518,21 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 384
+      Name: Probe[main.testEmptyString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Expression:
+            Type: 8 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 385
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7603,11 +7543,11 @@ Types:
             Type: 241 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: x}
+                  Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 385
+      ID: 386
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7618,11 +7558,11 @@ Types:
             Type: 242 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: e}
+                  Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 386
+      ID: 387
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7637,16 +7577,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 387
+      ID: 388
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 388
+      ID: 389
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 389
+      ID: 390
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 390
+      ID: 391
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7661,7 +7601,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 391
+      ID: 392
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7675,5 +7615,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 391
+MaxTypeID: 392
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 356 EventRootType Probe[main.stackC]
+          Type: 369 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84cd6c", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 313 EventRootType Probe[main.testAny]
+          Type: 326 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84a85c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 283 EventRootType Probe[main.testArrayOfArrays]
+          Type: 296 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849620", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 285 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 298 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849640", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 321 EventRootType Probe[main.testArrayOfMaps]
+          Type: 334 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84ad40", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 284 EventRootType Probe[main.testArrayOfStrings]
+          Type: 297 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849630", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 303 EventRootType Probe[main.testBigStruct]
+          Type: 316 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849ba0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 272 EventRootType Probe[main.testBoolArray]
+          Type: 285 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x849570", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 269 EventRootType Probe[main.testByteArray]
+          Type: 282 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849540", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 337 EventRootType Probe[main.testChannel]
+          Type: 350 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84c390", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 335 EventRootType Probe[main.testCombinedByte]
+          Type: 348 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84c110", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 345 EventRootType Probe[main.testCycle]
+          Type: 358 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84c630", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 347 EventRootType Probe[main.testEmptySlice]
+          Type: 360 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84ca10", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 350 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 363 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84ca40", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 364 EventRootType Probe[main.testEmptyString]
+          Type: 377 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ce50", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 366 EventRootType Probe[main.testEmptyStruct]
+          Type: 379 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x84d160", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 314 EventRootType Probe[main.testError]
+          Type: 327 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 305 EventRootType Probe[main.testEsotericHeap]
+          Type: 318 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x849e3c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 304 EventRootType Probe[main.testEsotericStack]
+          Type: 317 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x849d6c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 310 EventRootType Probe[main.testFrameless]
+          Type: 323 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84a560", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 311 EventRootType Probe[main.testFramelessArray]
+          Type: 324 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84a570", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 306 EventRootType Probe[main.testInlinedBA]
+          Type: 319 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84a27c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 307 EventRootType Probe[main.testInlinedBB]
+          Type: 320 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84a30c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 308 EventRootType Probe[main.testInlinedBBA]
+          Type: 321 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84a3cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 368 EventRootType Probe[main.testInlinedBBB]
+          Type: 381 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84a368", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 309 EventRootType Probe[main.testInlinedBC]
+          Type: 322 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84a44c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 369 EventRootType Probe[main.testInlinedBCA]
+          Type: 382 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84a45c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 370 EventRootType Probe[main.testInlinedBCB]
+          Type: 383 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84a510", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 367 EventRootType Probe[main.testInlinedPrint]
+          Type: 380 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84a0dc"
               Frameless: true
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 371 EventRootType Probe[main.testInlinedSq]
+          Type: 384 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84a564", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 372 EventRootType Probe[main.testInlinedSumArray]
+          Type: 385 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84a594"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 275 EventRootType Probe[main.testInt16Array]
+          Type: 288 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 276 EventRootType Probe[main.testInt32Array]
+          Type: 289 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 277 EventRootType Probe[main.testInt64Array]
+          Type: 290 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 274 EventRootType Probe[main.testInt8Array]
+          Type: 287 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x849590", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 273 EventRootType Probe[main.testIntArray]
+          Type: 286 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x849580", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 312 EventRootType Probe[main.testInterface]
+          Type: 325 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84a80c", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 339 EventRootType Probe[main.testLinkedList]
+          Type: 352 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84c540", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 319 EventRootType Probe[main.testMapArrayToArray]
+          Type: 332 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84ad20", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 325 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 338 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 323 EventRootType Probe[main.testMapIntToInt]
+          Type: 336 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84ad60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 334 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 347 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84ae10", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 333 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 346 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84ae00", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 324 EventRootType Probe[main.testMapMassive]
+          Type: 337 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84ad70", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 332 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 345 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84adf0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 331 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 344 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84ade0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 317 EventRootType Probe[main.testMapStringToInt]
+          Type: 330 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 318 EventRootType Probe[main.testMapStringToSlice]
+          Type: 331 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 316 EventRootType Probe[main.testMapStringToStruct]
+          Type: 329 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 326 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 339 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84ad90", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 342 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84adc0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 343 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84add0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 327 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 340 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84ada0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 328 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 341 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84adb0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 362 EventRootType Probe[main.testMassiveString]
+          Type: 375 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ce30", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 336 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 349 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84c1f0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 344 EventRootType Probe[main.testNilPointer]
+          Type: 357 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84c610", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 354 EventRootType Probe[main.testNilSlice]
+          Type: 367 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84ca80", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 351 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 364 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84ca50", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 353 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 366 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84ca70", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 361 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 374 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ce20", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 340 EventRootType Probe[main.testPointerLoop]
+          Type: 353 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84c550", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 322 EventRootType Probe[main.testPointerToMap]
+          Type: 335 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84ad50", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 338 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 351 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84c530", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 270 EventRootType Probe[main.testRuneArray]
+          Type: 283 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849550", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 289 EventRootType Probe[main.testSingleBool]
+          Type: 302 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 287 EventRootType Probe[main.testSingleByte]
+          Type: 300 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 300 EventRootType Probe[main.testSingleFloat32]
+          Type: 313 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 301 EventRootType Probe[main.testSingleFloat64]
+          Type: 314 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 290 EventRootType Probe[main.testSingleInt]
+          Type: 303 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 292 EventRootType Probe[main.testSingleInt16]
+          Type: 305 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 293 EventRootType Probe[main.testSingleInt32]
+          Type: 306 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 294 EventRootType Probe[main.testSingleInt64]
+          Type: 307 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 291 EventRootType Probe[main.testSingleInt8]
+          Type: 304 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 288 EventRootType Probe[main.testSingleRune]
+          Type: 301 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 357 EventRootType Probe[main.testSingleString]
+          Type: 370 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84cdd0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 295 EventRootType Probe[main.testSingleUint]
+          Type: 308 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 297 EventRootType Probe[main.testSingleUint16]
+          Type: 310 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 298 EventRootType Probe[main.testSingleUint32]
+          Type: 311 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 299 EventRootType Probe[main.testSingleUint64]
+          Type: 312 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 296 EventRootType Probe[main.testSingleUint8]
+          Type: 309 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 348 EventRootType Probe[main.testSliceOfSlices]
+          Type: 361 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84ca20", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 320 EventRootType Probe[main.testSmallMap]
+          Type: 333 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84ad30", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 271 EventRootType Probe[main.testStringArray]
+          Type: 284 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849560", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 343 EventRootType Probe[main.testStringPointer]
+          Type: 356 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84c5f0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 352 EventRootType Probe[main.testStringSlice]
+          Type: 365 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84ca60", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 365 EventRootType Probe[main.testStruct]
+          Type: 378 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 349 EventRootType Probe[main.testStructSlice]
+          Type: 362 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84ca30", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 315 EventRootType Probe[main.testStructWithMap]
+          Type: 328 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 358 EventRootType Probe[main.testThreeStrings]
+          Type: 371 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84cde0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 359 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 372 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84cdf0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 360 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 373 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ce10", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 302 EventRootType Probe[main.testTypeAlias]
+          Type: 315 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 280 EventRootType Probe[main.testUint16Array]
+          Type: 293 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x8495f0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 281 EventRootType Probe[main.testUint32Array]
+          Type: 294 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849600", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 282 EventRootType Probe[main.testUint64Array]
+          Type: 295 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849610", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 279 EventRootType Probe[main.testUint8Array]
+          Type: 292 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x8495e0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 278 EventRootType Probe[main.testUintArray]
+          Type: 291 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 342 EventRootType Probe[main.testUintPointer]
+          Type: 355 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84c580", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 346 EventRootType Probe[main.testUintSlice]
+          Type: 359 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84ca00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 363 EventRootType Probe[main.testUnitializedString]
+          Type: 376 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ce40", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 341 EventRootType Probe[main.testUnsafePointer]
+          Type: 354 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84c560", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 286 EventRootType Probe[main.testVeryLargeArray]
+          Type: 299 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849670", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 355 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 368 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84ca90", Frameless: true}]
           Condition: null
 Subprograms:
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 226 PointerType *string.str
+          Type: 239 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 225 GoStringDataType string.str
+      Data: 238 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 227 GoSliceDataType []*string.array
+      Data: 240 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3686,7 +3686,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 229 GoSliceDataType []*table<int,int>.array
+      TablePtrSliceType: 242 GoSliceDataType []*table<int,int>.array
       GroupType: 68 StructureType noalg.map.group[int]int
     - __kind: BaseType
       ID: 62
@@ -3741,7 +3741,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 68 StructureType noalg.map.group[int]int
-      GroupSliceType: 230 GoSliceDataType []noalg.map.group[int]int.array
+      GroupSliceType: 243 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
       ID: 67
       Name: '*noalg.map.group[int]int'
@@ -3824,7 +3824,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 231 GoSliceDataType []*table<string,main.nestedStruct>.array
+      TablePtrSliceType: 244 GoSliceDataType []*table<string,main.nestedStruct>.array
       GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
       ID: 74
@@ -3873,7 +3873,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupSliceType: 245 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
       ID: 78
       Name: '*noalg.map.group[string]main.nestedStruct'
@@ -3969,7 +3969,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 233 GoSliceDataType []*table<string,int>.array
+      TablePtrSliceType: 246 GoSliceDataType []*table<string,int>.array
       GroupType: 91 StructureType noalg.map.group[string]int
     - __kind: PointerType
       ID: 86
@@ -4018,7 +4018,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 91 StructureType noalg.map.group[string]int
-      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]int.array
+      GroupSliceType: 247 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
       ID: 90
       Name: '*noalg.map.group[string]int'
@@ -4101,7 +4101,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]string>.array
+      TablePtrSliceType: 248 GoSliceDataType []*table<string,[]string>.array
       GroupType: 102 StructureType noalg.map.group[string][]string
     - __kind: PointerType
       ID: 97
@@ -4150,7 +4150,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 102 StructureType noalg.map.group[string][]string
-      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupSliceType: 249 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
       ID: 101
       Name: '*noalg.map.group[string][]string'
@@ -4207,7 +4207,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 237 GoSliceDataType []string.array
+      Data: 250 GoSliceDataType []string.array
     - __kind: GoMapType
       ID: 106
       Name: map[[4]string][2]int
@@ -4250,7 +4250,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 239 GoSliceDataType []*table<[4]string,[2]int>.array
+      TablePtrSliceType: 252 GoSliceDataType []*table<[4]string,[2]int>.array
       GroupType: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
       ID: 109
@@ -4299,7 +4299,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 114 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 240 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupSliceType: 253 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
       ID: 113
       Name: '*noalg.map.group[[4]string][2]int'
@@ -4405,7 +4405,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      TablePtrSliceType: 254 GoSliceDataType []*table<string,[]main.structWithMap>.array
       GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
       ID: 123
@@ -4454,7 +4454,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupSliceType: 255 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
       ID: 127
       Name: '*noalg.map.group[string][]main.structWithMap'
@@ -4511,7 +4511,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 243 GoSliceDataType []main.structWithMap.array
+      Data: 256 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
       ID: 132
       Name: '*main.structWithMap'
@@ -4561,7 +4561,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 245 GoSliceDataType []*table<bool,main.node>.array
+      TablePtrSliceType: 258 GoSliceDataType []*table<bool,main.node>.array
       GroupType: 141 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
       ID: 136
@@ -4610,7 +4610,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 141 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 246 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupSliceType: 259 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
       ID: 140
       Name: '*noalg.map.group[bool]main.node'
@@ -4713,7 +4713,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 247 GoSliceDataType []*table<int,uint8>.array
+      TablePtrSliceType: 260 GoSliceDataType []*table<int,uint8>.array
       GroupType: 154 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
       ID: 149
@@ -4762,7 +4762,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 154 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 248 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupSliceType: 261 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
       ID: 153
       Name: '*noalg.map.group[int]uint8'
@@ -4845,7 +4845,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<uint8,uint8>.array
+      TablePtrSliceType: 262 GoSliceDataType []*table<uint8,uint8>.array
       GroupType: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
       ID: 160
@@ -4894,7 +4894,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 165 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupSliceType: 263 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
       ID: 164
       Name: '*noalg.map.group[uint8]uint8'
@@ -4977,7 +4977,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<uint8,[4]int>.array
+      TablePtrSliceType: 264 GoSliceDataType []*table<uint8,[4]int>.array
       GroupType: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
       ID: 171
@@ -5026,7 +5026,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 176 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupSliceType: 265 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
       ID: 175
       Name: '*noalg.map.group[uint8][4]int'
@@ -5118,7 +5118,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,uint8>.array
+      TablePtrSliceType: 266 GoSliceDataType []*table<[4]int,uint8>.array
       GroupType: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
       ID: 183
@@ -5167,7 +5167,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 188 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupSliceType: 267 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
       ID: 187
       Name: '*noalg.map.group[[4]int]uint8'
@@ -5250,7 +5250,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 255 GoSliceDataType []*table<[4]int,[4]int>.array
+      TablePtrSliceType: 268 GoSliceDataType []*table<[4]int,[4]int>.array
       GroupType: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
       ID: 194
@@ -5299,7 +5299,7 @@ Types:
           Offset: 8
           Type: 26 BaseType uint64
       GroupType: 199 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 256 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupSliceType: 269 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
       ID: 198
       Name: '*noalg.map.group[[4]int][4]int'
@@ -5398,7 +5398,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 257 GoSliceDataType main.t.array
+      Data: 270 GoSliceDataType main.t.array
     - __kind: PointerType
       ID: 209
       Name: '**main.t'
@@ -5420,7 +5420,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 259 GoSliceDataType []uint.array
+      Data: 272 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
       ID: 211
       Name: '[][]uint'
@@ -5436,7 +5436,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 261 GoSliceDataType [][]uint.array
+      Data: 274 GoSliceDataType [][]uint.array
     - __kind: PointerType
       ID: 212
       Name: '*[]uint'
@@ -5457,7 +5457,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 263 GoSliceDataType []main.structWithNoStrings.array
+      Data: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
       ID: 214
       Name: '*main.structWithNoStrings'
@@ -5491,7 +5491,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 265 GoSliceDataType []bool.array
+      Data: 278 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
       ID: 217
       Name: '[]uint16'
@@ -5508,7 +5508,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 267 GoSliceDataType []uint16.array
+      Data: 280 GoSliceDataType []uint16.array
     - __kind: PointerType
       ID: 218
       Name: '*uint16'
@@ -5575,227 +5575,316 @@ Types:
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
-    - __kind: GoStringDataType
+    - __kind: PointerType
       ID: 225
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 385856
+      GoKind: 22
+      Pointee: 62 BaseType uintptr
+    - __kind: PointerType
+      ID: 226
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 385472
+      GoKind: 22
+      Pointee: 6 BaseType int32
+    - __kind: PointerType
+      ID: 227
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 385536
+      GoKind: 22
+      Pointee: 24 BaseType uint32
+    - __kind: BaseType
+      ID: 228
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 575584
+      GoKind: 15
+    - __kind: BaseType
+      ID: 229
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 575648
+      GoKind: 16
+    - __kind: PointerType
+      ID: 230
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 386112
+      GoKind: 22
+      Pointee: 31 BaseType float64
+    - __kind: PointerType
+      ID: 231
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 385600
+      GoKind: 22
+      Pointee: 18 BaseType int64
+    - __kind: PointerType
+      ID: 232
+      Name: '*int'
+      ByteSize: 8
+      GoRuntimeType: 385728
+      GoKind: 22
+      Pointee: 1 BaseType int
+    - __kind: PointerType
+      ID: 233
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 385664
+      GoKind: 22
+      Pointee: 26 BaseType uint64
+    - __kind: PointerType
+      ID: 234
+      Name: '*int16'
+      ByteSize: 8
+      GoRuntimeType: 385344
+      GoKind: 22
+      Pointee: 16 BaseType int16
+    - __kind: PointerType
+      ID: 235
+      Name: '*int8'
+      ByteSize: 8
+      GoRuntimeType: 385216
+      GoKind: 22
+      Pointee: 14 BaseType int8
+    - __kind: PointerType
+      ID: 236
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 385088
+      GoKind: 22
+      Pointee: 57 GoInterfaceType error
+    - __kind: PointerType
+      ID: 237
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 386048
+      GoKind: 22
+      Pointee: 30 BaseType float32
+    - __kind: GoStringDataType
+      ID: 238
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 226
+      ID: 239
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 225 GoStringDataType string.str
+      Pointee: 238 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 227
+      ID: 240
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 228
+      ID: 241
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 227 GoSliceDataType []*string.array
+      Pointee: 240 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 229
+      ID: 242
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
       Element: 64 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 230
+      ID: 243
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
       Element: 68 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 231
+      ID: 244
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
       Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 232
+      ID: 245
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
       Element: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 233
+      ID: 246
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 87 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 234
+      ID: 247
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
       Element: 91 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 235
+      ID: 248
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
       Element: 98 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 236
+      ID: 249
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
       Element: 102 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 237
+      ID: 250
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 238
+      ID: 251
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 237 GoSliceDataType []string.array
+      Pointee: 250 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 239
+      ID: 252
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
       Element: 110 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 240
+      ID: 253
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
       Element: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 241
+      ID: 254
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
       Element: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 242
+      ID: 255
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
       Element: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 243
+      ID: 256
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
       Element: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 244
+      ID: 257
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 243 GoSliceDataType []main.structWithMap.array
+      Pointee: 256 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 258
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
       Element: 137 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 246
+      ID: 259
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
       Element: 141 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 247
+      ID: 260
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
       Element: 150 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 248
+      ID: 261
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
       Element: 154 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 249
+      ID: 262
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
       Element: 161 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 263
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
       Element: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 264
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
       Element: 172 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 265
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
       Element: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 266
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
       Element: 184 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 267
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
       Element: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 268
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
       Element: 195 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 269
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
       Element: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 270
       Name: main.t.array
       ByteSize: 2048
       Element: 207 PointerType *main.t
     - __kind: PointerType
-      ID: 258
+      ID: 271
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType main.t.array
+      Pointee: 270 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 272
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 260
+      ID: 273
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 259 GoSliceDataType []uint.array
+      Pointee: 272 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 274
       Name: '[][]uint.array'
       ByteSize: 2048
       Element: 210 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 262
+      ID: 275
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 261 GoSliceDataType [][]uint.array
+      Pointee: 274 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 276
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
       Element: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 264
+      ID: 277
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 276 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 278
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 266
+      ID: 279
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 265 GoSliceDataType []bool.array
+      Pointee: 278 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 280
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 268
+      ID: 281
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 267 GoSliceDataType []uint16.array
+      Pointee: 280 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 269
+      ID: 282
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5810,7 +5899,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 270
+      ID: 283
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5825,7 +5914,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 271
+      ID: 284
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5840,7 +5929,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 272
+      ID: 285
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5855,7 +5944,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 273
+      ID: 286
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5870,7 +5959,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 287
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5885,7 +5974,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 275
+      ID: 288
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5900,7 +5989,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 276
+      ID: 289
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5915,7 +6004,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 290
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5930,7 +6019,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 291
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5945,7 +6034,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 292
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5960,7 +6049,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 280
+      ID: 293
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -5975,7 +6064,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 281
+      ID: 294
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5990,7 +6079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 295
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6005,7 +6094,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 296
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6020,7 +6109,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 284
+      ID: 297
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6035,7 +6124,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 285
+      ID: 298
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6050,7 +6139,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 286
+      ID: 299
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -6065,7 +6154,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 287
+      ID: 300
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6080,7 +6169,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 288
+      ID: 301
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6095,7 +6184,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 289
+      ID: 302
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6110,7 +6199,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 290
+      ID: 303
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6125,7 +6214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 304
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6140,7 +6229,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 292
+      ID: 305
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6155,7 +6244,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 306
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6170,7 +6259,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 294
+      ID: 307
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6185,7 +6274,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 308
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6200,7 +6289,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 309
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6215,7 +6304,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 297
+      ID: 310
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6230,7 +6319,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 298
+      ID: 311
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6245,7 +6334,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 299
+      ID: 312
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6260,7 +6349,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 300
+      ID: 313
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6275,7 +6364,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 301
+      ID: 314
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6290,7 +6379,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 315
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6305,7 +6394,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 303
+      ID: 316
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6320,7 +6409,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 304
+      ID: 317
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6335,7 +6424,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 305
+      ID: 318
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6350,7 +6439,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 319
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6365,7 +6454,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 320
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6389,7 +6478,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 321
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6404,10 +6493,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 322
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 310
+      ID: 323
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6422,7 +6511,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 324
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6437,7 +6526,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 312
+      ID: 325
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6452,7 +6541,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 326
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6467,7 +6556,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 314
+      ID: 327
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6482,7 +6571,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 328
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6497,7 +6586,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 329
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6512,7 +6601,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 330
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6527,7 +6616,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 331
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6542,7 +6631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 332
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6557,7 +6646,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 333
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6572,7 +6661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 334
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6587,7 +6676,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
+      ID: 335
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6602,7 +6691,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 336
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6617,7 +6706,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 337
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6632,7 +6721,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 338
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6647,7 +6736,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 339
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6662,7 +6751,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 340
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6677,7 +6766,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 341
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6692,7 +6781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 342
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6707,7 +6796,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 343
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6722,7 +6811,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 344
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6737,7 +6826,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 345
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6752,7 +6841,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 346
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6767,7 +6856,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 347
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6782,7 +6871,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 348
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -6815,7 +6904,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 336
+      ID: 349
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -6866,7 +6955,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 337
+      ID: 350
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -6881,7 +6970,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 338
+      ID: 351
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6896,7 +6985,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 352
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6911,7 +7000,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 353
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6926,7 +7015,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 354
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6941,7 +7030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 355
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6956,7 +7045,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 356
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6971,7 +7060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 357
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6995,7 +7084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 358
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7010,7 +7099,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 359
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7025,7 +7114,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 347
+      ID: 360
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7040,7 +7129,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 348
+      ID: 361
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7055,7 +7144,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 349
+      ID: 362
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7079,7 +7168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 363
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7103,7 +7192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 364
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7127,7 +7216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 365
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7142,7 +7231,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 353
+      ID: 366
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7175,7 +7264,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 367
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7190,7 +7279,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 355
+      ID: 368
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7205,10 +7294,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 356
+      ID: 369
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 357
+      ID: 370
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7223,7 +7312,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 358
+      ID: 371
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7256,7 +7345,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 359
+      ID: 372
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7271,7 +7360,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 360
+      ID: 373
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7286,7 +7375,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 374
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7301,7 +7390,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 375
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7316,7 +7405,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 363
+      ID: 376
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7331,7 +7420,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 364
+      ID: 377
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7346,7 +7435,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 365
+      ID: 378
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7361,7 +7450,7 @@ Types:
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 366
+      ID: 379
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7376,7 +7465,7 @@ Types:
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 367
+      ID: 380
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7391,16 +7480,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 368
+      ID: 381
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 369
+      ID: 382
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 370
+      ID: 383
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 371
+      ID: 384
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7415,7 +7504,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 385
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7429,5 +7518,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 372
+MaxTypeID: 385
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 94}
       events:
         - ID: 88
-          Type: 376 EventRootType Probe[main.stackC]
+          Type: 356 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84cd6c", Frameless: true}]
           Condition: null
     - id: testAny
@@ -25,7 +25,7 @@ Probes:
       subprogram: {subprogram: 51}
       events:
         - ID: 45
-          Type: 333 EventRootType Probe[main.testAny]
+          Type: 313 EventRootType Probe[main.testAny]
           InjectionPoints: [{PC: "0x84a85c", Frameless: true}]
           Condition: null
     - id: testArrayOfArrays
@@ -39,7 +39,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - ID: 15
-          Type: 303 EventRootType Probe[main.testArrayOfArrays]
+          Type: 283 EventRootType Probe[main.testArrayOfArrays]
           InjectionPoints: [{PC: "0x849620", Frameless: true}]
           Condition: null
     - id: testArrayOfArraysOfArrays
@@ -53,7 +53,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - ID: 17
-          Type: 305 EventRootType Probe[main.testArrayOfArraysOfArrays]
+          Type: 285 EventRootType Probe[main.testArrayOfArraysOfArrays]
           InjectionPoints: [{PC: "0x849640", Frameless: true}]
           Condition: null
     - id: testArrayOfMaps
@@ -67,7 +67,7 @@ Probes:
       subprogram: {subprogram: 59}
       events:
         - ID: 53
-          Type: 341 EventRootType Probe[main.testArrayOfMaps]
+          Type: 321 EventRootType Probe[main.testArrayOfMaps]
           InjectionPoints: [{PC: "0x84ad40", Frameless: true}]
           Condition: null
     - id: testArrayOfStrings
@@ -81,7 +81,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - ID: 16
-          Type: 304 EventRootType Probe[main.testArrayOfStrings]
+          Type: 284 EventRootType Probe[main.testArrayOfStrings]
           InjectionPoints: [{PC: "0x849630", Frameless: true}]
           Condition: null
     - id: testBigStruct
@@ -95,7 +95,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - ID: 35
-          Type: 323 EventRootType Probe[main.testBigStruct]
+          Type: 303 EventRootType Probe[main.testBigStruct]
           InjectionPoints: [{PC: "0x849ba0", Frameless: true}]
           Condition: null
     - id: testBoolArray
@@ -109,7 +109,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 4
-          Type: 292 EventRootType Probe[main.testBoolArray]
+          Type: 272 EventRootType Probe[main.testBoolArray]
           InjectionPoints: [{PC: "0x849570", Frameless: true}]
           Condition: null
     - id: testByteArray
@@ -123,7 +123,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 1
-          Type: 289 EventRootType Probe[main.testByteArray]
+          Type: 269 EventRootType Probe[main.testByteArray]
           InjectionPoints: [{PC: "0x849540", Frameless: true}]
           Condition: null
     - id: testChannel
@@ -137,7 +137,7 @@ Probes:
       subprogram: {subprogram: 75}
       events:
         - ID: 69
-          Type: 357 EventRootType Probe[main.testChannel]
+          Type: 337 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84c390", Frameless: true}]
           Condition: null
     - id: testCombinedByte
@@ -151,7 +151,7 @@ Probes:
       subprogram: {subprogram: 73}
       events:
         - ID: 67
-          Type: 355 EventRootType Probe[main.testCombinedByte]
+          Type: 335 EventRootType Probe[main.testCombinedByte]
           InjectionPoints: [{PC: "0x84c110", Frameless: true}]
           Condition: null
     - id: testCycle
@@ -165,7 +165,7 @@ Probes:
       subprogram: {subprogram: 83}
       events:
         - ID: 77
-          Type: 365 EventRootType Probe[main.testCycle]
+          Type: 345 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84c630", Frameless: true}]
           Condition: null
     - id: testEmptySlice
@@ -179,7 +179,7 @@ Probes:
       subprogram: {subprogram: 85}
       events:
         - ID: 79
-          Type: 367 EventRootType Probe[main.testEmptySlice]
+          Type: 347 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84ca10", Frameless: true}]
           Condition: null
     - id: testEmptySliceOfStructs
@@ -193,7 +193,7 @@ Probes:
       subprogram: {subprogram: 88}
       events:
         - ID: 82
-          Type: 370 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 350 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84ca40", Frameless: true}]
           Condition: null
     - id: testEmptyString
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 102}
       events:
         - ID: 96
-          Type: 384 EventRootType Probe[main.testEmptyString]
+          Type: 364 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ce50", Frameless: true}]
           Condition: null
     - id: testEmptyStruct
@@ -221,7 +221,7 @@ Probes:
       subprogram: {subprogram: 104}
       events:
         - ID: 98
-          Type: 386 EventRootType Probe[main.testEmptyStruct]
+          Type: 366 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x84d160", Frameless: true}]
           Condition: null
     - id: testError
@@ -235,7 +235,7 @@ Probes:
       subprogram: {subprogram: 52}
       events:
         - ID: 46
-          Type: 334 EventRootType Probe[main.testError]
+          Type: 314 EventRootType Probe[main.testError]
           InjectionPoints: [{PC: "0x84a8c0", Frameless: true}]
           Condition: null
     - id: testEsotericHeap
@@ -249,7 +249,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - ID: 37
-          Type: 325 EventRootType Probe[main.testEsotericHeap]
+          Type: 305 EventRootType Probe[main.testEsotericHeap]
           InjectionPoints: [{PC: "0x849e3c", Frameless: true}]
           Condition: null
     - id: testEsotericStack
@@ -263,7 +263,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - ID: 36
-          Type: 324 EventRootType Probe[main.testEsotericStack]
+          Type: 304 EventRootType Probe[main.testEsotericStack]
           InjectionPoints: [{PC: "0x849d6c", Frameless: true}]
           Condition: null
     - id: testFrameless
@@ -277,7 +277,7 @@ Probes:
       subprogram: {subprogram: 48}
       events:
         - ID: 42
-          Type: 330 EventRootType Probe[main.testFrameless]
+          Type: 310 EventRootType Probe[main.testFrameless]
           InjectionPoints: [{PC: "0x84a560", Frameless: true}]
           Condition: null
     - id: testFramelessArray
@@ -291,7 +291,7 @@ Probes:
       subprogram: {subprogram: 49}
       events:
         - ID: 43
-          Type: 331 EventRootType Probe[main.testFramelessArray]
+          Type: 311 EventRootType Probe[main.testFramelessArray]
           InjectionPoints: [{PC: "0x84a570", Frameless: true}]
           Condition: null
     - id: testInlinedBA
@@ -305,7 +305,7 @@ Probes:
       subprogram: {subprogram: 44}
       events:
         - ID: 38
-          Type: 326 EventRootType Probe[main.testInlinedBA]
+          Type: 306 EventRootType Probe[main.testInlinedBA]
           InjectionPoints: [{PC: "0x84a27c", Frameless: true}]
           Condition: null
     - id: testInlinedBB
@@ -319,7 +319,7 @@ Probes:
       subprogram: {subprogram: 45}
       events:
         - ID: 39
-          Type: 327 EventRootType Probe[main.testInlinedBB]
+          Type: 307 EventRootType Probe[main.testInlinedBB]
           InjectionPoints: [{PC: "0x84a30c", Frameless: true}]
           Condition: null
     - id: testInlinedBBA
@@ -333,7 +333,7 @@ Probes:
       subprogram: {subprogram: 46}
       events:
         - ID: 40
-          Type: 328 EventRootType Probe[main.testInlinedBBA]
+          Type: 308 EventRootType Probe[main.testInlinedBBA]
           InjectionPoints: [{PC: "0x84a3cc", Frameless: true}]
           Condition: null
     - id: testInlinedBBB
@@ -347,7 +347,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 100
-          Type: 388 EventRootType Probe[main.testInlinedBBB]
+          Type: 368 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84a368", Frameless: false}]
           Condition: null
     - id: testInlinedBC
@@ -361,7 +361,7 @@ Probes:
       subprogram: {subprogram: 47}
       events:
         - ID: 41
-          Type: 329 EventRootType Probe[main.testInlinedBC]
+          Type: 309 EventRootType Probe[main.testInlinedBC]
           InjectionPoints: [{PC: "0x84a44c", Frameless: true}]
           Condition: null
     - id: testInlinedBCA
@@ -375,7 +375,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 101
-          Type: 389 EventRootType Probe[main.testInlinedBCA]
+          Type: 369 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84a45c", Frameless: false}]
           Condition: null
     - id: testInlinedBCB
@@ -389,7 +389,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 102
-          Type: 390 EventRootType Probe[main.testInlinedBCB]
+          Type: 370 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84a510", Frameless: false}]
           Condition: null
     - id: testInlinedPrint
@@ -404,7 +404,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 99
-          Type: 387 EventRootType Probe[main.testInlinedPrint]
+          Type: 367 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84a0dc"
               Frameless: true
@@ -428,7 +428,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 103
-          Type: 391 EventRootType Probe[main.testInlinedSq]
+          Type: 371 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84a564", Frameless: true}]
           Condition: null
     - id: testInlinedSumArray
@@ -443,7 +443,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 104
-          Type: 392 EventRootType Probe[main.testInlinedSumArray]
+          Type: 372 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84a594"
               Frameless: false
@@ -461,7 +461,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - ID: 7
-          Type: 295 EventRootType Probe[main.testInt16Array]
+          Type: 275 EventRootType Probe[main.testInt16Array]
           InjectionPoints: [{PC: "0x8495a0", Frameless: true}]
           Condition: null
     - id: testInt32Array
@@ -475,7 +475,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - ID: 8
-          Type: 296 EventRootType Probe[main.testInt32Array]
+          Type: 276 EventRootType Probe[main.testInt32Array]
           InjectionPoints: [{PC: "0x8495b0", Frameless: true}]
           Condition: null
     - id: testInt64Array
@@ -489,7 +489,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - ID: 9
-          Type: 297 EventRootType Probe[main.testInt64Array]
+          Type: 277 EventRootType Probe[main.testInt64Array]
           InjectionPoints: [{PC: "0x8495c0", Frameless: true}]
           Condition: null
     - id: testInt8Array
@@ -503,7 +503,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 6
-          Type: 294 EventRootType Probe[main.testInt8Array]
+          Type: 274 EventRootType Probe[main.testInt8Array]
           InjectionPoints: [{PC: "0x849590", Frameless: true}]
           Condition: null
     - id: testIntArray
@@ -517,7 +517,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 5
-          Type: 293 EventRootType Probe[main.testIntArray]
+          Type: 273 EventRootType Probe[main.testIntArray]
           InjectionPoints: [{PC: "0x849580", Frameless: true}]
           Condition: null
     - id: testInterface
@@ -531,7 +531,7 @@ Probes:
       subprogram: {subprogram: 50}
       events:
         - ID: 44
-          Type: 332 EventRootType Probe[main.testInterface]
+          Type: 312 EventRootType Probe[main.testInterface]
           InjectionPoints: [{PC: "0x84a80c", Frameless: true}]
           Condition: null
     - id: testLinkedList
@@ -545,7 +545,7 @@ Probes:
       subprogram: {subprogram: 77}
       events:
         - ID: 71
-          Type: 359 EventRootType Probe[main.testLinkedList]
+          Type: 339 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84c540", Frameless: true}]
           Condition: null
     - id: testMapArrayToArray
@@ -559,7 +559,7 @@ Probes:
       subprogram: {subprogram: 57}
       events:
         - ID: 51
-          Type: 339 EventRootType Probe[main.testMapArrayToArray]
+          Type: 319 EventRootType Probe[main.testMapArrayToArray]
           InjectionPoints: [{PC: "0x84ad20", Frameless: true}]
           Condition: null
     - id: testMapEmbeddedMaps
@@ -573,7 +573,7 @@ Probes:
       subprogram: {subprogram: 63}
       events:
         - ID: 57
-          Type: 345 EventRootType Probe[main.testMapEmbeddedMaps]
+          Type: 325 EventRootType Probe[main.testMapEmbeddedMaps]
           InjectionPoints: [{PC: "0x84ad80", Frameless: true}]
           Condition: null
     - id: testMapIntToInt
@@ -587,7 +587,7 @@ Probes:
       subprogram: {subprogram: 61}
       events:
         - ID: 55
-          Type: 343 EventRootType Probe[main.testMapIntToInt]
+          Type: 323 EventRootType Probe[main.testMapIntToInt]
           InjectionPoints: [{PC: "0x84ad60", Frameless: true}]
           Condition: null
     - id: testMapLargeKeyLargeValue
@@ -601,7 +601,7 @@ Probes:
       subprogram: {subprogram: 72}
       events:
         - ID: 66
-          Type: 354 EventRootType Probe[main.testMapLargeKeyLargeValue]
+          Type: 334 EventRootType Probe[main.testMapLargeKeyLargeValue]
           InjectionPoints: [{PC: "0x84ae10", Frameless: true}]
           Condition: null
     - id: testMapLargeKeySmallValue
@@ -615,7 +615,7 @@ Probes:
       subprogram: {subprogram: 71}
       events:
         - ID: 65
-          Type: 353 EventRootType Probe[main.testMapLargeKeySmallValue]
+          Type: 333 EventRootType Probe[main.testMapLargeKeySmallValue]
           InjectionPoints: [{PC: "0x84ae00", Frameless: true}]
           Condition: null
     - id: testMapMassive
@@ -629,7 +629,7 @@ Probes:
       subprogram: {subprogram: 62}
       events:
         - ID: 56
-          Type: 344 EventRootType Probe[main.testMapMassive]
+          Type: 324 EventRootType Probe[main.testMapMassive]
           InjectionPoints: [{PC: "0x84ad70", Frameless: true}]
           Condition: null
     - id: testMapSmallKeyLargeValue
@@ -643,7 +643,7 @@ Probes:
       subprogram: {subprogram: 70}
       events:
         - ID: 64
-          Type: 352 EventRootType Probe[main.testMapSmallKeyLargeValue]
+          Type: 332 EventRootType Probe[main.testMapSmallKeyLargeValue]
           InjectionPoints: [{PC: "0x84adf0", Frameless: true}]
           Condition: null
     - id: testMapSmallKeySmallValue
@@ -657,7 +657,7 @@ Probes:
       subprogram: {subprogram: 69}
       events:
         - ID: 63
-          Type: 351 EventRootType Probe[main.testMapSmallKeySmallValue]
+          Type: 331 EventRootType Probe[main.testMapSmallKeySmallValue]
           InjectionPoints: [{PC: "0x84ade0", Frameless: true}]
           Condition: null
     - id: testMapStringToInt
@@ -671,7 +671,7 @@ Probes:
       subprogram: {subprogram: 55}
       events:
         - ID: 49
-          Type: 337 EventRootType Probe[main.testMapStringToInt]
+          Type: 317 EventRootType Probe[main.testMapStringToInt]
           InjectionPoints: [{PC: "0x84ad00", Frameless: true}]
           Condition: null
     - id: testMapStringToSlice
@@ -685,7 +685,7 @@ Probes:
       subprogram: {subprogram: 56}
       events:
         - ID: 50
-          Type: 338 EventRootType Probe[main.testMapStringToSlice]
+          Type: 318 EventRootType Probe[main.testMapStringToSlice]
           InjectionPoints: [{PC: "0x84ad10", Frameless: true}]
           Condition: null
     - id: testMapStringToStruct
@@ -699,7 +699,7 @@ Probes:
       subprogram: {subprogram: 54}
       events:
         - ID: 48
-          Type: 336 EventRootType Probe[main.testMapStringToStruct]
+          Type: 316 EventRootType Probe[main.testMapStringToStruct]
           InjectionPoints: [{PC: "0x84acf0", Frameless: true}]
           Condition: null
     - id: testMapWithLinkedList
@@ -713,7 +713,7 @@ Probes:
       subprogram: {subprogram: 64}
       events:
         - ID: 58
-          Type: 346 EventRootType Probe[main.testMapWithLinkedList]
+          Type: 326 EventRootType Probe[main.testMapWithLinkedList]
           InjectionPoints: [{PC: "0x84ad90", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValue
@@ -727,7 +727,7 @@ Probes:
       subprogram: {subprogram: 67}
       events:
         - ID: 61
-          Type: 349 EventRootType Probe[main.testMapWithSmallKeyAndValue]
+          Type: 329 EventRootType Probe[main.testMapWithSmallKeyAndValue]
           InjectionPoints: [{PC: "0x84adc0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallKeyAndValueMassive
@@ -741,7 +741,7 @@ Probes:
       subprogram: {subprogram: 68}
       events:
         - ID: 62
-          Type: 350 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
+          Type: 330 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
           InjectionPoints: [{PC: "0x84add0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValue
@@ -755,7 +755,7 @@ Probes:
       subprogram: {subprogram: 65}
       events:
         - ID: 59
-          Type: 347 EventRootType Probe[main.testMapWithSmallValue]
+          Type: 327 EventRootType Probe[main.testMapWithSmallValue]
           InjectionPoints: [{PC: "0x84ada0", Frameless: true}]
           Condition: null
     - id: testMapWithSmallValueMassive
@@ -769,7 +769,7 @@ Probes:
       subprogram: {subprogram: 66}
       events:
         - ID: 60
-          Type: 348 EventRootType Probe[main.testMapWithSmallValueMassive]
+          Type: 328 EventRootType Probe[main.testMapWithSmallValueMassive]
           InjectionPoints: [{PC: "0x84adb0", Frameless: true}]
           Condition: null
     - id: testMassiveString
@@ -783,7 +783,7 @@ Probes:
       subprogram: {subprogram: 100}
       events:
         - ID: 94
-          Type: 382 EventRootType Probe[main.testMassiveString]
+          Type: 362 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ce30", Frameless: true}]
           Condition: null
     - id: testMultipleSimpleParams
@@ -797,7 +797,7 @@ Probes:
       subprogram: {subprogram: 74}
       events:
         - ID: 68
-          Type: 356 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 336 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84c1f0", Frameless: true}]
           Condition: null
     - id: testNilPointer
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 82}
       events:
         - ID: 76
-          Type: 364 EventRootType Probe[main.testNilPointer]
+          Type: 344 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84c610", Frameless: true}]
           Condition: null
     - id: testNilSlice
@@ -825,7 +825,7 @@ Probes:
       subprogram: {subprogram: 92}
       events:
         - ID: 86
-          Type: 374 EventRootType Probe[main.testNilSlice]
+          Type: 354 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84ca80", Frameless: true}]
           Condition: null
     - id: testNilSliceOfStructs
@@ -839,7 +839,7 @@ Probes:
       subprogram: {subprogram: 89}
       events:
         - ID: 83
-          Type: 371 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 351 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84ca50", Frameless: true}]
           Condition: null
     - id: testNilSliceWithOtherParams
@@ -853,7 +853,7 @@ Probes:
       subprogram: {subprogram: 91}
       events:
         - ID: 85
-          Type: 373 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 353 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84ca70", Frameless: true}]
           Condition: null
     - id: testOneStringInStructPointer
@@ -867,7 +867,7 @@ Probes:
       subprogram: {subprogram: 99}
       events:
         - ID: 93
-          Type: 381 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 361 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ce20", Frameless: true}]
           Condition: null
     - id: testPointerLoop
@@ -881,7 +881,7 @@ Probes:
       subprogram: {subprogram: 78}
       events:
         - ID: 72
-          Type: 360 EventRootType Probe[main.testPointerLoop]
+          Type: 340 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84c550", Frameless: true}]
           Condition: null
     - id: testPointerToMap
@@ -895,7 +895,7 @@ Probes:
       subprogram: {subprogram: 60}
       events:
         - ID: 54
-          Type: 342 EventRootType Probe[main.testPointerToMap]
+          Type: 322 EventRootType Probe[main.testPointerToMap]
           InjectionPoints: [{PC: "0x84ad50", Frameless: true}]
           Condition: null
     - id: testPointerToSimpleStruct
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 76}
       events:
         - ID: 70
-          Type: 358 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 338 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84c530", Frameless: true}]
           Condition: null
     - id: testRuneArray
@@ -923,7 +923,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 2
-          Type: 290 EventRootType Probe[main.testRuneArray]
+          Type: 270 EventRootType Probe[main.testRuneArray]
           InjectionPoints: [{PC: "0x849550", Frameless: true}]
           Condition: null
     - id: testSingleBool
@@ -937,7 +937,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - ID: 21
-          Type: 309 EventRootType Probe[main.testSingleBool]
+          Type: 289 EventRootType Probe[main.testSingleBool]
           InjectionPoints: [{PC: "0x8499c0", Frameless: true}]
           Condition: null
     - id: testSingleByte
@@ -951,7 +951,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - ID: 19
-          Type: 307 EventRootType Probe[main.testSingleByte]
+          Type: 287 EventRootType Probe[main.testSingleByte]
           InjectionPoints: [{PC: "0x8499a0", Frameless: true}]
           Condition: null
     - id: testSingleFloat32
@@ -965,7 +965,7 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - ID: 32
-          Type: 320 EventRootType Probe[main.testSingleFloat32]
+          Type: 300 EventRootType Probe[main.testSingleFloat32]
           InjectionPoints: [{PC: "0x849a70", Frameless: true}]
           Condition: null
     - id: testSingleFloat64
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - ID: 33
-          Type: 321 EventRootType Probe[main.testSingleFloat64]
+          Type: 301 EventRootType Probe[main.testSingleFloat64]
           InjectionPoints: [{PC: "0x849a80", Frameless: true}]
           Condition: null
     - id: testSingleInt
@@ -993,7 +993,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - ID: 22
-          Type: 310 EventRootType Probe[main.testSingleInt]
+          Type: 290 EventRootType Probe[main.testSingleInt]
           InjectionPoints: [{PC: "0x8499d0", Frameless: true}]
           Condition: null
     - id: testSingleInt16
@@ -1007,7 +1007,7 @@ Probes:
       subprogram: {subprogram: 30}
       events:
         - ID: 24
-          Type: 312 EventRootType Probe[main.testSingleInt16]
+          Type: 292 EventRootType Probe[main.testSingleInt16]
           InjectionPoints: [{PC: "0x8499f0", Frameless: true}]
           Condition: null
     - id: testSingleInt32
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 31}
       events:
         - ID: 25
-          Type: 313 EventRootType Probe[main.testSingleInt32]
+          Type: 293 EventRootType Probe[main.testSingleInt32]
           InjectionPoints: [{PC: "0x849a00", Frameless: true}]
           Condition: null
     - id: testSingleInt64
@@ -1035,7 +1035,7 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - ID: 26
-          Type: 314 EventRootType Probe[main.testSingleInt64]
+          Type: 294 EventRootType Probe[main.testSingleInt64]
           InjectionPoints: [{PC: "0x849a10", Frameless: true}]
           Condition: null
     - id: testSingleInt8
@@ -1049,7 +1049,7 @@ Probes:
       subprogram: {subprogram: 29}
       events:
         - ID: 23
-          Type: 311 EventRootType Probe[main.testSingleInt8]
+          Type: 291 EventRootType Probe[main.testSingleInt8]
           InjectionPoints: [{PC: "0x8499e0", Frameless: true}]
           Condition: null
     - id: testSingleRune
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - ID: 20
-          Type: 308 EventRootType Probe[main.testSingleRune]
+          Type: 288 EventRootType Probe[main.testSingleRune]
           InjectionPoints: [{PC: "0x8499b0", Frameless: true}]
           Condition: null
     - id: testSingleString
@@ -1077,7 +1077,7 @@ Probes:
       subprogram: {subprogram: 95}
       events:
         - ID: 89
-          Type: 377 EventRootType Probe[main.testSingleString]
+          Type: 357 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84cdd0", Frameless: true}]
           Condition: null
     - id: testSingleUint
@@ -1091,7 +1091,7 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - ID: 27
-          Type: 315 EventRootType Probe[main.testSingleUint]
+          Type: 295 EventRootType Probe[main.testSingleUint]
           InjectionPoints: [{PC: "0x849a20", Frameless: true}]
           Condition: null
     - id: testSingleUint16
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - ID: 29
-          Type: 317 EventRootType Probe[main.testSingleUint16]
+          Type: 297 EventRootType Probe[main.testSingleUint16]
           InjectionPoints: [{PC: "0x849a40", Frameless: true}]
           Condition: null
     - id: testSingleUint32
@@ -1119,7 +1119,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - ID: 30
-          Type: 318 EventRootType Probe[main.testSingleUint32]
+          Type: 298 EventRootType Probe[main.testSingleUint32]
           InjectionPoints: [{PC: "0x849a50", Frameless: true}]
           Condition: null
     - id: testSingleUint64
@@ -1133,7 +1133,7 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - ID: 31
-          Type: 319 EventRootType Probe[main.testSingleUint64]
+          Type: 299 EventRootType Probe[main.testSingleUint64]
           InjectionPoints: [{PC: "0x849a60", Frameless: true}]
           Condition: null
     - id: testSingleUint8
@@ -1147,7 +1147,7 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - ID: 28
-          Type: 316 EventRootType Probe[main.testSingleUint8]
+          Type: 296 EventRootType Probe[main.testSingleUint8]
           InjectionPoints: [{PC: "0x849a30", Frameless: true}]
           Condition: null
     - id: testSliceOfSlices
@@ -1161,7 +1161,7 @@ Probes:
       subprogram: {subprogram: 86}
       events:
         - ID: 80
-          Type: 368 EventRootType Probe[main.testSliceOfSlices]
+          Type: 348 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84ca20", Frameless: true}]
           Condition: null
     - id: testSmallMap
@@ -1175,7 +1175,7 @@ Probes:
       subprogram: {subprogram: 58}
       events:
         - ID: 52
-          Type: 340 EventRootType Probe[main.testSmallMap]
+          Type: 320 EventRootType Probe[main.testSmallMap]
           InjectionPoints: [{PC: "0x84ad30", Frameless: true}]
           Condition: null
     - id: testStringArray
@@ -1189,7 +1189,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 3
-          Type: 291 EventRootType Probe[main.testStringArray]
+          Type: 271 EventRootType Probe[main.testStringArray]
           InjectionPoints: [{PC: "0x849560", Frameless: true}]
           Condition: null
     - id: testStringPointer
@@ -1203,7 +1203,7 @@ Probes:
       subprogram: {subprogram: 81}
       events:
         - ID: 75
-          Type: 363 EventRootType Probe[main.testStringPointer]
+          Type: 343 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84c5f0", Frameless: true}]
           Condition: null
     - id: testStringSlice
@@ -1217,7 +1217,7 @@ Probes:
       subprogram: {subprogram: 90}
       events:
         - ID: 84
-          Type: 372 EventRootType Probe[main.testStringSlice]
+          Type: 352 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84ca60", Frameless: true}]
           Condition: null
     - id: testStruct
@@ -1231,7 +1231,7 @@ Probes:
       subprogram: {subprogram: 103}
       events:
         - ID: 97
-          Type: 385 EventRootType Probe[main.testStruct]
+          Type: 365 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x84d060", Frameless: true}]
           Condition: null
     - id: testStructSlice
@@ -1245,7 +1245,7 @@ Probes:
       subprogram: {subprogram: 87}
       events:
         - ID: 81
-          Type: 369 EventRootType Probe[main.testStructSlice]
+          Type: 349 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84ca30", Frameless: true}]
           Condition: null
     - id: testStructWithMap
@@ -1259,7 +1259,7 @@ Probes:
       subprogram: {subprogram: 53}
       events:
         - ID: 47
-          Type: 335 EventRootType Probe[main.testStructWithMap]
+          Type: 315 EventRootType Probe[main.testStructWithMap]
           InjectionPoints: [{PC: "0x84ace0", Frameless: true}]
           Condition: null
     - id: testThreeStrings
@@ -1273,7 +1273,7 @@ Probes:
       subprogram: {subprogram: 96}
       events:
         - ID: 90
-          Type: 378 EventRootType Probe[main.testThreeStrings]
+          Type: 358 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84cde0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStruct
@@ -1287,7 +1287,7 @@ Probes:
       subprogram: {subprogram: 97}
       events:
         - ID: 91
-          Type: 379 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 359 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84cdf0", Frameless: true}]
           Condition: null
     - id: testThreeStringsInStructPointer
@@ -1301,7 +1301,7 @@ Probes:
       subprogram: {subprogram: 98}
       events:
         - ID: 92
-          Type: 380 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 360 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ce10", Frameless: true}]
           Condition: null
     - id: testTypeAlias
@@ -1315,7 +1315,7 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - ID: 34
-          Type: 322 EventRootType Probe[main.testTypeAlias]
+          Type: 302 EventRootType Probe[main.testTypeAlias]
           InjectionPoints: [{PC: "0x849a90", Frameless: true}]
           Condition: null
     - id: testUint16Array
@@ -1329,7 +1329,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - ID: 12
-          Type: 300 EventRootType Probe[main.testUint16Array]
+          Type: 280 EventRootType Probe[main.testUint16Array]
           InjectionPoints: [{PC: "0x8495f0", Frameless: true}]
           Condition: null
     - id: testUint32Array
@@ -1343,7 +1343,7 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - ID: 13
-          Type: 301 EventRootType Probe[main.testUint32Array]
+          Type: 281 EventRootType Probe[main.testUint32Array]
           InjectionPoints: [{PC: "0x849600", Frameless: true}]
           Condition: null
     - id: testUint64Array
@@ -1357,7 +1357,7 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - ID: 14
-          Type: 302 EventRootType Probe[main.testUint64Array]
+          Type: 282 EventRootType Probe[main.testUint64Array]
           InjectionPoints: [{PC: "0x849610", Frameless: true}]
           Condition: null
     - id: testUint8Array
@@ -1371,7 +1371,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - ID: 11
-          Type: 299 EventRootType Probe[main.testUint8Array]
+          Type: 279 EventRootType Probe[main.testUint8Array]
           InjectionPoints: [{PC: "0x8495e0", Frameless: true}]
           Condition: null
     - id: testUintArray
@@ -1385,7 +1385,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - ID: 10
-          Type: 298 EventRootType Probe[main.testUintArray]
+          Type: 278 EventRootType Probe[main.testUintArray]
           InjectionPoints: [{PC: "0x8495d0", Frameless: true}]
           Condition: null
     - id: testUintPointer
@@ -1399,7 +1399,7 @@ Probes:
       subprogram: {subprogram: 80}
       events:
         - ID: 74
-          Type: 362 EventRootType Probe[main.testUintPointer]
+          Type: 342 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84c580", Frameless: true}]
           Condition: null
     - id: testUintSlice
@@ -1413,7 +1413,7 @@ Probes:
       subprogram: {subprogram: 84}
       events:
         - ID: 78
-          Type: 366 EventRootType Probe[main.testUintSlice]
+          Type: 346 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84ca00", Frameless: true}]
           Condition: null
     - id: testUnitializedString
@@ -1427,7 +1427,7 @@ Probes:
       subprogram: {subprogram: 101}
       events:
         - ID: 95
-          Type: 383 EventRootType Probe[main.testUnitializedString]
+          Type: 363 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ce40", Frameless: true}]
           Condition: null
     - id: testUnsafePointer
@@ -1441,7 +1441,7 @@ Probes:
       subprogram: {subprogram: 79}
       events:
         - ID: 73
-          Type: 361 EventRootType Probe[main.testUnsafePointer]
+          Type: 341 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84c560", Frameless: true}]
           Condition: null
     - id: testVeryLargeArray
@@ -1455,7 +1455,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - ID: 18
-          Type: 306 EventRootType Probe[main.testVeryLargeArray]
+          Type: 286 EventRootType Probe[main.testVeryLargeArray]
           InjectionPoints: [{PC: "0x849670", Frameless: true}]
           Condition: null
     - id: testVeryLargeSlice
@@ -1469,7 +1469,7 @@ Probes:
       subprogram: {subprogram: 93}
       events:
         - ID: 87
-          Type: 375 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 355 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84ca90", Frameless: true}]
           Condition: null
 Subprograms:
@@ -1911,7 +1911,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
           Locations:
             - Range: 0x849d60..0x849da8
               Pieces:
@@ -1981,7 +1981,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 63 PointerType *main.esotericHeap
+          Type: 44 PointerType *main.esotericHeap
           Locations:
             - Range: 0x849e30..0x849e68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2106,7 +2106,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: b
-          Type: 75 GoInterfaceType main.behavior
+          Type: 56 GoInterfaceType main.behavior
           Locations:
             - Range: 0x84a800..0x84a828
               Pieces:
@@ -2133,7 +2133,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
           Locations:
             - Range: 0x84a850..0x84a880
               Pieces:
@@ -2160,7 +2160,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 76 GoInterfaceType error
+          Type: 57 GoInterfaceType error
           Locations:
             - Range: 0x84a8c0..0x84a8d0
               Pieces:
@@ -2176,7 +2176,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 77 StructureType main.structWithMap
+          Type: 58 StructureType main.structWithMap
           Locations:
             - Range: 0x84ace0..0x84acf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2188,7 +2188,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 89 GoMapType map[string]main.nestedStruct
+          Type: 71 GoMapType map[string]main.nestedStruct
           Locations:
             - Range: 0x84acf0..0x84ad00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2200,7 +2200,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 83 GoMapType map[string]int
           Locations:
             - Range: 0x84ad00..0x84ad10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2212,7 +2212,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 112 GoMapType map[string][]string
+          Type: 94 GoMapType map[string][]string
           Locations:
             - Range: 0x84ad10..0x84ad20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2224,7 +2224,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 124 GoMapType map[[4]string][2]int
+          Type: 106 GoMapType map[[4]string][2]int
           Locations:
             - Range: 0x84ad20..0x84ad30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2236,7 +2236,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 101 GoMapType map[string]int
+          Type: 83 GoMapType map[string]int
           Locations:
             - Range: 0x84ad30..0x84ad40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2248,7 +2248,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 136 ArrayType [2]map[string]int
+          Type: 118 ArrayType [2]map[string]int
           Locations:
             - Range: 0x84ad40..0x84ad50
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
@@ -2260,7 +2260,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 137 PointerType *map[string]int
+          Type: 119 PointerType *map[string]int
           Locations:
             - Range: 0x84ad50..0x84ad60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2272,7 +2272,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 78 GoMapType map[int]int
+          Type: 59 GoMapType map[int]int
           Locations:
             - Range: 0x84ad60..0x84ad70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2284,7 +2284,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad70..0x84ad80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2296,7 +2296,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 138 GoMapType map[string][]main.structWithMap
+          Type: 120 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x84ad80..0x84ad90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2308,7 +2308,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 151 GoMapType map[bool]main.node
+          Type: 133 GoMapType map[bool]main.node
           Locations:
             - Range: 0x84ad90..0x84ada0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2320,7 +2320,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 164 GoMapType map[int]uint8
+          Type: 146 GoMapType map[int]uint8
           Locations:
             - Range: 0x84ada0..0x84adb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2332,7 +2332,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: redactMyEntries
-          Type: 164 GoMapType map[int]uint8
+          Type: 146 GoMapType map[int]uint8
           Locations:
             - Range: 0x84adb0..0x84adc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2344,7 +2344,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84adc0..0x84add0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2356,7 +2356,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84add0..0x84ade0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2368,7 +2368,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 175 GoMapType map[uint8]uint8
+          Type: 157 GoMapType map[uint8]uint8
           Locations:
             - Range: 0x84ade0..0x84adf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2380,7 +2380,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 186 GoMapType map[uint8][4]int
+          Type: 168 GoMapType map[uint8][4]int
           Locations:
             - Range: 0x84adf0..0x84ae00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2392,7 +2392,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 198 GoMapType map[[4]int]uint8
+          Type: 180 GoMapType map[[4]int]uint8
           Locations:
             - Range: 0x84ae00..0x84ae10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2404,7 +2404,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: m
-          Type: 209 GoMapType map[[4]int][4]int
+          Type: 191 GoMapType map[[4]int][4]int
           Locations:
             - Range: 0x84ae10..0x84ae20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2486,7 +2486,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: c
-          Type: 220 GoChannelType chan bool
+          Type: 202 GoChannelType chan bool
           Locations:
             - Range: 0x84c390..0x84c3a0
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
@@ -2498,7 +2498,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 221 PointerType *main.structWithTwoValues
+          Type: 203 PointerType *main.structWithTwoValues
           Locations:
             - Range: 0x84c530..0x84c540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2510,7 +2510,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 162 StructureType main.node
+          Type: 144 StructureType main.node
           Locations:
             - Range: 0x84c540..0x84c550
               Pieces:
@@ -2526,7 +2526,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 163 PointerType *main.node
+          Type: 145 PointerType *main.node
           Locations:
             - Range: 0x84c550..0x84c560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2538,7 +2538,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
           Locations:
             - Range: 0x84c560..0x84c570
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2550,7 +2550,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 223 PointerType *uint
+          Type: 205 PointerType *uint
           Locations:
             - Range: 0x84c580..0x84c590
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2574,7 +2574,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: z
-          Type: 224 PointerType *bool
+          Type: 206 PointerType *bool
           Locations:
             - Range: 0x84c610..0x84c620
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2593,7 +2593,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: t
-          Type: 225 PointerType *main.t
+          Type: 207 PointerType *main.t
           Locations:
             - Range: 0x84c630..0x84c640
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2605,7 +2605,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca00..0x84ca10
               Pieces:
@@ -2623,7 +2623,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca10..0x84ca20
               Pieces:
@@ -2641,7 +2641,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 229 GoSliceHeaderType [][]uint
+          Type: 211 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x84ca20..0x84ca30
               Pieces:
@@ -2659,7 +2659,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca30..0x84ca40
               Pieces:
@@ -2684,7 +2684,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca40..0x84ca50
               Pieces:
@@ -2709,7 +2709,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 231 GoSliceHeaderType []main.structWithNoStrings
+          Type: 213 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x84ca50..0x84ca60
               Pieces:
@@ -2734,7 +2734,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: s
-          Type: 123 GoSliceHeaderType []string
+          Type: 105 GoSliceHeaderType []string
           Locations:
             - Range: 0x84ca60..0x84ca70
               Pieces:
@@ -2759,7 +2759,7 @@ Subprograms:
           IsParameter: true
           IsReturn: false
         - Name: s
-          Type: 234 GoSliceHeaderType []bool
+          Type: 216 GoSliceHeaderType []bool
           Locations:
             - Range: 0x84ca70..0x84ca80
               Pieces:
@@ -2784,7 +2784,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 235 GoSliceHeaderType []uint16
+          Type: 217 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x84ca80..0x84ca90
               Pieces:
@@ -2802,7 +2802,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 228 GoSliceHeaderType []uint
+          Type: 210 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84ca90..0x84caa0
               Pieces:
@@ -2884,7 +2884,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 237 StructureType main.threeStringStruct
+          Type: 219 StructureType main.threeStringStruct
           Locations:
             - Range: 0x84cdf0..0x84ce10
               Pieces:
@@ -2908,7 +2908,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 238 PointerType *main.threeStringStruct
+          Type: 220 PointerType *main.threeStringStruct
           Locations:
             - Range: 0x84ce10..0x84ce20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2920,7 +2920,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: a
-          Type: 239 PointerType *main.oneStringStruct
+          Type: 221 PointerType *main.oneStringStruct
           Locations:
             - Range: 0x84ce20..0x84ce30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
@@ -2980,7 +2980,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: x
-          Type: 241 StructureType main.aStruct
+          Type: 223 StructureType main.aStruct
           Locations:
             - Range: 0x84d060..0x84d080
               Pieces:
@@ -3006,7 +3006,7 @@ Subprograms:
       InlinePCRanges: []
       Variables:
         - Name: e
-          Type: 242 StructureType main.emptyStruct
+          Type: 224 StructureType main.emptyStruct
           Locations: [{Range: 0x84d160..0x84d170, Pieces: []}]
           IsParameter: true
           IsReturn: false
@@ -3156,11 +3156,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 244 PointerType *string.str
+          Type: 226 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 243 GoStringDataType string.str
+      Data: 225 GoStringDataType string.str
     - __kind: PointerType
       ID: 9
       Name: '*uint8'
@@ -3362,7 +3362,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 245 GoSliceDataType []*string.array
+      Data: 227 GoSliceDataType []*string.array
     - __kind: PointerType
       ID: 35
       Name: '**string'
@@ -3383,215 +3383,21 @@ Types:
       ByteSize: 16
       GoRuntimeType: 1.011776e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
-    - __kind: StructureType
-      ID: 38
-      Name: runtime.iface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: tab
           Offset: 0
-          Type: 39 PointerType *internal/abi.ITab
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
-    - __kind: PointerType
-      ID: 39
-      Name: '*internal/abi.ITab'
-      ByteSize: 8
-      GoRuntimeType: 409728
-      GoKind: 22
-      Pointee: 40 StructureType internal/abi.ITab
-    - __kind: StructureType
-      ID: 40
-      Name: internal/abi.ITab
-      ByteSize: 32
-      GoRuntimeType: 1.742464e+06
-      GoKind: 25
-      RawFields:
-        - Name: Inter
-          Offset: 0
-          Type: 41 PointerType *internal/abi.InterfaceType
-        - Name: Type
-          Offset: 8
-          Type: 54 PointerType *internal/abi.Type
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: Fun
-          Offset: 24
-          Type: 55 ArrayType [1]uintptr
-    - __kind: PointerType
-      ID: 41
-      Name: '*internal/abi.InterfaceType'
-      ByteSize: 8
-      GoRuntimeType: 2.18864e+06
-      GoKind: 22
-      Pointee: 42 StructureType internal/abi.InterfaceType
-    - __kind: StructureType
-      ID: 42
-      Name: internal/abi.InterfaceType
-      ByteSize: 80
-      GoRuntimeType: 1.619296e+06
-      GoKind: 25
-      RawFields:
-        - Name: Type
-          Offset: 0
-          Type: 43 StructureType internal/abi.Type
-        - Name: PkgPath
-          Offset: 48
-          Type: 50 StructureType internal/abi.Name
-        - Name: Methods
-          Offset: 56
-          Type: 51 GoSliceHeaderType []internal/abi.Imethod
-    - __kind: StructureType
-      ID: 43
-      Name: internal/abi.Type
-      ByteSize: 48
-      GoRuntimeType: 2.110432e+06
-      GoKind: 25
-      RawFields:
-        - Name: Size_
-          Offset: 0
-          Type: 44 BaseType uintptr
-        - Name: PtrBytes
-          Offset: 8
-          Type: 44 BaseType uintptr
-        - Name: Hash
-          Offset: 16
-          Type: 24 BaseType uint32
-        - Name: TFlag
-          Offset: 20
-          Type: 45 BaseType internal/abi.TFlag
-        - Name: Align_
-          Offset: 21
-          Type: 4 BaseType uint8
-        - Name: FieldAlign_
-          Offset: 22
-          Type: 4 BaseType uint8
-        - Name: Kind_
-          Offset: 23
-          Type: 46 BaseType internal/abi.Kind
-        - Name: Equal
-          Offset: 24
-          Type: 47 GoSubroutineType func(unsafe.Pointer, unsafe.Pointer) bool
-        - Name: GCData
-          Offset: 32
-          Type: 9 PointerType *uint8
-        - Name: Str
-          Offset: 40
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: PtrToThis
-          Offset: 44
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: BaseType
-      ID: 44
-      Name: uintptr
-      ByteSize: 8
-      GoRuntimeType: 575520
-      GoKind: 12
-    - __kind: BaseType
-      ID: 45
-      Name: internal/abi.TFlag
-      ByteSize: 1
-      GoRuntimeType: 578528
-      GoKind: 8
-    - __kind: BaseType
-      ID: 46
-      Name: internal/abi.Kind
-      ByteSize: 1
-      GoRuntimeType: 824224
-      GoKind: 8
-    - __kind: GoSubroutineType
-      ID: 47
-      Name: func(unsafe.Pointer, unsafe.Pointer) bool
-      ByteSize: 8
-      GoRuntimeType: 834304
-      GoKind: 19
-    - __kind: BaseType
-      ID: 48
-      Name: internal/abi.NameOff
-      ByteSize: 4
-      GoRuntimeType: 578592
-      GoKind: 5
-    - __kind: BaseType
-      ID: 49
-      Name: internal/abi.TypeOff
-      ByteSize: 4
-      GoRuntimeType: 578656
-      GoKind: 5
-    - __kind: StructureType
-      ID: 50
-      Name: internal/abi.Name
-      ByteSize: 8
-      GoRuntimeType: 1.954272e+06
-      GoKind: 25
-      RawFields:
-        - Name: Bytes
-          Offset: 0
-          Type: 9 PointerType *uint8
-    - __kind: GoSliceHeaderType
-      ID: 51
-      Name: '[]internal/abi.Imethod'
-      ByteSize: 24
-      GoRuntimeType: 499168
-      GoKind: 23
-      RawFields:
-        - Name: array
-          Offset: 0
-          Type: 52 PointerType *internal/abi.Imethod
-        - Name: len
-          Offset: 8
-          Type: 1 BaseType int
-        - Name: cap
-          Offset: 16
-          Type: 1 BaseType int
-      Data: 247 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: PointerType
-      ID: 52
-      Name: '*internal/abi.Imethod'
-      ByteSize: 8
-      GoRuntimeType: 409664
-      GoKind: 22
-      Pointee: 53 StructureType internal/abi.Imethod
-    - __kind: StructureType
-      ID: 53
-      Name: internal/abi.Imethod
-      ByteSize: 8
-      GoRuntimeType: 1.469952e+06
-      GoKind: 25
-      RawFields:
-        - Name: Name
-          Offset: 0
-          Type: 48 BaseType internal/abi.NameOff
-        - Name: Typ
-          Offset: 4
-          Type: 49 BaseType internal/abi.TypeOff
-    - __kind: PointerType
-      ID: 54
-      Name: '*internal/abi.Type'
-      ByteSize: 8
-      GoRuntimeType: 2.189088e+06
-      GoKind: 22
-      Pointee: 43 StructureType internal/abi.Type
-    - __kind: ArrayType
-      ID: 55
-      Name: '[1]uintptr'
-      ByteSize: 8
-      GoRuntimeType: 674144
-      GoKind: 17
-      Count: 1
-      HasCount: true
-      Element: 44 BaseType uintptr
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: VoidPointerType
-      ID: 56
+      ID: 38
       Name: unsafe.Pointer
       ByteSize: 8
       GoRuntimeType: 575904
       GoKind: 26
     - __kind: StructureType
-      ID: 57
+      ID: 39
       Name: main.esotericStack
       ByteSize: 64
       GoRuntimeType: 1.944768e+06
@@ -3605,65 +3411,65 @@ Types:
           Type: 6 BaseType int32
         - Name: c
           Offset: 8
-          Type: 58 GoChannelType chan struct {}
+          Type: 40 GoChannelType chan struct {}
         - Name: val
           Offset: 16
-          Type: 59 GoEmptyInterfaceType interface {}
+          Type: 41 GoEmptyInterfaceType interface {}
         - Name: _
           Offset: 32
           Type: 26 BaseType uint64
         - Name: work
           Offset: 40
-          Type: 61 GoInterfaceType main.something
+          Type: 42 GoInterfaceType main.something
         - Name: foo
           Offset: 56
-          Type: 62 GoSubroutineType func()
+          Type: 43 GoSubroutineType func()
     - __kind: GoChannelType
-      ID: 58
+      ID: 40
       Name: chan struct {}
       GoRuntimeType: 586080
       GoKind: 18
     - __kind: GoEmptyInterfaceType
-      ID: 59
+      ID: 41
       Name: interface {}
       ByteSize: 16
       GoRuntimeType: 837760
       GoKind: 20
-      UnderlyingStructure: 60 StructureType runtime.eface
-    - __kind: StructureType
-      ID: 60
-      Name: runtime.eface
-      ByteSize: 16
-      GoKind: 25
       RawFields:
         - Name: _type
           Offset: 0
-          Type: 54 PointerType *internal/abi.Type
+          Type: 38 VoidPointerType unsafe.Pointer
         - Name: data
           Offset: 8
-          Type: 56 VoidPointerType unsafe.Pointer
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 61
+      ID: 42
       Name: main.something
       ByteSize: 16
       GoRuntimeType: 1.01152e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoSubroutineType
-      ID: 62
+      ID: 43
       Name: func()
       ByteSize: 8
       GoRuntimeType: 468800
       GoKind: 19
     - __kind: PointerType
-      ID: 63
+      ID: 44
       Name: '*main.esotericHeap'
       ByteSize: 8
       GoRuntimeType: 380160
       GoKind: 22
-      Pointee: 64 StructureType main.esotericHeap
+      Pointee: 45 StructureType main.esotericHeap
     - __kind: StructureType
-      ID: 64
+      ID: 45
       Name: main.esotericHeap
       ByteSize: 112
       GoRuntimeType: 1.811168e+06
@@ -3671,21 +3477,21 @@ Types:
       RawFields:
         - Name: esotericStack
           Offset: 0
-          Type: 57 StructureType main.esotericStack
+          Type: 39 StructureType main.esotericStack
         - Name: mu
           Offset: 64
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
         - Name: once
           Offset: 72
-          Type: 68 StructureType sync.Once
+          Type: 49 StructureType sync.Once
         - Name: wg
           Offset: 88
-          Type: 71 StructureType sync.WaitGroup
+          Type: 52 StructureType sync.WaitGroup
         - Name: a
           Offset: 104
-          Type: 74 StructureType sync/atomic.Int32
+          Type: 55 StructureType sync/atomic.Int32
     - __kind: StructureType
-      ID: 65
+      ID: 46
       Name: sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.444672e+06
@@ -3693,18 +3499,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: mu
           Offset: 0
-          Type: 67 StructureType internal/sync.Mutex
+          Type: 48 StructureType internal/sync.Mutex
     - __kind: StructureType
-      ID: 66
+      ID: 47
       Name: sync.noCopy
       GoRuntimeType: 977056
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 67
+      ID: 48
       Name: internal/sync.Mutex
       ByteSize: 8
       GoRuntimeType: 1.453952e+06
@@ -3717,7 +3523,7 @@ Types:
           Offset: 4
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 68
+      ID: 49
       Name: sync.Once
       ByteSize: 12
       GoRuntimeType: 1.593184e+06
@@ -3725,15 +3531,15 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: done
           Offset: 0
-          Type: 69 StructureType sync/atomic.Uint32
+          Type: 50 StructureType sync/atomic.Uint32
         - Name: m
           Offset: 4
-          Type: 65 StructureType sync.Mutex
+          Type: 46 StructureType sync.Mutex
     - __kind: StructureType
-      ID: 69
+      ID: 50
       Name: sync/atomic.Uint32
       ByteSize: 4
       GoRuntimeType: 1.446112e+06
@@ -3741,18 +3547,18 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 70
+      ID: 51
       Name: sync/atomic.noCopy
       GoRuntimeType: 977152
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 71
+      ID: 52
       Name: sync.WaitGroup
       ByteSize: 16
       GoRuntimeType: 1.593376e+06
@@ -3760,15 +3566,15 @@ Types:
       RawFields:
         - Name: noCopy
           Offset: 0
-          Type: 66 StructureType sync.noCopy
+          Type: 47 StructureType sync.noCopy
         - Name: state
           Offset: 0
-          Type: 72 StructureType sync/atomic.Uint64
+          Type: 53 StructureType sync/atomic.Uint64
         - Name: sema
           Offset: 8
           Type: 24 BaseType uint32
     - __kind: StructureType
-      ID: 72
+      ID: 53
       Name: sync/atomic.Uint64
       ByteSize: 8
       GoRuntimeType: 1.59376e+06
@@ -3776,21 +3582,21 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: _
           Offset: 0
-          Type: 73 StructureType sync/atomic.align64
+          Type: 54 StructureType sync/atomic.align64
         - Name: v
           Offset: 0
           Type: 26 BaseType uint64
     - __kind: StructureType
-      ID: 73
+      ID: 54
       Name: sync/atomic.align64
       GoRuntimeType: 977248
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 74
+      ID: 55
       Name: sync/atomic.Int32
       ByteSize: 4
       GoRuntimeType: 1.445952e+06
@@ -3798,26 +3604,38 @@ Types:
       RawFields:
         - Name: _
           Offset: 0
-          Type: 70 StructureType sync/atomic.noCopy
+          Type: 51 StructureType sync/atomic.noCopy
         - Name: v
           Offset: 0
           Type: 6 BaseType int32
     - __kind: GoInterfaceType
-      ID: 75
+      ID: 56
       Name: main.behavior
       ByteSize: 16
       GoRuntimeType: 1.011392e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: GoInterfaceType
-      ID: 76
+      ID: 57
       Name: error
       ByteSize: 16
       GoRuntimeType: 1.015744e+06
       GoKind: 20
-      UnderlyingStructure: 38 StructureType runtime.iface
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 38 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 38 VoidPointerType unsafe.Pointer
     - __kind: StructureType
-      ID: 77
+      ID: 58
       Name: main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.172832e+06
@@ -3825,21 +3643,21 @@ Types:
       RawFields:
         - Name: m
           Offset: 0
-          Type: 78 GoMapType map[int]int
+          Type: 59 GoMapType map[int]int
     - __kind: GoMapType
-      ID: 78
+      ID: 59
       Name: map[int]int
       ByteSize: 8
       GoRuntimeType: 1.116512e+06
       GoKind: 21
-      HeaderType: 80 GoSwissMapHeaderType map<int,int>
+      HeaderType: 61 GoSwissMapHeaderType map<int,int>
     - __kind: PointerType
-      ID: 79
+      ID: 60
       Name: '*map<int,int>'
       ByteSize: 8
-      Pointee: 80 GoSwissMapHeaderType map<int,int>
+      Pointee: 61 GoSwissMapHeaderType map<int,int>
     - __kind: GoSwissMapHeaderType
-      ID: 80
+      ID: 61
       Name: map<int,int>
       ByteSize: 48
       GoKind: 25
@@ -3849,10 +3667,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 81 PointerType **table<int,int>
+          Type: 63 PointerType **table<int,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -3868,20 +3686,26 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 249 GoSliceDataType []*table<int,int>.array
-      GroupType: 86 StructureType noalg.map.group[int]int
+      TablePtrSliceType: 229 GoSliceDataType []*table<int,int>.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+    - __kind: BaseType
+      ID: 62
+      Name: uintptr
+      ByteSize: 8
+      GoRuntimeType: 575520
+      GoKind: 12
     - __kind: PointerType
-      ID: 81
+      ID: 63
       Name: '**table<int,int>'
       ByteSize: 8
-      Pointee: 82 PointerType *table<int,int>
+      Pointee: 64 PointerType *table<int,int>
     - __kind: PointerType
-      ID: 82
+      ID: 64
       Name: '*table<int,int>'
       ByteSize: 8
-      Pointee: 83 StructureType table<int,int>
+      Pointee: 65 StructureType table<int,int>
     - __kind: StructureType
-      ID: 83
+      ID: 65
       Name: table<int,int>
       ByteSize: 32
       GoKind: 25
@@ -3903,28 +3727,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 84 GoSwissMapGroupsType groupReference<int,int>
+          Type: 66 GoSwissMapGroupsType groupReference<int,int>
     - __kind: GoSwissMapGroupsType
-      ID: 84
+      ID: 66
       Name: groupReference<int,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 85 PointerType *noalg.map.group[int]int
+          Type: 67 PointerType *noalg.map.group[int]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 86 StructureType noalg.map.group[int]int
-      GroupSliceType: 250 GoSliceDataType []noalg.map.group[int]int.array
+      GroupType: 68 StructureType noalg.map.group[int]int
+      GroupSliceType: 230 GoSliceDataType []noalg.map.group[int]int.array
     - __kind: PointerType
-      ID: 85
+      ID: 67
       Name: '*noalg.map.group[int]int'
       ByteSize: 8
-      Pointee: 86 StructureType noalg.map.group[int]int
+      Pointee: 68 StructureType noalg.map.group[int]int
     - __kind: StructureType
-      ID: 86
+      ID: 68
       Name: noalg.map.group[int]int
       ByteSize: 136
       GoRuntimeType: 1.275808e+06
@@ -3935,18 +3759,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 87 ArrayType noalg.[8]struct { key int; elem int }
+          Type: 69 ArrayType noalg.[8]struct { key int; elem int }
     - __kind: ArrayType
-      ID: 87
+      ID: 69
       Name: noalg.[8]struct { key int; elem int }
       ByteSize: 128
       GoRuntimeType: 671072
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 88 StructureType noalg.struct { key int; elem int }
+      Element: 70 StructureType noalg.struct { key int; elem int }
     - __kind: StructureType
-      ID: 88
+      ID: 70
       Name: noalg.struct { key int; elem int }
       ByteSize: 16
       GoRuntimeType: 1.27568e+06
@@ -3959,19 +3783,19 @@ Types:
           Offset: 8
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 89
+      ID: 71
       Name: map[string]main.nestedStruct
       ByteSize: 8
       GoRuntimeType: 1.11792e+06
       GoKind: 21
-      HeaderType: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
+      HeaderType: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 90
+      ID: 72
       Name: '*map<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 91 GoSwissMapHeaderType map<string,main.nestedStruct>
+      Pointee: 73 GoSwissMapHeaderType map<string,main.nestedStruct>
     - __kind: GoSwissMapHeaderType
-      ID: 91
+      ID: 73
       Name: map<string,main.nestedStruct>
       ByteSize: 48
       GoKind: 25
@@ -3981,10 +3805,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 92 PointerType **table<string,main.nestedStruct>
+          Type: 74 PointerType **table<string,main.nestedStruct>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4000,20 +3824,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 251 GoSliceDataType []*table<string,main.nestedStruct>.array
-      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
+      TablePtrSliceType: 231 GoSliceDataType []*table<string,main.nestedStruct>.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: PointerType
-      ID: 92
+      ID: 74
       Name: '**table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 93 PointerType *table<string,main.nestedStruct>
+      Pointee: 75 PointerType *table<string,main.nestedStruct>
     - __kind: PointerType
-      ID: 93
+      ID: 75
       Name: '*table<string,main.nestedStruct>'
       ByteSize: 8
-      Pointee: 94 StructureType table<string,main.nestedStruct>
+      Pointee: 76 StructureType table<string,main.nestedStruct>
     - __kind: StructureType
-      ID: 94
+      ID: 76
       Name: table<string,main.nestedStruct>
       ByteSize: 32
       GoKind: 25
@@ -4035,28 +3859,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 95 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
+          Type: 77 GoSwissMapGroupsType groupReference<string,main.nestedStruct>
     - __kind: GoSwissMapGroupsType
-      ID: 95
+      ID: 77
       Name: groupReference<string,main.nestedStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 96 PointerType *noalg.map.group[string]main.nestedStruct
+          Type: 78 PointerType *noalg.map.group[string]main.nestedStruct
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 97 StructureType noalg.map.group[string]main.nestedStruct
-      GroupSliceType: 252 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
+      GroupType: 79 StructureType noalg.map.group[string]main.nestedStruct
+      GroupSliceType: 232 GoSliceDataType []noalg.map.group[string]main.nestedStruct.array
     - __kind: PointerType
-      ID: 96
+      ID: 78
       Name: '*noalg.map.group[string]main.nestedStruct'
       ByteSize: 8
-      Pointee: 97 StructureType noalg.map.group[string]main.nestedStruct
+      Pointee: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: StructureType
-      ID: 97
+      ID: 79
       Name: noalg.map.group[string]main.nestedStruct
       ByteSize: 328
       GoRuntimeType: 1.278624e+06
@@ -4067,18 +3891,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 98 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
+          Type: 80 ArrayType noalg.[8]struct { key string; elem main.nestedStruct }
     - __kind: ArrayType
-      ID: 98
+      ID: 80
       Name: noalg.[8]struct { key string; elem main.nestedStruct }
       ByteSize: 320
       GoRuntimeType: 673760
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 99 StructureType noalg.struct { key string; elem main.nestedStruct }
+      Element: 81 StructureType noalg.struct { key string; elem main.nestedStruct }
     - __kind: StructureType
-      ID: 99
+      ID: 81
       Name: noalg.struct { key string; elem main.nestedStruct }
       ByteSize: 40
       GoRuntimeType: 1.278496e+06
@@ -4089,9 +3913,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 100 StructureType main.nestedStruct
+          Type: 82 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 100
+      ID: 82
       Name: main.nestedStruct
       ByteSize: 24
       GoRuntimeType: 1.443392e+06
@@ -4104,19 +3928,19 @@ Types:
           Offset: 8
           Type: 8 GoStringHeaderType string
     - __kind: GoMapType
-      ID: 101
+      ID: 83
       Name: map[string]int
       ByteSize: 8
       GoRuntimeType: 1.117792e+06
       GoKind: 21
-      HeaderType: 103 GoSwissMapHeaderType map<string,int>
+      HeaderType: 85 GoSwissMapHeaderType map<string,int>
     - __kind: PointerType
-      ID: 102
+      ID: 84
       Name: '*map<string,int>'
       ByteSize: 8
-      Pointee: 103 GoSwissMapHeaderType map<string,int>
+      Pointee: 85 GoSwissMapHeaderType map<string,int>
     - __kind: GoSwissMapHeaderType
-      ID: 103
+      ID: 85
       Name: map<string,int>
       ByteSize: 48
       GoKind: 25
@@ -4126,10 +3950,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 104 PointerType **table<string,int>
+          Type: 86 PointerType **table<string,int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4145,20 +3969,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 253 GoSliceDataType []*table<string,int>.array
-      GroupType: 109 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 233 GoSliceDataType []*table<string,int>.array
+      GroupType: 91 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 104
+      ID: 86
       Name: '**table<string,int>'
       ByteSize: 8
-      Pointee: 105 PointerType *table<string,int>
+      Pointee: 87 PointerType *table<string,int>
     - __kind: PointerType
-      ID: 105
+      ID: 87
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 106 StructureType table<string,int>
+      Pointee: 88 StructureType table<string,int>
     - __kind: StructureType
-      ID: 106
+      ID: 88
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -4180,28 +4004,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 107 GoSwissMapGroupsType groupReference<string,int>
+          Type: 89 GoSwissMapGroupsType groupReference<string,int>
     - __kind: GoSwissMapGroupsType
-      ID: 107
+      ID: 89
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 108 PointerType *noalg.map.group[string]int
+          Type: 90 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 109 StructureType noalg.map.group[string]int
-      GroupSliceType: 254 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 91 StructureType noalg.map.group[string]int
+      GroupSliceType: 234 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
-      ID: 108
+      ID: 90
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 109 StructureType noalg.map.group[string]int
+      Pointee: 91 StructureType noalg.map.group[string]int
     - __kind: StructureType
-      ID: 109
+      ID: 91
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 1.278368e+06
@@ -4212,18 +4036,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 110 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 92 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: ArrayType
-      ID: 110
+      ID: 92
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 673664
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 111 StructureType noalg.struct { key string; elem int }
+      Element: 93 StructureType noalg.struct { key string; elem int }
     - __kind: StructureType
-      ID: 111
+      ID: 93
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 1.27824e+06
@@ -4236,19 +4060,19 @@ Types:
           Offset: 16
           Type: 1 BaseType int
     - __kind: GoMapType
-      ID: 112
+      ID: 94
       Name: map[string][]string
       ByteSize: 8
       GoRuntimeType: 1.117664e+06
       GoKind: 21
-      HeaderType: 114 GoSwissMapHeaderType map<string,[]string>
+      HeaderType: 96 GoSwissMapHeaderType map<string,[]string>
     - __kind: PointerType
-      ID: 113
+      ID: 95
       Name: '*map<string,[]string>'
       ByteSize: 8
-      Pointee: 114 GoSwissMapHeaderType map<string,[]string>
+      Pointee: 96 GoSwissMapHeaderType map<string,[]string>
     - __kind: GoSwissMapHeaderType
-      ID: 114
+      ID: 96
       Name: map<string,[]string>
       ByteSize: 48
       GoKind: 25
@@ -4258,10 +4082,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 115 PointerType **table<string,[]string>
+          Type: 97 PointerType **table<string,[]string>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4277,20 +4101,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 255 GoSliceDataType []*table<string,[]string>.array
-      GroupType: 120 StructureType noalg.map.group[string][]string
+      TablePtrSliceType: 235 GoSliceDataType []*table<string,[]string>.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
     - __kind: PointerType
-      ID: 115
+      ID: 97
       Name: '**table<string,[]string>'
       ByteSize: 8
-      Pointee: 116 PointerType *table<string,[]string>
+      Pointee: 98 PointerType *table<string,[]string>
     - __kind: PointerType
-      ID: 116
+      ID: 98
       Name: '*table<string,[]string>'
       ByteSize: 8
-      Pointee: 117 StructureType table<string,[]string>
+      Pointee: 99 StructureType table<string,[]string>
     - __kind: StructureType
-      ID: 117
+      ID: 99
       Name: table<string,[]string>
       ByteSize: 32
       GoKind: 25
@@ -4312,28 +4136,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 118 GoSwissMapGroupsType groupReference<string,[]string>
+          Type: 100 GoSwissMapGroupsType groupReference<string,[]string>
     - __kind: GoSwissMapGroupsType
-      ID: 118
+      ID: 100
       Name: groupReference<string,[]string>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 119 PointerType *noalg.map.group[string][]string
+          Type: 101 PointerType *noalg.map.group[string][]string
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 120 StructureType noalg.map.group[string][]string
-      GroupSliceType: 256 GoSliceDataType []noalg.map.group[string][]string.array
+      GroupType: 102 StructureType noalg.map.group[string][]string
+      GroupSliceType: 236 GoSliceDataType []noalg.map.group[string][]string.array
     - __kind: PointerType
-      ID: 119
+      ID: 101
       Name: '*noalg.map.group[string][]string'
       ByteSize: 8
-      Pointee: 120 StructureType noalg.map.group[string][]string
+      Pointee: 102 StructureType noalg.map.group[string][]string
     - __kind: StructureType
-      ID: 120
+      ID: 102
       Name: noalg.map.group[string][]string
       ByteSize: 328
       GoRuntimeType: 1.278112e+06
@@ -4344,18 +4168,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 121 ArrayType noalg.[8]struct { key string; elem []string }
+          Type: 103 ArrayType noalg.[8]struct { key string; elem []string }
     - __kind: ArrayType
-      ID: 121
+      ID: 103
       Name: noalg.[8]struct { key string; elem []string }
       ByteSize: 320
       GoRuntimeType: 673568
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 122 StructureType noalg.struct { key string; elem []string }
+      Element: 104 StructureType noalg.struct { key string; elem []string }
     - __kind: StructureType
-      ID: 122
+      ID: 104
       Name: noalg.struct { key string; elem []string }
       ByteSize: 40
       GoRuntimeType: 1.277984e+06
@@ -4366,9 +4190,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 123 GoSliceHeaderType []string
+          Type: 105 GoSliceHeaderType []string
     - __kind: GoSliceHeaderType
-      ID: 123
+      ID: 105
       Name: '[]string'
       ByteSize: 24
       GoRuntimeType: 478528
@@ -4383,21 +4207,21 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 257 GoSliceDataType []string.array
+      Data: 237 GoSliceDataType []string.array
     - __kind: GoMapType
-      ID: 124
+      ID: 106
       Name: map[[4]string][2]int
       ByteSize: 8
       GoRuntimeType: 1.117152e+06
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<[4]string,[2]int>
+      HeaderType: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: PointerType
-      ID: 125
+      ID: 107
       Name: '*map<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<[4]string,[2]int>
+      Pointee: 108 GoSwissMapHeaderType map<[4]string,[2]int>
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 108
       Name: map<[4]string,[2]int>
       ByteSize: 48
       GoKind: 25
@@ -4407,10 +4231,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<[4]string,[2]int>
+          Type: 109 PointerType **table<[4]string,[2]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4426,20 +4250,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 259 GoSliceDataType []*table<[4]string,[2]int>.array
-      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
+      TablePtrSliceType: 239 GoSliceDataType []*table<[4]string,[2]int>.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: PointerType
-      ID: 127
+      ID: 109
       Name: '**table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<[4]string,[2]int>
+      Pointee: 110 PointerType *table<[4]string,[2]int>
     - __kind: PointerType
-      ID: 128
+      ID: 110
       Name: '*table<[4]string,[2]int>'
       ByteSize: 8
-      Pointee: 129 StructureType table<[4]string,[2]int>
+      Pointee: 111 StructureType table<[4]string,[2]int>
     - __kind: StructureType
-      ID: 129
+      ID: 111
       Name: table<[4]string,[2]int>
       ByteSize: 32
       GoKind: 25
@@ -4461,28 +4285,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 130 GoSwissMapGroupsType groupReference<[4]string,[2]int>
+          Type: 112 GoSwissMapGroupsType groupReference<[4]string,[2]int>
     - __kind: GoSwissMapGroupsType
-      ID: 130
+      ID: 112
       Name: groupReference<[4]string,[2]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 131 PointerType *noalg.map.group[[4]string][2]int
+          Type: 113 PointerType *noalg.map.group[[4]string][2]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 132 StructureType noalg.map.group[[4]string][2]int
-      GroupSliceType: 260 GoSliceDataType []noalg.map.group[[4]string][2]int.array
+      GroupType: 114 StructureType noalg.map.group[[4]string][2]int
+      GroupSliceType: 240 GoSliceDataType []noalg.map.group[[4]string][2]int.array
     - __kind: PointerType
-      ID: 131
+      ID: 113
       Name: '*noalg.map.group[[4]string][2]int'
       ByteSize: 8
-      Pointee: 132 StructureType noalg.map.group[[4]string][2]int
+      Pointee: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: StructureType
-      ID: 132
+      ID: 114
       Name: noalg.map.group[[4]string][2]int
       ByteSize: 648
       GoRuntimeType: 1.277088e+06
@@ -4493,18 +4317,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 133 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
+          Type: 115 ArrayType noalg.[8]struct { key [4]string; elem [2]int }
     - __kind: ArrayType
-      ID: 133
+      ID: 115
       Name: noalg.[8]struct { key [4]string; elem [2]int }
       ByteSize: 640
       GoRuntimeType: 673184
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 134 StructureType noalg.struct { key [4]string; elem [2]int }
+      Element: 116 StructureType noalg.struct { key [4]string; elem [2]int }
     - __kind: StructureType
-      ID: 134
+      ID: 116
       Name: noalg.struct { key [4]string; elem [2]int }
       ByteSize: 80
       GoRuntimeType: 1.27696e+06
@@ -4512,12 +4336,12 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 135 ArrayType [4]string
+          Type: 117 ArrayType [4]string
         - Name: elem
           Offset: 64
           Type: 12 ArrayType [2]int
     - __kind: ArrayType
-      ID: 135
+      ID: 117
       Name: '[4]string'
       ByteSize: 64
       GoRuntimeType: 672992
@@ -4526,33 +4350,33 @@ Types:
       HasCount: true
       Element: 8 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 136
+      ID: 118
       Name: '[2]map[string]int'
       ByteSize: 16
       GoKind: 17
       Count: 2
       HasCount: true
-      Element: 101 GoMapType map[string]int
+      Element: 83 GoMapType map[string]int
     - __kind: PointerType
-      ID: 137
+      ID: 119
       Name: '*map[string]int'
       ByteSize: 8
       GoKind: 22
-      Pointee: 101 GoMapType map[string]int
+      Pointee: 83 GoMapType map[string]int
     - __kind: GoMapType
-      ID: 138
+      ID: 120
       Name: map[string][]main.structWithMap
       ByteSize: 8
       GoRuntimeType: 1.117536e+06
       GoKind: 21
-      HeaderType: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      HeaderType: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 139
+      ID: 121
       Name: '*map<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 140 GoSwissMapHeaderType map<string,[]main.structWithMap>
+      Pointee: 122 GoSwissMapHeaderType map<string,[]main.structWithMap>
     - __kind: GoSwissMapHeaderType
-      ID: 140
+      ID: 122
       Name: map<string,[]main.structWithMap>
       ByteSize: 48
       GoKind: 25
@@ -4562,10 +4386,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 141 PointerType **table<string,[]main.structWithMap>
+          Type: 123 PointerType **table<string,[]main.structWithMap>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4581,20 +4405,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 261 GoSliceDataType []*table<string,[]main.structWithMap>.array
-      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
+      TablePtrSliceType: 241 GoSliceDataType []*table<string,[]main.structWithMap>.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: PointerType
-      ID: 141
+      ID: 123
       Name: '**table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 142 PointerType *table<string,[]main.structWithMap>
+      Pointee: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: PointerType
-      ID: 142
+      ID: 124
       Name: '*table<string,[]main.structWithMap>'
       ByteSize: 8
-      Pointee: 143 StructureType table<string,[]main.structWithMap>
+      Pointee: 125 StructureType table<string,[]main.structWithMap>
     - __kind: StructureType
-      ID: 143
+      ID: 125
       Name: table<string,[]main.structWithMap>
       ByteSize: 32
       GoKind: 25
@@ -4616,28 +4440,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 144 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
+          Type: 126 GoSwissMapGroupsType groupReference<string,[]main.structWithMap>
     - __kind: GoSwissMapGroupsType
-      ID: 144
+      ID: 126
       Name: groupReference<string,[]main.structWithMap>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 145 PointerType *noalg.map.group[string][]main.structWithMap
+          Type: 127 PointerType *noalg.map.group[string][]main.structWithMap
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 146 StructureType noalg.map.group[string][]main.structWithMap
-      GroupSliceType: 262 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
+      GroupType: 128 StructureType noalg.map.group[string][]main.structWithMap
+      GroupSliceType: 242 GoSliceDataType []noalg.map.group[string][]main.structWithMap.array
     - __kind: PointerType
-      ID: 145
+      ID: 127
       Name: '*noalg.map.group[string][]main.structWithMap'
       ByteSize: 8
-      Pointee: 146 StructureType noalg.map.group[string][]main.structWithMap
+      Pointee: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: StructureType
-      ID: 146
+      ID: 128
       Name: noalg.map.group[string][]main.structWithMap
       ByteSize: 328
       GoRuntimeType: 1.277856e+06
@@ -4648,18 +4472,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 147 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
+          Type: 129 ArrayType noalg.[8]struct { key string; elem []main.structWithMap }
     - __kind: ArrayType
-      ID: 147
+      ID: 129
       Name: noalg.[8]struct { key string; elem []main.structWithMap }
       ByteSize: 320
       GoRuntimeType: 673472
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 148 StructureType noalg.struct { key string; elem []main.structWithMap }
+      Element: 130 StructureType noalg.struct { key string; elem []main.structWithMap }
     - __kind: StructureType
-      ID: 148
+      ID: 130
       Name: noalg.struct { key string; elem []main.structWithMap }
       ByteSize: 40
       GoRuntimeType: 1.277728e+06
@@ -4670,9 +4494,9 @@ Types:
           Type: 8 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 149 GoSliceHeaderType []main.structWithMap
+          Type: 131 GoSliceHeaderType []main.structWithMap
     - __kind: GoSliceHeaderType
-      ID: 149
+      ID: 131
       Name: '[]main.structWithMap'
       ByteSize: 24
       GoRuntimeType: 469760
@@ -4680,35 +4504,35 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 150 PointerType *main.structWithMap
+          Type: 132 PointerType *main.structWithMap
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 263 GoSliceDataType []main.structWithMap.array
+      Data: 243 GoSliceDataType []main.structWithMap.array
     - __kind: PointerType
-      ID: 150
+      ID: 132
       Name: '*main.structWithMap'
       ByteSize: 8
       GoRuntimeType: 380096
       GoKind: 22
-      Pointee: 77 StructureType main.structWithMap
+      Pointee: 58 StructureType main.structWithMap
     - __kind: GoMapType
-      ID: 151
+      ID: 133
       Name: map[bool]main.node
       ByteSize: 8
       GoRuntimeType: 1.11728e+06
       GoKind: 21
-      HeaderType: 153 GoSwissMapHeaderType map<bool,main.node>
+      HeaderType: 135 GoSwissMapHeaderType map<bool,main.node>
     - __kind: PointerType
-      ID: 152
+      ID: 134
       Name: '*map<bool,main.node>'
       ByteSize: 8
-      Pointee: 153 GoSwissMapHeaderType map<bool,main.node>
+      Pointee: 135 GoSwissMapHeaderType map<bool,main.node>
     - __kind: GoSwissMapHeaderType
-      ID: 153
+      ID: 135
       Name: map<bool,main.node>
       ByteSize: 48
       GoKind: 25
@@ -4718,10 +4542,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 154 PointerType **table<bool,main.node>
+          Type: 136 PointerType **table<bool,main.node>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4737,20 +4561,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 265 GoSliceDataType []*table<bool,main.node>.array
-      GroupType: 159 StructureType noalg.map.group[bool]main.node
+      TablePtrSliceType: 245 GoSliceDataType []*table<bool,main.node>.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
     - __kind: PointerType
-      ID: 154
+      ID: 136
       Name: '**table<bool,main.node>'
       ByteSize: 8
-      Pointee: 155 PointerType *table<bool,main.node>
+      Pointee: 137 PointerType *table<bool,main.node>
     - __kind: PointerType
-      ID: 155
+      ID: 137
       Name: '*table<bool,main.node>'
       ByteSize: 8
-      Pointee: 156 StructureType table<bool,main.node>
+      Pointee: 138 StructureType table<bool,main.node>
     - __kind: StructureType
-      ID: 156
+      ID: 138
       Name: table<bool,main.node>
       ByteSize: 32
       GoKind: 25
@@ -4772,28 +4596,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 157 GoSwissMapGroupsType groupReference<bool,main.node>
+          Type: 139 GoSwissMapGroupsType groupReference<bool,main.node>
     - __kind: GoSwissMapGroupsType
-      ID: 157
+      ID: 139
       Name: groupReference<bool,main.node>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 158 PointerType *noalg.map.group[bool]main.node
+          Type: 140 PointerType *noalg.map.group[bool]main.node
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 159 StructureType noalg.map.group[bool]main.node
-      GroupSliceType: 266 GoSliceDataType []noalg.map.group[bool]main.node.array
+      GroupType: 141 StructureType noalg.map.group[bool]main.node
+      GroupSliceType: 246 GoSliceDataType []noalg.map.group[bool]main.node.array
     - __kind: PointerType
-      ID: 158
+      ID: 140
       Name: '*noalg.map.group[bool]main.node'
       ByteSize: 8
-      Pointee: 159 StructureType noalg.map.group[bool]main.node
+      Pointee: 141 StructureType noalg.map.group[bool]main.node
     - __kind: StructureType
-      ID: 159
+      ID: 141
       Name: noalg.map.group[bool]main.node
       ByteSize: 200
       GoRuntimeType: 1.277344e+06
@@ -4804,18 +4628,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 160 ArrayType noalg.[8]struct { key bool; elem main.node }
+          Type: 142 ArrayType noalg.[8]struct { key bool; elem main.node }
     - __kind: ArrayType
-      ID: 160
+      ID: 142
       Name: noalg.[8]struct { key bool; elem main.node }
       ByteSize: 192
       GoRuntimeType: 673280
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 161 StructureType noalg.struct { key bool; elem main.node }
+      Element: 143 StructureType noalg.struct { key bool; elem main.node }
     - __kind: StructureType
-      ID: 161
+      ID: 143
       Name: noalg.struct { key bool; elem main.node }
       ByteSize: 24
       GoRuntimeType: 1.277216e+06
@@ -4826,9 +4650,9 @@ Types:
           Type: 11 BaseType bool
         - Name: elem
           Offset: 8
-          Type: 162 StructureType main.node
+          Type: 144 StructureType main.node
     - __kind: StructureType
-      ID: 162
+      ID: 144
       Name: main.node
       ByteSize: 16
       GoRuntimeType: 1.443232e+06
@@ -4839,28 +4663,28 @@ Types:
           Type: 1 BaseType int
         - Name: b
           Offset: 8
-          Type: 163 PointerType *main.node
+          Type: 145 PointerType *main.node
     - __kind: PointerType
-      ID: 163
+      ID: 145
       Name: '*main.node'
       ByteSize: 8
       GoRuntimeType: 380224
       GoKind: 22
-      Pointee: 162 StructureType main.node
+      Pointee: 144 StructureType main.node
     - __kind: GoMapType
-      ID: 164
+      ID: 146
       Name: map[int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117408e+06
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<int,uint8>
+      HeaderType: 148 GoSwissMapHeaderType map<int,uint8>
     - __kind: PointerType
-      ID: 165
+      ID: 147
       Name: '*map<int,uint8>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<int,uint8>
+      Pointee: 148 GoSwissMapHeaderType map<int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 148
       Name: map<int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -4870,10 +4694,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<int,uint8>
+          Type: 149 PointerType **table<int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -4889,20 +4713,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 267 GoSliceDataType []*table<int,uint8>.array
-      GroupType: 172 StructureType noalg.map.group[int]uint8
+      TablePtrSliceType: 247 GoSliceDataType []*table<int,uint8>.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
     - __kind: PointerType
-      ID: 167
+      ID: 149
       Name: '**table<int,uint8>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<int,uint8>
+      Pointee: 150 PointerType *table<int,uint8>
     - __kind: PointerType
-      ID: 168
+      ID: 150
       Name: '*table<int,uint8>'
       ByteSize: 8
-      Pointee: 169 StructureType table<int,uint8>
+      Pointee: 151 StructureType table<int,uint8>
     - __kind: StructureType
-      ID: 169
+      ID: 151
       Name: table<int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -4924,28 +4748,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 170 GoSwissMapGroupsType groupReference<int,uint8>
+          Type: 152 GoSwissMapGroupsType groupReference<int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 170
+      ID: 152
       Name: groupReference<int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 171 PointerType *noalg.map.group[int]uint8
+          Type: 153 PointerType *noalg.map.group[int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 172 StructureType noalg.map.group[int]uint8
-      GroupSliceType: 268 GoSliceDataType []noalg.map.group[int]uint8.array
+      GroupType: 154 StructureType noalg.map.group[int]uint8
+      GroupSliceType: 248 GoSliceDataType []noalg.map.group[int]uint8.array
     - __kind: PointerType
-      ID: 171
+      ID: 153
       Name: '*noalg.map.group[int]uint8'
       ByteSize: 8
-      Pointee: 172 StructureType noalg.map.group[int]uint8
+      Pointee: 154 StructureType noalg.map.group[int]uint8
     - __kind: StructureType
-      ID: 172
+      ID: 154
       Name: noalg.map.group[int]uint8
       ByteSize: 136
       GoRuntimeType: 1.2776e+06
@@ -4956,18 +4780,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 173 ArrayType noalg.[8]struct { key int; elem uint8 }
+          Type: 155 ArrayType noalg.[8]struct { key int; elem uint8 }
     - __kind: ArrayType
-      ID: 173
+      ID: 155
       Name: noalg.[8]struct { key int; elem uint8 }
       ByteSize: 128
       GoRuntimeType: 673376
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 174 StructureType noalg.struct { key int; elem uint8 }
+      Element: 156 StructureType noalg.struct { key int; elem uint8 }
     - __kind: StructureType
-      ID: 174
+      ID: 156
       Name: noalg.struct { key int; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 1.277472e+06
@@ -4980,19 +4804,19 @@ Types:
           Offset: 8
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 175
+      ID: 157
       Name: map[uint8]uint8
       ByteSize: 8
       GoRuntimeType: 1.118176e+06
       GoKind: 21
-      HeaderType: 177 GoSwissMapHeaderType map<uint8,uint8>
+      HeaderType: 159 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: PointerType
-      ID: 176
+      ID: 158
       Name: '*map<uint8,uint8>'
       ByteSize: 8
-      Pointee: 177 GoSwissMapHeaderType map<uint8,uint8>
+      Pointee: 159 GoSwissMapHeaderType map<uint8,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 177
+      ID: 159
       Name: map<uint8,uint8>
       ByteSize: 48
       GoKind: 25
@@ -5002,10 +4826,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 178 PointerType **table<uint8,uint8>
+          Type: 160 PointerType **table<uint8,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5021,20 +4845,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 269 GoSliceDataType []*table<uint8,uint8>.array
-      GroupType: 183 StructureType noalg.map.group[uint8]uint8
+      TablePtrSliceType: 249 GoSliceDataType []*table<uint8,uint8>.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: PointerType
-      ID: 178
+      ID: 160
       Name: '**table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 179 PointerType *table<uint8,uint8>
+      Pointee: 161 PointerType *table<uint8,uint8>
     - __kind: PointerType
-      ID: 179
+      ID: 161
       Name: '*table<uint8,uint8>'
       ByteSize: 8
-      Pointee: 180 StructureType table<uint8,uint8>
+      Pointee: 162 StructureType table<uint8,uint8>
     - __kind: StructureType
-      ID: 180
+      ID: 162
       Name: table<uint8,uint8>
       ByteSize: 32
       GoKind: 25
@@ -5056,28 +4880,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 181 GoSwissMapGroupsType groupReference<uint8,uint8>
+          Type: 163 GoSwissMapGroupsType groupReference<uint8,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 181
+      ID: 163
       Name: groupReference<uint8,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 182 PointerType *noalg.map.group[uint8]uint8
+          Type: 164 PointerType *noalg.map.group[uint8]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 183 StructureType noalg.map.group[uint8]uint8
-      GroupSliceType: 270 GoSliceDataType []noalg.map.group[uint8]uint8.array
+      GroupType: 165 StructureType noalg.map.group[uint8]uint8
+      GroupSliceType: 250 GoSliceDataType []noalg.map.group[uint8]uint8.array
     - __kind: PointerType
-      ID: 182
+      ID: 164
       Name: '*noalg.map.group[uint8]uint8'
       ByteSize: 8
-      Pointee: 183 StructureType noalg.map.group[uint8]uint8
+      Pointee: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: StructureType
-      ID: 183
+      ID: 165
       Name: noalg.map.group[uint8]uint8
       ByteSize: 24
       GoRuntimeType: 1.279136e+06
@@ -5088,18 +4912,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 184 ArrayType noalg.[8]struct { key uint8; elem uint8 }
+          Type: 166 ArrayType noalg.[8]struct { key uint8; elem uint8 }
     - __kind: ArrayType
-      ID: 184
+      ID: 166
       Name: noalg.[8]struct { key uint8; elem uint8 }
       ByteSize: 16
       GoRuntimeType: 673952
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 185 StructureType noalg.struct { key uint8; elem uint8 }
+      Element: 167 StructureType noalg.struct { key uint8; elem uint8 }
     - __kind: StructureType
-      ID: 185
+      ID: 167
       Name: noalg.struct { key uint8; elem uint8 }
       ByteSize: 2
       GoRuntimeType: 1.279008e+06
@@ -5112,19 +4936,19 @@ Types:
           Offset: 1
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 186
+      ID: 168
       Name: map[uint8][4]int
       ByteSize: 8
       GoRuntimeType: 1.118048e+06
       GoKind: 21
-      HeaderType: 188 GoSwissMapHeaderType map<uint8,[4]int>
+      HeaderType: 170 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: PointerType
-      ID: 187
+      ID: 169
       Name: '*map<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 188 GoSwissMapHeaderType map<uint8,[4]int>
+      Pointee: 170 GoSwissMapHeaderType map<uint8,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 188
+      ID: 170
       Name: map<uint8,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -5134,10 +4958,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 189 PointerType **table<uint8,[4]int>
+          Type: 171 PointerType **table<uint8,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5153,20 +4977,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 271 GoSliceDataType []*table<uint8,[4]int>.array
-      GroupType: 194 StructureType noalg.map.group[uint8][4]int
+      TablePtrSliceType: 251 GoSliceDataType []*table<uint8,[4]int>.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: PointerType
-      ID: 189
+      ID: 171
       Name: '**table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 190 PointerType *table<uint8,[4]int>
+      Pointee: 172 PointerType *table<uint8,[4]int>
     - __kind: PointerType
-      ID: 190
+      ID: 172
       Name: '*table<uint8,[4]int>'
       ByteSize: 8
-      Pointee: 191 StructureType table<uint8,[4]int>
+      Pointee: 173 StructureType table<uint8,[4]int>
     - __kind: StructureType
-      ID: 191
+      ID: 173
       Name: table<uint8,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -5188,28 +5012,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 192 GoSwissMapGroupsType groupReference<uint8,[4]int>
+          Type: 174 GoSwissMapGroupsType groupReference<uint8,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 192
+      ID: 174
       Name: groupReference<uint8,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 193 PointerType *noalg.map.group[uint8][4]int
+          Type: 175 PointerType *noalg.map.group[uint8][4]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 194 StructureType noalg.map.group[uint8][4]int
-      GroupSliceType: 272 GoSliceDataType []noalg.map.group[uint8][4]int.array
+      GroupType: 176 StructureType noalg.map.group[uint8][4]int
+      GroupSliceType: 252 GoSliceDataType []noalg.map.group[uint8][4]int.array
     - __kind: PointerType
-      ID: 193
+      ID: 175
       Name: '*noalg.map.group[uint8][4]int'
       ByteSize: 8
-      Pointee: 194 StructureType noalg.map.group[uint8][4]int
+      Pointee: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: StructureType
-      ID: 194
+      ID: 176
       Name: noalg.map.group[uint8][4]int
       ByteSize: 328
       GoRuntimeType: 1.27888e+06
@@ -5220,18 +5044,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 195 ArrayType noalg.[8]struct { key uint8; elem [4]int }
+          Type: 177 ArrayType noalg.[8]struct { key uint8; elem [4]int }
     - __kind: ArrayType
-      ID: 195
+      ID: 177
       Name: noalg.[8]struct { key uint8; elem [4]int }
       ByteSize: 320
       GoRuntimeType: 673856
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 196 StructureType noalg.struct { key uint8; elem [4]int }
+      Element: 178 StructureType noalg.struct { key uint8; elem [4]int }
     - __kind: StructureType
-      ID: 196
+      ID: 178
       Name: noalg.struct { key uint8; elem [4]int }
       ByteSize: 40
       GoRuntimeType: 1.278752e+06
@@ -5242,9 +5066,9 @@ Types:
           Type: 4 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
     - __kind: ArrayType
-      ID: 197
+      ID: 179
       Name: '[4]int'
       ByteSize: 32
       GoRuntimeType: 672704
@@ -5253,19 +5077,19 @@ Types:
       HasCount: true
       Element: 1 BaseType int
     - __kind: GoMapType
-      ID: 198
+      ID: 180
       Name: map[[4]int]uint8
       ByteSize: 8
       GoRuntimeType: 1.117024e+06
       GoKind: 21
-      HeaderType: 200 GoSwissMapHeaderType map<[4]int,uint8>
+      HeaderType: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: PointerType
-      ID: 199
+      ID: 181
       Name: '*map<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 200 GoSwissMapHeaderType map<[4]int,uint8>
+      Pointee: 182 GoSwissMapHeaderType map<[4]int,uint8>
     - __kind: GoSwissMapHeaderType
-      ID: 200
+      ID: 182
       Name: map<[4]int,uint8>
       ByteSize: 48
       GoKind: 25
@@ -5275,10 +5099,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 201 PointerType **table<[4]int,uint8>
+          Type: 183 PointerType **table<[4]int,uint8>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5294,20 +5118,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 273 GoSliceDataType []*table<[4]int,uint8>.array
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
+      TablePtrSliceType: 253 GoSliceDataType []*table<[4]int,uint8>.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: PointerType
-      ID: 201
+      ID: 183
       Name: '**table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 202 PointerType *table<[4]int,uint8>
+      Pointee: 184 PointerType *table<[4]int,uint8>
     - __kind: PointerType
-      ID: 202
+      ID: 184
       Name: '*table<[4]int,uint8>'
       ByteSize: 8
-      Pointee: 203 StructureType table<[4]int,uint8>
+      Pointee: 185 StructureType table<[4]int,uint8>
     - __kind: StructureType
-      ID: 203
+      ID: 185
       Name: table<[4]int,uint8>
       ByteSize: 32
       GoKind: 25
@@ -5329,28 +5153,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 204 GoSwissMapGroupsType groupReference<[4]int,uint8>
+          Type: 186 GoSwissMapGroupsType groupReference<[4]int,uint8>
     - __kind: GoSwissMapGroupsType
-      ID: 204
+      ID: 186
       Name: groupReference<[4]int,uint8>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 205 PointerType *noalg.map.group[[4]int]uint8
+          Type: 187 PointerType *noalg.map.group[[4]int]uint8
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 206 StructureType noalg.map.group[[4]int]uint8
-      GroupSliceType: 274 GoSliceDataType []noalg.map.group[[4]int]uint8.array
+      GroupType: 188 StructureType noalg.map.group[[4]int]uint8
+      GroupSliceType: 254 GoSliceDataType []noalg.map.group[[4]int]uint8.array
     - __kind: PointerType
-      ID: 205
+      ID: 187
       Name: '*noalg.map.group[[4]int]uint8'
       ByteSize: 8
-      Pointee: 206 StructureType noalg.map.group[[4]int]uint8
+      Pointee: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: StructureType
-      ID: 206
+      ID: 188
       Name: noalg.map.group[[4]int]uint8
       ByteSize: 328
       GoRuntimeType: 1.276832e+06
@@ -5361,18 +5185,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 207 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
+          Type: 189 ArrayType noalg.[8]struct { key [4]int; elem uint8 }
     - __kind: ArrayType
-      ID: 207
+      ID: 189
       Name: noalg.[8]struct { key [4]int; elem uint8 }
       ByteSize: 320
       GoRuntimeType: 672896
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 208 StructureType noalg.struct { key [4]int; elem uint8 }
+      Element: 190 StructureType noalg.struct { key [4]int; elem uint8 }
     - __kind: StructureType
-      ID: 208
+      ID: 190
       Name: noalg.struct { key [4]int; elem uint8 }
       ByteSize: 40
       GoRuntimeType: 1.276704e+06
@@ -5380,24 +5204,24 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
         - Name: elem
           Offset: 32
           Type: 4 BaseType uint8
     - __kind: GoMapType
-      ID: 209
+      ID: 191
       Name: map[[4]int][4]int
       ByteSize: 8
       GoRuntimeType: 1.116896e+06
       GoKind: 21
-      HeaderType: 211 GoSwissMapHeaderType map<[4]int,[4]int>
+      HeaderType: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: PointerType
-      ID: 210
+      ID: 192
       Name: '*map<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 211 GoSwissMapHeaderType map<[4]int,[4]int>
+      Pointee: 193 GoSwissMapHeaderType map<[4]int,[4]int>
     - __kind: GoSwissMapHeaderType
-      ID: 211
+      ID: 193
       Name: map<[4]int,[4]int>
       ByteSize: 48
       GoKind: 25
@@ -5407,10 +5231,10 @@ Types:
           Type: 26 BaseType uint64
         - Name: seed
           Offset: 8
-          Type: 44 BaseType uintptr
+          Type: 62 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 212 PointerType **table<[4]int,[4]int>
+          Type: 194 PointerType **table<[4]int,[4]int>
         - Name: dirLen
           Offset: 24
           Type: 1 BaseType int
@@ -5426,20 +5250,20 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 26 BaseType uint64
-      TablePtrSliceType: 275 GoSliceDataType []*table<[4]int,[4]int>.array
-      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
+      TablePtrSliceType: 255 GoSliceDataType []*table<[4]int,[4]int>.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: PointerType
-      ID: 212
+      ID: 194
       Name: '**table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 213 PointerType *table<[4]int,[4]int>
+      Pointee: 195 PointerType *table<[4]int,[4]int>
     - __kind: PointerType
-      ID: 213
+      ID: 195
       Name: '*table<[4]int,[4]int>'
       ByteSize: 8
-      Pointee: 214 StructureType table<[4]int,[4]int>
+      Pointee: 196 StructureType table<[4]int,[4]int>
     - __kind: StructureType
-      ID: 214
+      ID: 196
       Name: table<[4]int,[4]int>
       ByteSize: 32
       GoKind: 25
@@ -5461,28 +5285,28 @@ Types:
           Type: 1 BaseType int
         - Name: groups
           Offset: 16
-          Type: 215 GoSwissMapGroupsType groupReference<[4]int,[4]int>
+          Type: 197 GoSwissMapGroupsType groupReference<[4]int,[4]int>
     - __kind: GoSwissMapGroupsType
-      ID: 215
+      ID: 197
       Name: groupReference<[4]int,[4]int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 216 PointerType *noalg.map.group[[4]int][4]int
+          Type: 198 PointerType *noalg.map.group[[4]int][4]int
         - Name: lengthMask
           Offset: 8
           Type: 26 BaseType uint64
-      GroupType: 217 StructureType noalg.map.group[[4]int][4]int
-      GroupSliceType: 276 GoSliceDataType []noalg.map.group[[4]int][4]int.array
+      GroupType: 199 StructureType noalg.map.group[[4]int][4]int
+      GroupSliceType: 256 GoSliceDataType []noalg.map.group[[4]int][4]int.array
     - __kind: PointerType
-      ID: 216
+      ID: 198
       Name: '*noalg.map.group[[4]int][4]int'
       ByteSize: 8
-      Pointee: 217 StructureType noalg.map.group[[4]int][4]int
+      Pointee: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: StructureType
-      ID: 217
+      ID: 199
       Name: noalg.map.group[[4]int][4]int
       ByteSize: 520
       GoRuntimeType: 1.276576e+06
@@ -5493,18 +5317,18 @@ Types:
           Type: 26 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 218 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
+          Type: 200 ArrayType noalg.[8]struct { key [4]int; elem [4]int }
     - __kind: ArrayType
-      ID: 218
+      ID: 200
       Name: noalg.[8]struct { key [4]int; elem [4]int }
       ByteSize: 512
       GoRuntimeType: 672800
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 219 StructureType noalg.struct { key [4]int; elem [4]int }
+      Element: 201 StructureType noalg.struct { key [4]int; elem [4]int }
     - __kind: StructureType
-      ID: 219
+      ID: 201
       Name: noalg.struct { key [4]int; elem [4]int }
       ByteSize: 64
       GoRuntimeType: 1.276448e+06
@@ -5512,23 +5336,23 @@ Types:
       RawFields:
         - Name: key
           Offset: 0
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
         - Name: elem
           Offset: 32
-          Type: 197 ArrayType [4]int
+          Type: 179 ArrayType [4]int
     - __kind: GoChannelType
-      ID: 220
+      ID: 202
       Name: chan bool
       GoRuntimeType: 587168
       GoKind: 18
     - __kind: PointerType
-      ID: 221
+      ID: 203
       Name: '*main.structWithTwoValues'
       ByteSize: 8
       GoKind: 22
-      Pointee: 222 StructureType main.structWithTwoValues
+      Pointee: 204 StructureType main.structWithTwoValues
     - __kind: StructureType
-      ID: 222
+      ID: 204
       Name: main.structWithTwoValues
       ByteSize: 16
       GoKind: 25
@@ -5540,48 +5364,48 @@ Types:
           Offset: 8
           Type: 11 BaseType bool
     - __kind: PointerType
-      ID: 223
+      ID: 205
       Name: '*uint'
       ByteSize: 8
       GoRuntimeType: 385792
       GoKind: 22
       Pointee: 20 BaseType uint
     - __kind: PointerType
-      ID: 224
+      ID: 206
       Name: '*bool'
       ByteSize: 8
       GoRuntimeType: 386176
       GoKind: 22
       Pointee: 11 BaseType bool
     - __kind: PointerType
-      ID: 225
+      ID: 207
       Name: '*main.t'
       ByteSize: 8
       GoKind: 22
-      Pointee: 226 GoSliceHeaderType main.t
+      Pointee: 208 GoSliceHeaderType main.t
     - __kind: GoSliceHeaderType
-      ID: 226
+      ID: 208
       Name: main.t
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 227 PointerType **main.t
+          Type: 209 PointerType **main.t
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 277 GoSliceDataType main.t.array
+      Data: 257 GoSliceDataType main.t.array
     - __kind: PointerType
-      ID: 227
+      ID: 209
       Name: '**main.t'
       ByteSize: 8
-      Pointee: 225 PointerType *main.t
+      Pointee: 207 PointerType *main.t
     - __kind: GoSliceHeaderType
-      ID: 228
+      ID: 210
       Name: '[]uint'
       ByteSize: 24
       GoRuntimeType: 478016
@@ -5589,58 +5413,58 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 223 PointerType *uint
+          Type: 205 PointerType *uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 279 GoSliceDataType []uint.array
+      Data: 259 GoSliceDataType []uint.array
     - __kind: GoSliceHeaderType
-      ID: 229
+      ID: 211
       Name: '[][]uint'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 230 PointerType *[]uint
+          Type: 212 PointerType *[]uint
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 281 GoSliceDataType [][]uint.array
+      Data: 261 GoSliceDataType [][]uint.array
     - __kind: PointerType
-      ID: 230
+      ID: 212
       Name: '*[]uint'
       ByteSize: 8
-      Pointee: 228 GoSliceHeaderType []uint
+      Pointee: 210 GoSliceHeaderType []uint
     - __kind: GoSliceHeaderType
-      ID: 231
+      ID: 213
       Name: '[]main.structWithNoStrings'
       ByteSize: 24
       GoKind: 23
       RawFields:
         - Name: array
           Offset: 0
-          Type: 232 PointerType *main.structWithNoStrings
+          Type: 214 PointerType *main.structWithNoStrings
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 283 GoSliceDataType []main.structWithNoStrings.array
+      Data: 263 GoSliceDataType []main.structWithNoStrings.array
     - __kind: PointerType
-      ID: 232
+      ID: 214
       Name: '*main.structWithNoStrings'
       ByteSize: 8
-      Pointee: 233 StructureType main.structWithNoStrings
+      Pointee: 215 StructureType main.structWithNoStrings
     - __kind: StructureType
-      ID: 233
+      ID: 215
       Name: main.structWithNoStrings
       ByteSize: 2
       GoKind: 25
@@ -5652,7 +5476,7 @@ Types:
           Offset: 1
           Type: 11 BaseType bool
     - __kind: GoSliceHeaderType
-      ID: 234
+      ID: 216
       Name: '[]bool'
       ByteSize: 24
       GoRuntimeType: 478400
@@ -5660,16 +5484,16 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 224 PointerType *bool
+          Type: 206 PointerType *bool
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 285 GoSliceDataType []bool.array
+      Data: 265 GoSliceDataType []bool.array
     - __kind: GoSliceHeaderType
-      ID: 235
+      ID: 217
       Name: '[]uint16'
       ByteSize: 24
       GoRuntimeType: 477376
@@ -5677,23 +5501,23 @@ Types:
       RawFields:
         - Name: array
           Offset: 0
-          Type: 236 PointerType *uint16
+          Type: 218 PointerType *uint16
         - Name: len
           Offset: 8
           Type: 1 BaseType int
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 287 GoSliceDataType []uint16.array
+      Data: 267 GoSliceDataType []uint16.array
     - __kind: PointerType
-      ID: 236
+      ID: 218
       Name: '*uint16'
       ByteSize: 8
       GoRuntimeType: 385408
       GoKind: 22
       Pointee: 22 BaseType uint16
     - __kind: StructureType
-      ID: 237
+      ID: 219
       Name: main.threeStringStruct
       ByteSize: 48
       GoKind: 25
@@ -5708,19 +5532,19 @@ Types:
           Offset: 32
           Type: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 238
+      ID: 220
       Name: '*main.threeStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 237 StructureType main.threeStringStruct
+      Pointee: 219 StructureType main.threeStringStruct
     - __kind: PointerType
-      ID: 239
+      ID: 221
       Name: '*main.oneStringStruct'
       ByteSize: 8
       GoKind: 22
-      Pointee: 240 StructureType main.oneStringStruct
+      Pointee: 222 StructureType main.oneStringStruct
     - __kind: StructureType
-      ID: 240
+      ID: 222
       Name: main.oneStringStruct
       ByteSize: 16
       GoKind: 25
@@ -5729,7 +5553,7 @@ Types:
           Offset: 0
           Type: 8 GoStringHeaderType string
     - __kind: StructureType
-      ID: 241
+      ID: 223
       Name: main.aStruct
       ByteSize: 56
       GoKind: 25
@@ -5745,243 +5569,233 @@ Types:
           Type: 1 BaseType int
         - Name: nested
           Offset: 32
-          Type: 100 StructureType main.nestedStruct
+          Type: 82 StructureType main.nestedStruct
     - __kind: StructureType
-      ID: 242
+      ID: 224
       Name: main.emptyStruct
       GoKind: 25
       RawFields: []
     - __kind: GoStringDataType
-      ID: 243
+      ID: 225
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 244
+      ID: 226
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 243 GoStringDataType string.str
+      Pointee: 225 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 245
+      ID: 227
       Name: '[]*string.array'
       ByteSize: 2048
       Element: 36 PointerType *string
     - __kind: PointerType
-      ID: 246
+      ID: 228
       Name: '*[]*string.array'
       ByteSize: 8
-      Pointee: 245 GoSliceDataType []*string.array
+      Pointee: 227 GoSliceDataType []*string.array
     - __kind: GoSliceDataType
-      ID: 247
-      Name: '[]internal/abi.Imethod.array'
-      ByteSize: 2048
-      Element: 53 StructureType internal/abi.Imethod
-    - __kind: PointerType
-      ID: 248
-      Name: '*[]internal/abi.Imethod.array'
-      ByteSize: 8
-      Pointee: 247 GoSliceDataType []internal/abi.Imethod.array
-    - __kind: GoSliceDataType
-      ID: 249
+      ID: 229
       Name: '[]*table<int,int>.array'
       ByteSize: 8192
-      Element: 82 PointerType *table<int,int>
+      Element: 64 PointerType *table<int,int>
     - __kind: GoSliceDataType
-      ID: 250
+      ID: 230
       Name: '[]noalg.map.group[int]int.array'
       ByteSize: 2048
-      Element: 86 StructureType noalg.map.group[int]int
+      Element: 68 StructureType noalg.map.group[int]int
     - __kind: GoSliceDataType
-      ID: 251
+      ID: 231
       Name: '[]*table<string,main.nestedStruct>.array'
       ByteSize: 8192
-      Element: 93 PointerType *table<string,main.nestedStruct>
+      Element: 75 PointerType *table<string,main.nestedStruct>
     - __kind: GoSliceDataType
-      ID: 252
+      ID: 232
       Name: '[]noalg.map.group[string]main.nestedStruct.array'
       ByteSize: 2048
-      Element: 97 StructureType noalg.map.group[string]main.nestedStruct
+      Element: 79 StructureType noalg.map.group[string]main.nestedStruct
     - __kind: GoSliceDataType
-      ID: 253
+      ID: 233
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
-      Element: 105 PointerType *table<string,int>
+      Element: 87 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 254
+      ID: 234
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
-      Element: 109 StructureType noalg.map.group[string]int
+      Element: 91 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 255
+      ID: 235
       Name: '[]*table<string,[]string>.array'
       ByteSize: 8192
-      Element: 116 PointerType *table<string,[]string>
+      Element: 98 PointerType *table<string,[]string>
     - __kind: GoSliceDataType
-      ID: 256
+      ID: 236
       Name: '[]noalg.map.group[string][]string.array'
       ByteSize: 2048
-      Element: 120 StructureType noalg.map.group[string][]string
+      Element: 102 StructureType noalg.map.group[string][]string
     - __kind: GoSliceDataType
-      ID: 257
+      ID: 237
       Name: '[]string.array'
       ByteSize: 2048
       Element: 8 GoStringHeaderType string
     - __kind: PointerType
-      ID: 258
+      ID: 238
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 257 GoSliceDataType []string.array
+      Pointee: 237 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 259
+      ID: 239
       Name: '[]*table<[4]string,[2]int>.array'
       ByteSize: 8192
-      Element: 128 PointerType *table<[4]string,[2]int>
+      Element: 110 PointerType *table<[4]string,[2]int>
     - __kind: GoSliceDataType
-      ID: 260
+      ID: 240
       Name: '[]noalg.map.group[[4]string][2]int.array'
       ByteSize: 2048
-      Element: 132 StructureType noalg.map.group[[4]string][2]int
+      Element: 114 StructureType noalg.map.group[[4]string][2]int
     - __kind: GoSliceDataType
-      ID: 261
+      ID: 241
       Name: '[]*table<string,[]main.structWithMap>.array'
       ByteSize: 8192
-      Element: 142 PointerType *table<string,[]main.structWithMap>
+      Element: 124 PointerType *table<string,[]main.structWithMap>
     - __kind: GoSliceDataType
-      ID: 262
+      ID: 242
       Name: '[]noalg.map.group[string][]main.structWithMap.array'
       ByteSize: 2048
-      Element: 146 StructureType noalg.map.group[string][]main.structWithMap
+      Element: 128 StructureType noalg.map.group[string][]main.structWithMap
     - __kind: GoSliceDataType
-      ID: 263
+      ID: 243
       Name: '[]main.structWithMap.array'
       ByteSize: 2048
-      Element: 77 StructureType main.structWithMap
+      Element: 58 StructureType main.structWithMap
     - __kind: PointerType
-      ID: 264
+      ID: 244
       Name: '*[]main.structWithMap.array'
       ByteSize: 8
-      Pointee: 263 GoSliceDataType []main.structWithMap.array
+      Pointee: 243 GoSliceDataType []main.structWithMap.array
     - __kind: GoSliceDataType
-      ID: 265
+      ID: 245
       Name: '[]*table<bool,main.node>.array'
       ByteSize: 8192
-      Element: 155 PointerType *table<bool,main.node>
+      Element: 137 PointerType *table<bool,main.node>
     - __kind: GoSliceDataType
-      ID: 266
+      ID: 246
       Name: '[]noalg.map.group[bool]main.node.array'
       ByteSize: 2048
-      Element: 159 StructureType noalg.map.group[bool]main.node
+      Element: 141 StructureType noalg.map.group[bool]main.node
     - __kind: GoSliceDataType
-      ID: 267
+      ID: 247
       Name: '[]*table<int,uint8>.array'
       ByteSize: 8192
-      Element: 168 PointerType *table<int,uint8>
+      Element: 150 PointerType *table<int,uint8>
     - __kind: GoSliceDataType
-      ID: 268
+      ID: 248
       Name: '[]noalg.map.group[int]uint8.array'
       ByteSize: 2048
-      Element: 172 StructureType noalg.map.group[int]uint8
+      Element: 154 StructureType noalg.map.group[int]uint8
     - __kind: GoSliceDataType
-      ID: 269
+      ID: 249
       Name: '[]*table<uint8,uint8>.array'
       ByteSize: 8192
-      Element: 179 PointerType *table<uint8,uint8>
+      Element: 161 PointerType *table<uint8,uint8>
     - __kind: GoSliceDataType
-      ID: 270
+      ID: 250
       Name: '[]noalg.map.group[uint8]uint8.array'
       ByteSize: 2048
-      Element: 183 StructureType noalg.map.group[uint8]uint8
+      Element: 165 StructureType noalg.map.group[uint8]uint8
     - __kind: GoSliceDataType
-      ID: 271
+      ID: 251
       Name: '[]*table<uint8,[4]int>.array'
       ByteSize: 8192
-      Element: 190 PointerType *table<uint8,[4]int>
+      Element: 172 PointerType *table<uint8,[4]int>
     - __kind: GoSliceDataType
-      ID: 272
+      ID: 252
       Name: '[]noalg.map.group[uint8][4]int.array'
       ByteSize: 2048
-      Element: 194 StructureType noalg.map.group[uint8][4]int
+      Element: 176 StructureType noalg.map.group[uint8][4]int
     - __kind: GoSliceDataType
-      ID: 273
+      ID: 253
       Name: '[]*table<[4]int,uint8>.array'
       ByteSize: 8192
-      Element: 202 PointerType *table<[4]int,uint8>
+      Element: 184 PointerType *table<[4]int,uint8>
     - __kind: GoSliceDataType
-      ID: 274
+      ID: 254
       Name: '[]noalg.map.group[[4]int]uint8.array'
       ByteSize: 2048
-      Element: 206 StructureType noalg.map.group[[4]int]uint8
+      Element: 188 StructureType noalg.map.group[[4]int]uint8
     - __kind: GoSliceDataType
-      ID: 275
+      ID: 255
       Name: '[]*table<[4]int,[4]int>.array'
       ByteSize: 8192
-      Element: 213 PointerType *table<[4]int,[4]int>
+      Element: 195 PointerType *table<[4]int,[4]int>
     - __kind: GoSliceDataType
-      ID: 276
+      ID: 256
       Name: '[]noalg.map.group[[4]int][4]int.array'
       ByteSize: 2048
-      Element: 217 StructureType noalg.map.group[[4]int][4]int
+      Element: 199 StructureType noalg.map.group[[4]int][4]int
     - __kind: GoSliceDataType
-      ID: 277
+      ID: 257
       Name: main.t.array
       ByteSize: 2048
-      Element: 225 PointerType *main.t
+      Element: 207 PointerType *main.t
     - __kind: PointerType
-      ID: 278
+      ID: 258
       Name: '*main.t.array'
       ByteSize: 8
-      Pointee: 277 GoSliceDataType main.t.array
+      Pointee: 257 GoSliceDataType main.t.array
     - __kind: GoSliceDataType
-      ID: 279
+      ID: 259
       Name: '[]uint.array'
       ByteSize: 2048
       Element: 20 BaseType uint
     - __kind: PointerType
-      ID: 280
+      ID: 260
       Name: '*[]uint.array'
       ByteSize: 8
-      Pointee: 279 GoSliceDataType []uint.array
+      Pointee: 259 GoSliceDataType []uint.array
     - __kind: GoSliceDataType
-      ID: 281
+      ID: 261
       Name: '[][]uint.array'
       ByteSize: 2048
-      Element: 228 GoSliceHeaderType []uint
+      Element: 210 GoSliceHeaderType []uint
     - __kind: PointerType
-      ID: 282
+      ID: 262
       Name: '*[][]uint.array'
       ByteSize: 8
-      Pointee: 281 GoSliceDataType [][]uint.array
+      Pointee: 261 GoSliceDataType [][]uint.array
     - __kind: GoSliceDataType
-      ID: 283
+      ID: 263
       Name: '[]main.structWithNoStrings.array'
       ByteSize: 2048
-      Element: 233 StructureType main.structWithNoStrings
+      Element: 215 StructureType main.structWithNoStrings
     - __kind: PointerType
-      ID: 284
+      ID: 264
       Name: '*[]main.structWithNoStrings.array'
       ByteSize: 8
-      Pointee: 283 GoSliceDataType []main.structWithNoStrings.array
+      Pointee: 263 GoSliceDataType []main.structWithNoStrings.array
     - __kind: GoSliceDataType
-      ID: 285
+      ID: 265
       Name: '[]bool.array'
       ByteSize: 2048
       Element: 11 BaseType bool
     - __kind: PointerType
-      ID: 286
+      ID: 266
       Name: '*[]bool.array'
       ByteSize: 8
-      Pointee: 285 GoSliceDataType []bool.array
+      Pointee: 265 GoSliceDataType []bool.array
     - __kind: GoSliceDataType
-      ID: 287
+      ID: 267
       Name: '[]uint16.array'
       ByteSize: 2048
       Element: 22 BaseType uint16
     - __kind: PointerType
-      ID: 288
+      ID: 268
       Name: '*[]uint16.array'
       ByteSize: 8
-      Pointee: 287 GoSliceDataType []uint16.array
+      Pointee: 267 GoSliceDataType []uint16.array
     - __kind: EventRootType
-      ID: 289
+      ID: 269
       Name: Probe[main.testByteArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -5996,7 +5810,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 290
+      ID: 270
       Name: Probe[main.testRuneArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6011,7 +5825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 271
       Name: Probe[main.testStringArray]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6026,7 +5840,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 292
+      ID: 272
       Name: Probe[main.testBoolArray]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6041,7 +5855,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 293
+      ID: 273
       Name: Probe[main.testIntArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6056,7 +5870,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 274
       Name: Probe[main.testInt8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6071,7 +5885,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 295
+      ID: 275
       Name: Probe[main.testInt16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6086,7 +5900,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 296
+      ID: 276
       Name: Probe[main.testInt32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6101,7 +5915,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 277
       Name: Probe[main.testInt64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6116,7 +5930,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 278
       Name: Probe[main.testUintArray]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6131,7 +5945,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 279
       Name: Probe[main.testUint8Array]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6146,7 +5960,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 300
+      ID: 280
       Name: Probe[main.testUint16Array]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6161,7 +5975,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 301
+      ID: 281
       Name: Probe[main.testUint32Array]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6176,7 +5990,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 282
       Name: Probe[main.testUint64Array]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6191,7 +6005,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 283
       Name: Probe[main.testArrayOfArrays]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6206,7 +6020,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 304
+      ID: 284
       Name: Probe[main.testArrayOfStrings]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -6221,7 +6035,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 305
+      ID: 285
       Name: Probe[main.testArrayOfArraysOfArrays]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6236,7 +6050,7 @@ Types:
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 306
+      ID: 286
       Name: Probe[main.testVeryLargeArray]
       ByteSize: 801
       PresenceBitsetSize: 1
@@ -6251,7 +6065,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 307
+      ID: 287
       Name: Probe[main.testSingleByte]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6266,7 +6080,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 308
+      ID: 288
       Name: Probe[main.testSingleRune]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6281,7 +6095,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 309
+      ID: 289
       Name: Probe[main.testSingleBool]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6296,7 +6110,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 310
+      ID: 290
       Name: Probe[main.testSingleInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6311,7 +6125,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 291
       Name: Probe[main.testSingleInt8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6326,7 +6140,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 312
+      ID: 292
       Name: Probe[main.testSingleInt16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6341,7 +6155,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 313
+      ID: 293
       Name: Probe[main.testSingleInt32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6356,7 +6170,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 314
+      ID: 294
       Name: Probe[main.testSingleInt64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6371,7 +6185,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 295
       Name: Probe[main.testSingleUint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6386,7 +6200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 296
       Name: Probe[main.testSingleUint8]
       ByteSize: 2
       PresenceBitsetSize: 1
@@ -6401,7 +6215,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 317
+      ID: 297
       Name: Probe[main.testSingleUint16]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6416,7 +6230,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 318
+      ID: 298
       Name: Probe[main.testSingleUint32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6431,7 +6245,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 319
+      ID: 299
       Name: Probe[main.testSingleUint64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6446,7 +6260,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 300
       Name: Probe[main.testSingleFloat32]
       ByteSize: 5
       PresenceBitsetSize: 1
@@ -6461,7 +6275,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 321
+      ID: 301
       Name: Probe[main.testSingleFloat64]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6476,7 +6290,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 302
       Name: Probe[main.testTypeAlias]
       ByteSize: 3
       PresenceBitsetSize: 1
@@ -6491,7 +6305,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 323
+      ID: 303
       Name: Probe[main.testBigStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -6506,7 +6320,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 324
+      ID: 304
       Name: Probe[main.testEsotericStack]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -6514,14 +6328,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 57 StructureType main.esotericStack
+            Type: 39 StructureType main.esotericStack
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 42, index: 0, name: e}
                   Offset: 0
                   ByteSize: 64
     - __kind: EventRootType
-      ID: 325
+      ID: 305
       Name: Probe[main.testEsotericHeap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6529,14 +6343,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 63 PointerType *main.esotericHeap
+            Type: 44 PointerType *main.esotericHeap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 43, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 306
       Name: Probe[main.testInlinedBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6551,7 +6365,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 307
       Name: Probe[main.testInlinedBB]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6575,7 +6389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 308
       Name: Probe[main.testInlinedBBA]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6590,10 +6404,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 309
       Name: Probe[main.testInlinedBC]
     - __kind: EventRootType
-      ID: 330
+      ID: 310
       Name: Probe[main.testFrameless]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6608,7 +6422,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 311
       Name: Probe[main.testFramelessArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -6623,7 +6437,7 @@ Types:
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 332
+      ID: 312
       Name: Probe[main.testInterface]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6631,14 +6445,14 @@ Types:
         - Name: b
           Offset: 1
           Expression:
-            Type: 75 GoInterfaceType main.behavior
+            Type: 56 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 50, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 333
+      ID: 313
       Name: Probe[main.testAny]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6646,14 +6460,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 59 GoEmptyInterfaceType interface {}
+            Type: 41 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 51, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 334
+      ID: 314
       Name: Probe[main.testError]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6661,14 +6475,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 76 GoInterfaceType error
+            Type: 57 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 52, index: 0, name: e}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 315
       Name: Probe[main.testStructWithMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6676,14 +6490,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 77 StructureType main.structWithMap
+            Type: 58 StructureType main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 53, index: 0, name: s}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 316
       Name: Probe[main.testMapStringToStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6691,14 +6505,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 89 GoMapType map[string]main.nestedStruct
+            Type: 71 GoMapType map[string]main.nestedStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 54, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 317
       Name: Probe[main.testMapStringToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6706,14 +6520,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 83 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 55, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 318
       Name: Probe[main.testMapStringToSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6721,14 +6535,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 112 GoMapType map[string][]string
+            Type: 94 GoMapType map[string][]string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 56, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 319
       Name: Probe[main.testMapArrayToArray]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6736,14 +6550,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 124 GoMapType map[[4]string][2]int
+            Type: 106 GoMapType map[[4]string][2]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 57, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 320
       Name: Probe[main.testSmallMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6751,14 +6565,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 101 GoMapType map[string]int
+            Type: 83 GoMapType map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 58, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 321
       Name: Probe[main.testArrayOfMaps]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6766,14 +6580,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 136 ArrayType [2]map[string]int
+            Type: 118 ArrayType [2]map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 59, index: 0, name: m}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 322
       Name: Probe[main.testPointerToMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6781,14 +6595,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 137 PointerType *map[string]int
+            Type: 119 PointerType *map[string]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 60, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 323
       Name: Probe[main.testMapIntToInt]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6796,14 +6610,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 78 GoMapType map[int]int
+            Type: 59 GoMapType map[int]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 61, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 324
       Name: Probe[main.testMapMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6811,14 +6625,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 62, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 325
       Name: Probe[main.testMapEmbeddedMaps]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6826,14 +6640,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 138 GoMapType map[string][]main.structWithMap
+            Type: 120 GoMapType map[string][]main.structWithMap
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 63, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 326
       Name: Probe[main.testMapWithLinkedList]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6841,14 +6655,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 151 GoMapType map[bool]main.node
+            Type: 133 GoMapType map[bool]main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 64, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 327
       Name: Probe[main.testMapWithSmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6856,14 +6670,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[int]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 65, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 328
       Name: Probe[main.testMapWithSmallValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6871,14 +6685,14 @@ Types:
         - Name: redactMyEntries
           Offset: 1
           Expression:
-            Type: 164 GoMapType map[int]uint8
+            Type: 146 GoMapType map[int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 66, index: 0, name: redactMyEntries}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 329
       Name: Probe[main.testMapWithSmallKeyAndValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6886,14 +6700,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 67, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 330
       Name: Probe[main.testMapWithSmallKeyAndValueMassive]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6901,14 +6715,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 68, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 331
       Name: Probe[main.testMapSmallKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6916,14 +6730,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 175 GoMapType map[uint8]uint8
+            Type: 157 GoMapType map[uint8]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 69, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 332
       Name: Probe[main.testMapSmallKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6931,14 +6745,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 186 GoMapType map[uint8][4]int
+            Type: 168 GoMapType map[uint8][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 70, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 353
+      ID: 333
       Name: Probe[main.testMapLargeKeySmallValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6946,14 +6760,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 198 GoMapType map[[4]int]uint8
+            Type: 180 GoMapType map[[4]int]uint8
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 71, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 334
       Name: Probe[main.testMapLargeKeyLargeValue]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6961,14 +6775,14 @@ Types:
         - Name: m
           Offset: 1
           Expression:
-            Type: 209 GoMapType map[[4]int][4]int
+            Type: 191 GoMapType map[[4]int][4]int
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 72, index: 0, name: m}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 335
       Name: Probe[main.testCombinedByte]
       ByteSize: 7
       PresenceBitsetSize: 1
@@ -7001,7 +6815,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 356
+      ID: 336
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -7052,7 +6866,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 357
+      ID: 337
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7060,14 +6874,14 @@ Types:
         - Name: c
           Offset: 1
           Expression:
-            Type: 220 GoChannelType chan bool
+            Type: 202 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 75, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 358
+      ID: 338
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7075,14 +6889,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 221 PointerType *main.structWithTwoValues
+            Type: 203 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 76, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 339
       Name: Probe[main.testLinkedList]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7090,14 +6904,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 162 StructureType main.node
+            Type: 144 StructureType main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 77, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 360
+      ID: 340
       Name: Probe[main.testPointerLoop]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7105,14 +6919,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 163 PointerType *main.node
+            Type: 145 PointerType *main.node
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 78, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 341
       Name: Probe[main.testUnsafePointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7120,14 +6934,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 56 VoidPointerType unsafe.Pointer
+            Type: 38 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 79, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 342
       Name: Probe[main.testUintPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7135,14 +6949,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 223 PointerType *uint
+            Type: 205 PointerType *uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 80, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 363
+      ID: 343
       Name: Probe[main.testStringPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7157,7 +6971,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 364
+      ID: 344
       Name: Probe[main.testNilPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7165,7 +6979,7 @@ Types:
         - Name: z
           Offset: 1
           Expression:
-            Type: 224 PointerType *bool
+            Type: 206 PointerType *bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 82, index: 0, name: z}
@@ -7181,7 +6995,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 345
       Name: Probe[main.testCycle]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7189,14 +7003,14 @@ Types:
         - Name: t
           Offset: 1
           Expression:
-            Type: 225 PointerType *main.t
+            Type: 207 PointerType *main.t
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 83, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 366
+      ID: 346
       Name: Probe[main.testUintSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7204,14 +7018,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 84, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 367
+      ID: 347
       Name: Probe[main.testEmptySlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7219,14 +7033,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 85, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 368
+      ID: 348
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7234,14 +7048,14 @@ Types:
         - Name: u
           Offset: 1
           Expression:
-            Type: 229 GoSliceHeaderType [][]uint
+            Type: 211 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 86, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 369
+      ID: 349
       Name: Probe[main.testStructSlice]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7249,7 +7063,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 87, index: 0, name: xs}
@@ -7265,7 +7079,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 350
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7273,7 +7087,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 88, index: 0, name: xs}
@@ -7289,7 +7103,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 371
+      ID: 351
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -7297,7 +7111,7 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 231 GoSliceHeaderType []main.structWithNoStrings
+            Type: 213 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 89, index: 0, name: xs}
@@ -7313,7 +7127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 352
       Name: Probe[main.testStringSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7321,14 +7135,14 @@ Types:
         - Name: s
           Offset: 1
           Expression:
-            Type: 123 GoSliceHeaderType []string
+            Type: 105 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 90, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 373
+      ID: 353
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 34
       PresenceBitsetSize: 1
@@ -7345,7 +7159,7 @@ Types:
         - Name: s
           Offset: 2
           Expression:
-            Type: 234 GoSliceHeaderType []bool
+            Type: 216 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 91, index: 1, name: s}
@@ -7361,7 +7175,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 374
+      ID: 354
       Name: Probe[main.testNilSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7369,14 +7183,14 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 235 GoSliceHeaderType []uint16
+            Type: 217 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 92, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 375
+      ID: 355
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -7384,17 +7198,17 @@ Types:
         - Name: xs
           Offset: 1
           Expression:
-            Type: 228 GoSliceHeaderType []uint
+            Type: 210 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 93, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 376
+      ID: 356
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 377
+      ID: 357
       Name: Probe[main.testSingleString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7409,7 +7223,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 378
+      ID: 358
       Name: Probe[main.testThreeStrings]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7442,7 +7256,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 379
+      ID: 359
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -7450,14 +7264,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 237 StructureType main.threeStringStruct
+            Type: 219 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 97, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 380
+      ID: 360
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7465,14 +7279,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 238 PointerType *main.threeStringStruct
+            Type: 220 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 98, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 381
+      ID: 361
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7480,14 +7294,14 @@ Types:
         - Name: a
           Offset: 1
           Expression:
-            Type: 239 PointerType *main.oneStringStruct
+            Type: 221 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 99, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 382
+      ID: 362
       Name: Probe[main.testMassiveString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7502,7 +7316,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 383
+      ID: 363
       Name: Probe[main.testUnitializedString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7517,7 +7331,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 384
+      ID: 364
       Name: Probe[main.testEmptyString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -7532,7 +7346,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 385
+      ID: 365
       Name: Probe[main.testStruct]
       ByteSize: 57
       PresenceBitsetSize: 1
@@ -7540,14 +7354,14 @@ Types:
         - Name: x
           Offset: 1
           Expression:
-            Type: 241 StructureType main.aStruct
+            Type: 223 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 103, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 386
+      ID: 366
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -7555,14 +7369,14 @@ Types:
         - Name: e
           Offset: 1
           Expression:
-            Type: 242 StructureType main.emptyStruct
+            Type: 224 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 104, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
-      ID: 387
+      ID: 367
       Name: Probe[main.testInlinedPrint]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7577,16 +7391,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 388
+      ID: 368
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
-      ID: 389
+      ID: 369
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 390
+      ID: 370
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 391
+      ID: 371
       Name: Probe[main.testInlinedSq]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7601,7 +7415,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 392
+      ID: 372
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -7615,5 +7429,5 @@ Types:
                   Variable: {subprogram: 6, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
-MaxTypeID: 392
+MaxTypeID: 372
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1159,3 +1159,4 @@ Types:
                   ByteSize: 8
 MaxTypeID: 86
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x572240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 11
-          Type: 62 EventRootType Probe[main.PointerChainArg]
+          Type: 85 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 12
-          Type: 63 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 86 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6050", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 9
-          Type: 60 EventRootType Probe[main.bigMapArg]
+          Type: 83 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a64f3", Frameless: false}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 10
-          Type: 61 EventRootType Probe[main.inlined]
+          Type: 84 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a63ca"
               Frameless: false
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 1
-          Type: 52 EventRootType Probe[main.intArg]
+          Type: 75 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a60aa", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 4
-          Type: 55 EventRootType Probe[main.intArrayArg]
+          Type: 78 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a622a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 7
-          Type: 58 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 81 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a63a0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 3
-          Type: 54 EventRootType Probe[main.intSliceArg]
+          Type: 77 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a61aa", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 8
-          Type: 59 EventRootType Probe[main.mapArg]
+          Type: 82 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a648a", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 2
-          Type: 53 EventRootType Probe[main.stringArg]
+          Type: 76 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a612a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 6
-          Type: 57 EventRootType Probe[main.stringArrayArg]
+          Type: 80 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a632a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 5
-          Type: 56 EventRootType Probe[main.stringSliceArg]
+          Type: 79 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a62aa", Frameless: false}]
           Condition: null
 Subprograms:
@@ -391,11 +391,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 43 PointerType *string.str
+          Type: 66 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 42 GoStringDataType string.str
+      Data: 65 GoStringDataType string.str
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -425,7 +425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 44 GoSliceDataType []int.array
+      Data: 67 GoSliceDataType []int.array
     - __kind: ArrayType
       ID: 11
       Name: '[3]int'
@@ -451,7 +451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 46 GoSliceDataType []string.array
+      Data: 69 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 13
       Name: '*string'
@@ -513,7 +513,7 @@ Types:
           Offset: 40
           Type: 26 PointerType *runtime.mapextra
       BucketType: 21 GoHMapBucketType bucket<string,int>
-      BucketsType: 48 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 71 GoSliceDataType []bucket<string,int>.array
     - __kind: BaseType
       ID: 18
       Name: uint16
@@ -625,7 +625,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 49 GoSliceDataType []*runtime.bmap.array
+      Data: 72 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 30
       Name: '**runtime.bmap'
@@ -693,7 +693,7 @@ Types:
           Offset: 40
           Type: 26 PointerType *runtime.mapextra
       BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 51 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 74 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: PointerType
       ID: 36
       Name: '*bucket<string,main.bigStruct>'
@@ -772,57 +772,213 @@ Types:
       Count: 128
       HasCount: true
       Element: 9 BaseType uint8
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 42
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 38464
+      GoKind: 1
+    - __kind: PointerType
+      ID: 43
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26944
+      GoKind: 22
+      Pointee: 42 BaseType bool
+    - __kind: PointerType
+      ID: 44
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26624
+      GoKind: 22
+      Pointee: 25 BaseType uintptr
+    - __kind: BaseType
+      ID: 45
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 37952
+      GoKind: 11
+    - __kind: BaseType
+      ID: 46
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37760
+      GoKind: 5
+    - __kind: BaseType
+      ID: 47
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 37888
+      GoKind: 6
+    - __kind: BaseType
+      ID: 48
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 37504
+      GoKind: 3
+    - __kind: BaseType
+      ID: 49
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 38080
+      GoKind: 7
+    - __kind: BaseType
+      ID: 50
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 38336
+      GoKind: 13
+    - __kind: BaseType
+      ID: 51
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 38400
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 52
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 59008
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 53 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 53 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 53
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 38528
+      GoKind: 26
+    - __kind: PointerType
+      ID: 54
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26240
+      GoKind: 22
+      Pointee: 46 BaseType int32
+    - __kind: PointerType
+      ID: 55
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26304
+      GoKind: 22
+      Pointee: 19 BaseType uint32
+    - __kind: BaseType
+      ID: 56
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 38208
+      GoKind: 15
+    - __kind: BaseType
+      ID: 57
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 38272
+      GoKind: 16
+    - __kind: PointerType
+      ID: 58
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26880
+      GoKind: 22
+      Pointee: 51 BaseType float64
+    - __kind: PointerType
+      ID: 59
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26368
+      GoKind: 22
+      Pointee: 47 BaseType int64
+    - __kind: PointerType
+      ID: 60
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26432
+      GoKind: 22
+      Pointee: 45 BaseType uint64
+    - __kind: PointerType
+      ID: 61
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25856
+      GoKind: 22
+      Pointee: 52 GoInterfaceType error
+    - __kind: PointerType
+      ID: 62
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26816
+      GoKind: 22
+      Pointee: 50 BaseType float32
+    - __kind: PointerType
+      ID: 63
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26560
+      GoKind: 22
+      Pointee: 49 BaseType uint
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 26176
+      GoKind: 22
+      Pointee: 18 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 65
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 43
+      ID: 66
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 42 GoStringDataType string.str
+      Pointee: 65 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 44
+      ID: 67
       Name: '[]int.array'
       ByteSize: 2048
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 45
+      ID: 68
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 44 GoSliceDataType []int.array
+      Pointee: 67 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 46
+      ID: 69
       Name: '[]string.array'
       ByteSize: 2048
       Element: 7 GoStringHeaderType string
     - __kind: PointerType
-      ID: 47
+      ID: 70
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 46 GoSliceDataType []string.array
+      Pointee: 69 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 48
+      ID: 71
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 21 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 49
+      ID: 72
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 31 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 50
+      ID: 73
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 49 GoSliceDataType []*runtime.bmap.array
+      Pointee: 72 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 51
+      ID: 74
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: EventRootType
-      ID: 52
+      ID: 75
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -837,7 +993,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 53
+      ID: 76
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -852,7 +1008,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 54
+      ID: 77
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -867,7 +1023,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 55
+      ID: 78
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -882,7 +1038,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 56
+      ID: 79
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -897,7 +1053,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 57
+      ID: 80
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -912,7 +1068,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 58
+      ID: 81
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -927,7 +1083,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 59
+      ID: 82
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -942,7 +1098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 60
+      ID: 83
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -957,7 +1113,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 61
+      ID: 84
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -972,7 +1128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 85
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -987,7 +1143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 63
+      ID: 86
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1001,5 +1157,5 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 63
+MaxTypeID: 86
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 11
-          Type: 63 EventRootType Probe[main.PointerChainArg]
+          Type: 86 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8006", Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 12
-          Type: 64 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 87 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8050", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 9
-          Type: 61 EventRootType Probe[main.bigMapArg]
+          Type: 84 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a84f3", Frameless: false}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 10
-          Type: 62 EventRootType Probe[main.inlined]
+          Type: 85 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a83ca"
               Frameless: false
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 1
-          Type: 53 EventRootType Probe[main.intArg]
+          Type: 76 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a80aa", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 4
-          Type: 56 EventRootType Probe[main.intArrayArg]
+          Type: 79 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a822a", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 7
-          Type: 59 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a83a0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 3
-          Type: 55 EventRootType Probe[main.intSliceArg]
+          Type: 78 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a81aa", Frameless: false}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 8
-          Type: 60 EventRootType Probe[main.mapArg]
+          Type: 83 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a848a", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 2
-          Type: 54 EventRootType Probe[main.stringArg]
+          Type: 77 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a812a", Frameless: false}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 6
-          Type: 58 EventRootType Probe[main.stringArrayArg]
+          Type: 81 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a832a", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 5
-          Type: 57 EventRootType Probe[main.stringSliceArg]
+          Type: 80 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a82aa", Frameless: false}]
           Condition: null
 Subprograms:
@@ -391,11 +391,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 44 PointerType *string.str
+          Type: 67 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 43 GoStringDataType string.str
+      Data: 66 GoStringDataType string.str
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -425,7 +425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 45 GoSliceDataType []int.array
+      Data: 68 GoSliceDataType []int.array
     - __kind: ArrayType
       ID: 11
       Name: '[3]int'
@@ -451,7 +451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 47 GoSliceDataType []string.array
+      Data: 70 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 13
       Name: '*string'
@@ -510,7 +510,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 18 BaseType uint64
-      TablePtrSliceType: 49 GoSliceDataType []*table<string,int>.array
+      TablePtrSliceType: 72 GoSliceDataType []*table<string,int>.array
       GroupType: 26 StructureType noalg.map.group[string]int
     - __kind: BaseType
       ID: 18
@@ -577,7 +577,7 @@ Types:
           Offset: 8
           Type: 18 BaseType uint64
       GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 50 GoSliceDataType []noalg.map.group[string]int.array
+      GroupSliceType: 73 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
       ID: 25
       Name: '*noalg.map.group[string]int'
@@ -660,7 +660,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 18 BaseType uint64
-      TablePtrSliceType: 51 GoSliceDataType []*table<string,main.bigStruct>.array
+      TablePtrSliceType: 74 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 32
@@ -709,7 +709,7 @@ Types:
           Offset: 8
           Type: 18 BaseType uint64
       GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 52 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupSliceType: 75 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
       ID: 36
       Name: '*noalg.map.group[string]main.bigStruct'
@@ -797,57 +797,213 @@ Types:
       Count: 128
       HasCount: true
       Element: 9 BaseType uint8
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 43
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 41760
+      GoKind: 10
+    - __kind: BaseType
+      ID: 44
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 42400
+      GoKind: 1
+    - __kind: BaseType
+      ID: 45
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 41696
+      GoKind: 5
+    - __kind: PointerType
+      ID: 46
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 29568
+      GoKind: 22
+      Pointee: 44 BaseType bool
+    - __kind: BaseType
+      ID: 47
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41824
+      GoKind: 6
+    - __kind: GoInterfaceType
+      ID: 48
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 63168
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 49 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 49 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 49
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 42464
+      GoKind: 26
+    - __kind: BaseType
+      ID: 50
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 41440
+      GoKind: 3
+    - __kind: BaseType
+      ID: 51
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 42016
+      GoKind: 7
+    - __kind: BaseType
+      ID: 52
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42272
+      GoKind: 13
+    - __kind: BaseType
+      ID: 53
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42336
+      GoKind: 14
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29248
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28864
+      GoKind: 22
+      Pointee: 45 BaseType int32
+    - __kind: PointerType
+      ID: 56
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28928
+      GoKind: 22
+      Pointee: 43 BaseType uint32
+    - __kind: BaseType
+      ID: 57
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42144
+      GoKind: 15
+    - __kind: BaseType
+      ID: 58
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42208
+      GoKind: 16
+    - __kind: PointerType
+      ID: 59
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29504
+      GoKind: 22
+      Pointee: 53 BaseType float64
+    - __kind: PointerType
+      ID: 60
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28992
+      GoKind: 22
+      Pointee: 47 BaseType int64
+    - __kind: PointerType
+      ID: 61
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29056
+      GoKind: 22
+      Pointee: 18 BaseType uint64
+    - __kind: PointerType
+      ID: 62
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 28480
+      GoKind: 22
+      Pointee: 48 GoInterfaceType error
+    - __kind: PointerType
+      ID: 63
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 29440
+      GoKind: 22
+      Pointee: 52 BaseType float32
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 29184
+      GoKind: 22
+      Pointee: 51 BaseType uint
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 28800
+      GoKind: 22
+      Pointee: 23 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 66
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 44
+      ID: 67
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 43 GoStringDataType string.str
+      Pointee: 66 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 45
+      ID: 68
       Name: '[]int.array'
       ByteSize: 2048
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 46
+      ID: 69
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 45 GoSliceDataType []int.array
+      Pointee: 68 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 47
+      ID: 70
       Name: '[]string.array'
       ByteSize: 2048
       Element: 7 GoStringHeaderType string
     - __kind: PointerType
-      ID: 48
+      ID: 71
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 47 GoSliceDataType []string.array
+      Pointee: 70 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 49
+      ID: 72
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 21 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 50
+      ID: 73
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
       Element: 26 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 51
+      ID: 74
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 33 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 52
+      ID: 75
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
       Element: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
-      ID: 53
+      ID: 76
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -862,7 +1018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 54
+      ID: 77
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -877,7 +1033,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 55
+      ID: 78
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -892,7 +1048,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 56
+      ID: 79
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -907,7 +1063,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 57
+      ID: 80
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -922,7 +1078,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 58
+      ID: 81
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -937,7 +1093,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 59
+      ID: 82
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -952,7 +1108,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 60
+      ID: 83
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -967,7 +1123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 61
+      ID: 84
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -982,7 +1138,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 85
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -997,7 +1153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 63
+      ID: 86
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1012,7 +1168,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 64
+      ID: 87
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1026,5 +1182,5 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 64
+MaxTypeID: 87
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1184,3 +1184,4 @@ Types:
                   ByteSize: 8
 MaxTypeID: 87
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x57e340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 11
-          Type: 62 EventRootType Probe[main.PointerChainArg]
+          Type: 86 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: 742200, Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 12
-          Type: 63 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 87 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: 742256, Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 9
-          Type: 60 EventRootType Probe[main.bigMapArg]
+          Type: 84 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: 743456, Frameless: true}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 10
-          Type: 61 EventRootType Probe[main.inlined]
+          Type: 85 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: 743148
               Frameless: true
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 1
-          Type: 52 EventRootType Probe[main.intArg]
+          Type: 76 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: 742348, Frameless: true}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 4
-          Type: 55 EventRootType Probe[main.intArrayArg]
+          Type: 79 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: 742732, Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 7
-          Type: 58 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 82 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: 743120, Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 3
-          Type: 54 EventRootType Probe[main.intSliceArg]
+          Type: 78 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: 742588, Frameless: true}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 8
-          Type: 59 EventRootType Probe[main.mapArg]
+          Type: 83 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: 743340, Frameless: true}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 2
-          Type: 53 EventRootType Probe[main.stringArg]
+          Type: 77 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: 742460, Frameless: true}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 6
-          Type: 57 EventRootType Probe[main.stringArrayArg]
+          Type: 81 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: 743004, Frameless: true}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 5
-          Type: 56 EventRootType Probe[main.stringSliceArg]
+          Type: 80 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: 742860, Frameless: true}]
           Condition: null
 Subprograms:
@@ -391,11 +391,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 43 PointerType *string.str
+          Type: 67 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 42 GoStringDataType string.str
+      Data: 66 GoStringDataType string.str
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -425,7 +425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 44 GoSliceDataType []int.array
+      Data: 68 GoSliceDataType []int.array
     - __kind: ArrayType
       ID: 11
       Name: '[3]int'
@@ -451,7 +451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 46 GoSliceDataType []string.array
+      Data: 70 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 13
       Name: '*string'
@@ -513,7 +513,7 @@ Types:
           Offset: 40
           Type: 26 PointerType *runtime.mapextra
       BucketType: 21 GoHMapBucketType bucket<string,int>
-      BucketsType: 48 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 72 GoSliceDataType []bucket<string,int>.array
     - __kind: BaseType
       ID: 18
       Name: uint16
@@ -625,7 +625,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 49 GoSliceDataType []*runtime.bmap.array
+      Data: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: PointerType
       ID: 30
       Name: '**runtime.bmap'
@@ -693,7 +693,7 @@ Types:
           Offset: 40
           Type: 26 PointerType *runtime.mapextra
       BucketType: 37 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 51 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 75 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: PointerType
       ID: 36
       Name: '*bucket<string,main.bigStruct>'
@@ -772,57 +772,219 @@ Types:
       Count: 128
       HasCount: true
       Element: 9 BaseType uint8
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 42
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 38432
+      GoKind: 1
+    - __kind: PointerType
+      ID: 43
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 26912
+      GoKind: 22
+      Pointee: 42 BaseType bool
+    - __kind: PointerType
+      ID: 44
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 26592
+      GoKind: 22
+      Pointee: 25 BaseType uintptr
+    - __kind: BaseType
+      ID: 45
+      Name: uint64
+      ByteSize: 8
+      GoRuntimeType: 37920
+      GoKind: 11
+    - __kind: BaseType
+      ID: 46
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 38048
+      GoKind: 7
+    - __kind: BaseType
+      ID: 47
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 37728
+      GoKind: 5
+    - __kind: BaseType
+      ID: 48
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 37856
+      GoKind: 6
+    - __kind: BaseType
+      ID: 49
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 37472
+      GoKind: 3
+    - __kind: BaseType
+      ID: 50
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 38304
+      GoKind: 13
+    - __kind: BaseType
+      ID: 51
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 38368
+      GoKind: 14
+    - __kind: GoInterfaceType
+      ID: 52
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 58880
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 53 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 53 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 53
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 38496
+      GoKind: 26
+    - __kind: PointerType
+      ID: 54
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 26208
+      GoKind: 22
+      Pointee: 47 BaseType int32
+    - __kind: PointerType
+      ID: 55
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 26272
+      GoKind: 22
+      Pointee: 19 BaseType uint32
+    - __kind: BaseType
+      ID: 56
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 37600
+      GoKind: 4
+    - __kind: BaseType
+      ID: 57
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 38176
+      GoKind: 15
+    - __kind: BaseType
+      ID: 58
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 38240
+      GoKind: 16
+    - __kind: PointerType
+      ID: 59
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 26848
+      GoKind: 22
+      Pointee: 51 BaseType float64
+    - __kind: PointerType
+      ID: 60
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 26336
+      GoKind: 22
+      Pointee: 48 BaseType int64
+    - __kind: PointerType
+      ID: 61
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 26400
+      GoKind: 22
+      Pointee: 45 BaseType uint64
+    - __kind: PointerType
+      ID: 62
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 25824
+      GoKind: 22
+      Pointee: 52 GoInterfaceType error
+    - __kind: PointerType
+      ID: 63
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 26784
+      GoKind: 22
+      Pointee: 50 BaseType float32
+    - __kind: PointerType
+      ID: 64
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 26528
+      GoKind: 22
+      Pointee: 46 BaseType uint
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 26144
+      GoKind: 22
+      Pointee: 18 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 66
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 43
+      ID: 67
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 42 GoStringDataType string.str
+      Pointee: 66 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 44
+      ID: 68
       Name: '[]int.array'
       ByteSize: 2048
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 45
+      ID: 69
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 44 GoSliceDataType []int.array
+      Pointee: 68 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 46
+      ID: 70
       Name: '[]string.array'
       ByteSize: 2048
       Element: 7 GoStringHeaderType string
     - __kind: PointerType
-      ID: 47
+      ID: 71
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 46 GoSliceDataType []string.array
+      Pointee: 70 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 48
+      ID: 72
       Name: '[]bucket<string,int>.array'
       ByteSize: 2048
       Element: 21 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 49
+      ID: 73
       Name: '[]*runtime.bmap.array'
       ByteSize: 2048
       Element: 31 PointerType *runtime.bmap
     - __kind: PointerType
-      ID: 50
+      ID: 74
       Name: '*[]*runtime.bmap.array'
       ByteSize: 8
-      Pointee: 49 GoSliceDataType []*runtime.bmap.array
+      Pointee: 73 GoSliceDataType []*runtime.bmap.array
     - __kind: GoSliceDataType
-      ID: 51
+      ID: 75
       Name: '[]bucket<string,main.bigStruct>.array'
       ByteSize: 2048
       Element: 37 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: EventRootType
-      ID: 52
+      ID: 76
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -837,7 +999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 53
+      ID: 77
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -852,7 +1014,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 54
+      ID: 78
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -867,7 +1029,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 55
+      ID: 79
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -882,7 +1044,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 56
+      ID: 80
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -897,7 +1059,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 57
+      ID: 81
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -912,7 +1074,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 58
+      ID: 82
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -927,7 +1089,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 59
+      ID: 83
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -942,7 +1104,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 60
+      ID: 84
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -957,7 +1119,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 61
+      ID: 85
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -972,7 +1134,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 86
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -987,7 +1149,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 63
+      ID: 87
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1001,5 +1163,5 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 63
+MaxTypeID: 87
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1165,3 +1165,4 @@ Types:
                   ByteSize: 8
 MaxTypeID: 87
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x191240", TypesOffset: 296}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -14,7 +14,7 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - ID: 11
-          Type: 63 EventRootType Probe[main.PointerChainArg]
+          Type: 87 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: 741836, Frameless: false}]
           Condition: null
     - id: PointerSmallChainArg
@@ -31,7 +31,7 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - ID: 12
-          Type: 64 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 88 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: 741892, Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -44,7 +44,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - ID: 9
-          Type: 61 EventRootType Probe[main.bigMapArg]
+          Type: 85 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: 743056, Frameless: true}]
           Condition: null
     - id: inlined
@@ -58,7 +58,7 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - ID: 10
-          Type: 62 EventRootType Probe[main.inlined]
+          Type: 86 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: 742748
               Frameless: true
@@ -75,7 +75,7 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - ID: 1
-          Type: 53 EventRootType Probe[main.intArg]
+          Type: 77 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: 741980, Frameless: true}]
           Condition: null
     - id: intArrayArg
@@ -88,7 +88,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - ID: 4
-          Type: 56 EventRootType Probe[main.intArrayArg]
+          Type: 80 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: 742348, Frameless: true}]
           Condition: null
     - id: intArrayArgFrameless
@@ -101,7 +101,7 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - ID: 7
-          Type: 59 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 83 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: 742720, Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -114,7 +114,7 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - ID: 3
-          Type: 55 EventRootType Probe[main.intSliceArg]
+          Type: 79 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: 742220, Frameless: true}]
           Condition: null
     - id: mapArg
@@ -127,7 +127,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - ID: 8
-          Type: 60 EventRootType Probe[main.mapArg]
+          Type: 84 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: 742940, Frameless: true}]
           Condition: null
     - id: stringArg
@@ -140,7 +140,7 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - ID: 2
-          Type: 54 EventRootType Probe[main.stringArg]
+          Type: 78 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: 742092, Frameless: true}]
           Condition: null
     - id: stringArrayArg
@@ -153,7 +153,7 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - ID: 6
-          Type: 58 EventRootType Probe[main.stringArrayArg]
+          Type: 82 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: 742604, Frameless: true}]
           Condition: null
     - id: stringSliceArg
@@ -166,7 +166,7 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - ID: 5
-          Type: 57 EventRootType Probe[main.stringSliceArg]
+          Type: 81 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: 742476, Frameless: true}]
           Condition: null
 Subprograms:
@@ -391,11 +391,11 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 44 PointerType *string.str
+          Type: 68 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 1 BaseType int
-      Data: 43 GoStringDataType string.str
+      Data: 67 GoStringDataType string.str
     - __kind: PointerType
       ID: 8
       Name: '*uint8'
@@ -425,7 +425,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 45 GoSliceDataType []int.array
+      Data: 69 GoSliceDataType []int.array
     - __kind: ArrayType
       ID: 11
       Name: '[3]int'
@@ -451,7 +451,7 @@ Types:
         - Name: cap
           Offset: 16
           Type: 1 BaseType int
-      Data: 47 GoSliceDataType []string.array
+      Data: 71 GoSliceDataType []string.array
     - __kind: PointerType
       ID: 13
       Name: '*string'
@@ -510,7 +510,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 18 BaseType uint64
-      TablePtrSliceType: 49 GoSliceDataType []*table<string,int>.array
+      TablePtrSliceType: 73 GoSliceDataType []*table<string,int>.array
       GroupType: 26 StructureType noalg.map.group[string]int
     - __kind: BaseType
       ID: 18
@@ -577,7 +577,7 @@ Types:
           Offset: 8
           Type: 18 BaseType uint64
       GroupType: 26 StructureType noalg.map.group[string]int
-      GroupSliceType: 50 GoSliceDataType []noalg.map.group[string]int.array
+      GroupSliceType: 74 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: PointerType
       ID: 25
       Name: '*noalg.map.group[string]int'
@@ -660,7 +660,7 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 18 BaseType uint64
-      TablePtrSliceType: 51 GoSliceDataType []*table<string,main.bigStruct>.array
+      TablePtrSliceType: 75 GoSliceDataType []*table<string,main.bigStruct>.array
       GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
       ID: 32
@@ -709,7 +709,7 @@ Types:
           Offset: 8
           Type: 18 BaseType uint64
       GroupType: 37 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 52 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupSliceType: 76 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: PointerType
       ID: 36
       Name: '*noalg.map.group[string]main.bigStruct'
@@ -797,57 +797,219 @@ Types:
       Count: 128
       HasCount: true
       Element: 9 BaseType uint8
-    - __kind: GoStringDataType
+    - __kind: BaseType
       ID: 43
+      Name: uint32
+      ByteSize: 4
+      GoRuntimeType: 41728
+      GoKind: 10
+    - __kind: BaseType
+      ID: 44
+      Name: bool
+      ByteSize: 1
+      GoRuntimeType: 42368
+      GoKind: 1
+    - __kind: BaseType
+      ID: 45
+      Name: uint
+      ByteSize: 8
+      GoRuntimeType: 41984
+      GoKind: 7
+    - __kind: PointerType
+      ID: 46
+      Name: '*bool'
+      ByteSize: 8
+      GoRuntimeType: 29536
+      GoKind: 22
+      Pointee: 44 BaseType bool
+    - __kind: BaseType
+      ID: 47
+      Name: int32
+      ByteSize: 4
+      GoRuntimeType: 41664
+      GoKind: 5
+    - __kind: BaseType
+      ID: 48
+      Name: int64
+      ByteSize: 8
+      GoRuntimeType: 41792
+      GoKind: 6
+    - __kind: GoInterfaceType
+      ID: 49
+      Name: error
+      ByteSize: 16
+      GoRuntimeType: 63040
+      GoKind: 20
+      RawFields:
+        - Name: tab
+          Offset: 0
+          Type: 50 VoidPointerType unsafe.Pointer
+        - Name: data
+          Offset: 8
+          Type: 50 VoidPointerType unsafe.Pointer
+    - __kind: VoidPointerType
+      ID: 50
+      Name: unsafe.Pointer
+      ByteSize: 8
+      GoRuntimeType: 42432
+      GoKind: 26
+    - __kind: BaseType
+      ID: 51
+      Name: int8
+      ByteSize: 1
+      GoRuntimeType: 41408
+      GoKind: 3
+    - __kind: BaseType
+      ID: 52
+      Name: float32
+      ByteSize: 4
+      GoRuntimeType: 42240
+      GoKind: 13
+    - __kind: BaseType
+      ID: 53
+      Name: float64
+      ByteSize: 8
+      GoRuntimeType: 42304
+      GoKind: 14
+    - __kind: PointerType
+      ID: 54
+      Name: '*uintptr'
+      ByteSize: 8
+      GoRuntimeType: 29216
+      GoKind: 22
+      Pointee: 19 BaseType uintptr
+    - __kind: PointerType
+      ID: 55
+      Name: '*int32'
+      ByteSize: 8
+      GoRuntimeType: 28832
+      GoKind: 22
+      Pointee: 47 BaseType int32
+    - __kind: PointerType
+      ID: 56
+      Name: '*uint32'
+      ByteSize: 8
+      GoRuntimeType: 28896
+      GoKind: 22
+      Pointee: 43 BaseType uint32
+    - __kind: BaseType
+      ID: 57
+      Name: int16
+      ByteSize: 2
+      GoRuntimeType: 41536
+      GoKind: 4
+    - __kind: BaseType
+      ID: 58
+      Name: complex64
+      ByteSize: 8
+      GoRuntimeType: 42112
+      GoKind: 15
+    - __kind: BaseType
+      ID: 59
+      Name: complex128
+      ByteSize: 16
+      GoRuntimeType: 42176
+      GoKind: 16
+    - __kind: PointerType
+      ID: 60
+      Name: '*float64'
+      ByteSize: 8
+      GoRuntimeType: 29472
+      GoKind: 22
+      Pointee: 53 BaseType float64
+    - __kind: PointerType
+      ID: 61
+      Name: '*int64'
+      ByteSize: 8
+      GoRuntimeType: 28960
+      GoKind: 22
+      Pointee: 48 BaseType int64
+    - __kind: PointerType
+      ID: 62
+      Name: '*uint64'
+      ByteSize: 8
+      GoRuntimeType: 29024
+      GoKind: 22
+      Pointee: 18 BaseType uint64
+    - __kind: PointerType
+      ID: 63
+      Name: '*error'
+      ByteSize: 8
+      GoRuntimeType: 28448
+      GoKind: 22
+      Pointee: 49 GoInterfaceType error
+    - __kind: PointerType
+      ID: 64
+      Name: '*float32'
+      ByteSize: 8
+      GoRuntimeType: 29408
+      GoKind: 22
+      Pointee: 52 BaseType float32
+    - __kind: PointerType
+      ID: 65
+      Name: '*uint'
+      ByteSize: 8
+      GoRuntimeType: 29152
+      GoKind: 22
+      Pointee: 45 BaseType uint
+    - __kind: PointerType
+      ID: 66
+      Name: '*uint16'
+      ByteSize: 8
+      GoRuntimeType: 28768
+      GoKind: 22
+      Pointee: 23 BaseType uint16
+    - __kind: GoStringDataType
+      ID: 67
       Name: string.str
       ByteSize: 2048
     - __kind: PointerType
-      ID: 44
+      ID: 68
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 43 GoStringDataType string.str
+      Pointee: 67 GoStringDataType string.str
     - __kind: GoSliceDataType
-      ID: 45
+      ID: 69
       Name: '[]int.array'
       ByteSize: 2048
       Element: 1 BaseType int
     - __kind: PointerType
-      ID: 46
+      ID: 70
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 45 GoSliceDataType []int.array
+      Pointee: 69 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 47
+      ID: 71
       Name: '[]string.array'
       ByteSize: 2048
       Element: 7 GoStringHeaderType string
     - __kind: PointerType
-      ID: 48
+      ID: 72
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 47 GoSliceDataType []string.array
+      Pointee: 71 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 49
+      ID: 73
       Name: '[]*table<string,int>.array'
       ByteSize: 8192
       Element: 21 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 50
+      ID: 74
       Name: '[]noalg.map.group[string]int.array'
       ByteSize: 2048
       Element: 26 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 51
+      ID: 75
       Name: '[]*table<string,main.bigStruct>.array'
       ByteSize: 8192
       Element: 33 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 52
+      ID: 76
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       ByteSize: 2048
       Element: 37 StructureType noalg.map.group[string]main.bigStruct
     - __kind: EventRootType
-      ID: 53
+      ID: 77
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -862,7 +1024,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 54
+      ID: 78
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -877,7 +1039,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 55
+      ID: 79
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -892,7 +1054,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 56
+      ID: 80
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -907,7 +1069,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 57
+      ID: 81
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -922,7 +1084,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 58
+      ID: 82
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -937,7 +1099,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 59
+      ID: 83
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -952,7 +1114,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 60
+      ID: 84
       Name: Probe[main.mapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -967,7 +1129,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 61
+      ID: 85
       Name: Probe[main.bigMapArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -982,7 +1144,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 62
+      ID: 86
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -997,7 +1159,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 63
+      ID: 87
       Name: Probe[main.PointerChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1012,7 +1174,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 64
+      ID: 88
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -1026,5 +1188,5 @@ Types:
                   Variable: {subprogram: 3, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
-MaxTypeID: 64
+MaxTypeID: 88
 Issues: []

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1190,3 +1190,4 @@ Types:
                   ByteSize: 8
 MaxTypeID: 88
 Issues: []
+GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}

--- a/pkg/dyninst/irgen/type_catalog.go
+++ b/pkg/dyninst/irgen/type_catalog.go
@@ -293,30 +293,23 @@ func (c *typeCatalog) buildType(
 				GoTypeAttributes: goAttrs,
 			}, nil
 		case reflect.Interface:
-			underlyingType, err := getUnderlyingType()
+			name, byteSize, fields, err := processInterfaceTypedef(c, entry)
 			if err != nil {
 				return nil, err
 			}
-			underlyingStructure, ok := underlyingType.(*ir.StructureType)
-			if !ok {
-				return nil, fmt.Errorf(
-					"underlying type for interface is not a structure type: %T",
-					underlyingType,
-				)
-			}
-			common.ByteSize = underlyingStructure.GetByteSize()
-			switch name := underlyingStructure.GetName(); name {
+			common.ByteSize = uint32(byteSize)
+			switch name {
 			case "runtime.eface":
 				return &ir.GoEmptyInterfaceType{
-					TypeCommon:          common,
-					GoTypeAttributes:    goAttrs,
-					UnderlyingStructure: underlyingStructure,
+					TypeCommon:       common,
+					GoTypeAttributes: goAttrs,
+					RawFields:        fields,
 				}, nil
 			case "runtime.iface":
 				return &ir.GoInterfaceType{
-					TypeCommon:          common,
-					GoTypeAttributes:    goAttrs,
-					UnderlyingStructure: underlyingStructure,
+					TypeCommon:       common,
+					GoTypeAttributes: goAttrs,
+					RawFields:        fields,
 				}, nil
 			default:
 				return nil, fmt.Errorf(
@@ -372,6 +365,153 @@ func (c *typeCatalog) buildType(
 	default:
 		return nil, fmt.Errorf("unexpected tag for type: %s", entry.Tag)
 	}
+}
+
+// processInterfaceTypedef processes a typedef that resolves to a runtime
+// structure (either runtime.eface or runtime.iface). Each of these structures
+// has two pointer fields. One of those is always an unsafe.Pointer (a pointer
+// with no pointee type in DWARF). The other is a pointer to a concrete runtime
+// type (e.g., runtime._type or runtime.itab). We do not want to pull those
+// concrete types into the type graph. Treat both fields as void pointers.
+func processInterfaceTypedef(
+	c *typeCatalog, entry *dwarf.Entry,
+) (name string, byteSize int64, fields []ir.Field, _ error) {
+	r := c.dwarf.Reader()
+	getUnderlyingEntry := func(entry *dwarf.Entry) (*dwarf.Entry, error) {
+		underlyingOffset, err := getAttr[dwarf.Offset](entry, dwarf.AttrType)
+		if err != nil {
+			return nil, err
+		}
+		r.Seek(underlyingOffset)
+		nextEntry, err := r.Next()
+		if err != nil {
+			return nil, err
+		}
+		if nextEntry == nil {
+			return nil, fmt.Errorf(
+				"unexpected EOF while reading underlying type",
+			)
+		}
+		return nextEntry, nil
+	}
+	underlyingEntry := entry
+	for underlyingEntry.Tag == dwarf.TagTypedef {
+		var err error
+		underlyingEntry, err = getUnderlyingEntry(underlyingEntry)
+		if err != nil {
+			return "", 0, nil, err
+		}
+		if underlyingEntry.Tag == 0 {
+			return "", 0, nil, fmt.Errorf("unexpected end of underlying type")
+		}
+	}
+	if underlyingEntry.Tag != dwarf.TagStructType {
+		return "", 0, nil, fmt.Errorf(
+			"underlying type for interface is not a structure type: %v",
+			underlyingEntry.Tag,
+		)
+	}
+	byteSize, ok := underlyingEntry.Val(dwarf.AttrByteSize).(int64)
+	if !ok {
+		return "", 0, nil, fmt.Errorf(
+			"unexpected byte size for interface: %T",
+			underlyingEntry.Val(dwarf.AttrByteSize),
+		)
+	}
+	if byteSize > math.MaxUint32 {
+		return "", 0, nil, fmt.Errorf(
+			"byte size for interface is too large: %d", byteSize,
+		)
+	}
+	fields = make([]ir.Field, 0, 2)
+	var voidPointerType ir.Type
+	var fieldTypeReader *dwarf.Reader
+	// Walk the underlying struct members, capture their offsets and reuse a
+	// single void pointer type for all fields.
+	for {
+		child, err := r.Next()
+		if err != nil {
+			return "", 0, nil, fmt.Errorf("failed to get next child: %w", err)
+		}
+		if child == nil {
+			return "", 0, nil, fmt.Errorf(
+				"unexpected EOF while reading underlying type",
+			)
+		}
+		if child.Tag == 0 {
+			break
+		}
+		if child.Tag != dwarf.TagMember {
+			continue
+		}
+		fname, err := getAttr[string](child, dwarf.AttrName)
+		if err != nil {
+			return "", 0, nil, fmt.Errorf(
+				"failed to get name for member %q: %w", fname, err,
+			)
+		}
+		offset, err := getAttr[int64](child, dwarf.AttrDataMemberLoc)
+		if err != nil {
+			return "", 0, nil, fmt.Errorf(
+				"failed to get offset for member %q: %w", fname, err,
+			)
+		}
+		typeOffset, err := getAttr[dwarf.Offset](child, dwarf.AttrType)
+		if err != nil {
+			return "", 0, nil, fmt.Errorf(
+				"failed to get type for member %q: %w", fname, err,
+			)
+		}
+		if fieldTypeReader == nil {
+			fieldTypeReader = c.dwarf.Reader()
+		}
+		fieldTypeReader.Seek(typeOffset)
+		fieldTypeEntry, err := fieldTypeReader.Next()
+		if err != nil {
+			return "", 0, nil, fmt.Errorf(
+				"failed to get type for member %q: %w", fname, err,
+			)
+		}
+		if fieldTypeEntry == nil {
+			return "", 0, nil, fmt.Errorf(
+				"unexpected EOF while reading type for member %q",
+				fname,
+			)
+		}
+		// Look for the unsafe.Pointer field. It is represented as a pointer
+		// that has no pointee type in DWARF. Reuse that one as the type for
+		// all interface fields to avoid expanding runtime types.
+		if fieldTypeEntry.Tag == dwarf.TagPointerType &&
+			fieldTypeEntry.Val(dwarf.AttrType) == nil &&
+			voidPointerType == nil {
+			vp, err := c.addType(typeOffset)
+			if err != nil {
+				return "", 0, nil, fmt.Errorf(
+					"failed to add void pointer type for member %q: %w",
+					fname, err,
+				)
+			}
+			voidPointerType = vp
+		}
+		fields = append(fields, ir.Field{
+			Name:   fname,
+			Offset: uint32(offset),
+			// Type set after loop to the void pointer type.
+		})
+	}
+	if voidPointerType == nil {
+		return "", 0, nil, fmt.Errorf(
+			"failed to find a void pointer field for interface %q", name,
+		)
+	}
+	for i := range fields {
+		fields[i].Type = voidPointerType
+	}
+	name, err := getAttr[string](underlyingEntry, dwarf.AttrName)
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("failed to get name for interface: %w", err)
+	}
+	return name, byteSize, fields, nil
 }
 
 func collectMembers(childReader *dwarf.Reader, c *typeCatalog) ([]ir.Field, error) {

--- a/pkg/dyninst/irprinter/example_test.go
+++ b/pkg/dyninst/irprinter/example_test.go
@@ -40,13 +40,13 @@ import (
 func ExamplePrintJSON() {
 	p := constructExampleProgram()
 
-	// Marshal to JSON
+	// Marshal to JSON.
 	data, err := PrintJSON(p)
 	if err != nil {
 		panic(err)
 	}
 
-	// Pretty print the JSON
+	// Pretty print the JSON.
 	var buf bytes.Buffer
 	json.Indent(&buf, data, "", "  ")
 	fmt.Println(buf.String())
@@ -91,7 +91,11 @@ func ExamplePrintJSON() {
 	//     }
 	//   ],
 	//   "MaxTypeID": 3,
-	//   "Issues": []
+	//   "Issues": [],
+	//   "GoModuledataInfo": {
+	//     "FirstModuledataAddr": "0xdeadbeef",
+	//     "TypesOffset": 1234
+	//   }
 	// }
 
 }
@@ -133,6 +137,7 @@ func ExamplePrintYAML() {
 	//       Pointee: 1 StructureType Node
 	// MaxTypeID: 3
 	// Issues: []
+	// GoModuledataInfo: {FirstModuledataAddr: "0xdeadbeef", TypesOffset: 1234}
 }
 
 func constructExampleProgram() *ir.Program {
@@ -141,6 +146,10 @@ func constructExampleProgram() *ir.Program {
 		ID:        1,
 		MaxTypeID: 3,
 		Types:     make(map[ir.TypeID]ir.Type),
+		GoModuledataInfo: ir.GoModuledataInfo{
+			FirstModuledataAddr: 0xdeadbeef,
+			TypesOffset:         1234,
+		},
 	}
 
 	// Create a self-referential linked list node

--- a/pkg/dyninst/json_redaction_test.go
+++ b/pkg/dyninst/json_redaction_test.go
@@ -83,6 +83,10 @@ func (m exactMatcher) matches(ptr jsontext.Pointer) bool {
 
 type reMatcher regexp.Regexp
 
+func matchRegexp(re string) matcher {
+	return (*reMatcher)(regexp.MustCompile(re))
+}
+
 func (m *reMatcher) matches(ptr jsontext.Pointer) bool {
 	return (*regexp.Regexp)(m).MatchString(string(ptr))
 }
@@ -188,7 +192,7 @@ func redactStackFrame(v jsontext.Value) jsontext.Value {
 
 var defaultRedactors = []jsonRedactor{
 	redactor(
-		(*reMatcher)(regexp.MustCompile(`^/debugger/snapshot/stack/[[:digit:]]+$`)),
+		matchRegexp(`^/debugger/snapshot/stack/[[:digit:]]+$`),
 		replacerFunc(redactStackFrame),
 	),
 	redactor(
@@ -216,8 +220,15 @@ var defaultRedactors = []jsonRedactor{
 		entriesSorter{},
 	),
 	redactor(
-		(*reMatcher)(regexp.MustCompile(`^/debugger/snapshot/captures/entry/arguments/.*`)),
+		matchRegexp(`^/debugger/snapshot/captures/entry/arguments/.*`),
 		replacerFunc(redactMutex),
+	),
+	redactor(
+		matchRegexp(`^/debugger/snapshot/captures/entry/arguments/.*/type`),
+		regexpStringReplacer(
+			`UnknownType\(0x[[:xdigit:]]+\)`,
+			`UnknownType(0x[GoRuntimeType])`,
+		),
 	),
 }
 
@@ -255,6 +266,24 @@ func redactMutex(v jsontext.Value) jsontext.Value {
 		return v
 	}
 	return jsontext.Value(`"[sync.Mutex (different in different versions)]"`)
+}
+
+func regexpStringReplacer(pat, replacement string) replacer {
+	re := regexp.MustCompile(pat)
+	replacementJSON, err := json.Marshal(replacement)
+	if err != nil {
+		panic(err)
+	}
+	return replacerFunc(func(v jsontext.Value) jsontext.Value {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			return v
+		}
+		if !re.MatchString(s) {
+			return v
+		}
+		return jsontext.Value(replacementJSON)
+	})
 }
 
 func redactJSON(t *testing.T, ptrPrefix jsontext.Pointer, input []byte, redactors []jsonRedactor) []byte {

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -280,8 +280,10 @@ func (l *Loader) loadData(
 	const throttlerMapName = "throttler_params"
 	const throttlerStateMapName = "throttler_buf"
 	const probeParamsMapName = "probe_params"
+	const goRuntimeTypeIDsMapName = "go_runtime_type_ids"
+	const goRuntimeTypesMapName = "go_runtime_types"
 
-	mapSpec, codeMap, err := makeArrayMap(codeMapName, serialized.code, true /* singleEntry */)
+	mapSpec, codeMap, err := makeArrayMap(codeMapName, serialized.code, forceSingleEntryMap)
 	spec.Maps[codeMapName] = mapSpec
 	if err != nil {
 		return nil, fmt.Errorf("failed to create code map: %w", err)
@@ -308,11 +310,13 @@ func (l *Loader) loadData(
 		return nil, fmt.Errorf("failed to set prog_id: %w", err)
 	}
 
-	mapSpec, typeIDsMap, err := makeArrayMap(typeIDsMapName, serialized.typeIDs, false /* singleEntry */)
-	spec.Maps[typeIDsMapName] = mapSpec
+	mapSpec, typeIDsMap, err := makeArrayMap(
+		typeIDsMapName, serialized.typeIDs, allowMultipleMapEntries,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create type_ids map: %w", err)
 	}
+	spec.Maps[typeIDsMapName] = mapSpec
 	defer func() {
 		if typeIDsMap != nil {
 			typeIDsMap.Close()
@@ -323,7 +327,9 @@ func (l *Loader) loadData(
 		return nil, fmt.Errorf("failed to set num_types: %w", err)
 	}
 
-	mapSpec, typeInfoMap, err := makeArrayMap(typeInfoMapName, serialized.typeInfos, false /* singleEntry */)
+	mapSpec, typeInfoMap, err := makeArrayMap(
+		typeInfoMapName, serialized.typeInfos, allowMultipleMapEntries,
+	)
 	spec.Maps[typeInfoMapName] = mapSpec
 	if err != nil {
 		return nil, fmt.Errorf("failed to create type_info map: %w", err)
@@ -333,19 +339,72 @@ func (l *Loader) loadData(
 			typeInfoMap.Close()
 		}
 	}()
+	grts := &serialized.goRuntimeTypeIDs
+	numGoRuntimeTypes := uint32(grts.Len())
+	if numGoRuntimeTypes == 0 {
+		// We're not allowed to have empty maps, so we set a single element with
+		// a zero value, but the associated variable for the length will still
+		// be set to zero.
+		grts.goRuntimeTypes = []uint64{0}
+		grts.typeIDs = []uint64{0}
+	}
+	goRuntimeTypeIDsMapSpec, goRuntimeTypeIDsMap, err := makeArrayMap(
+		goRuntimeTypeIDsMapName, grts.typeIDs, allowMultipleMapEntries,
+	)
+	spec.Maps[goRuntimeTypeIDsMapName] = goRuntimeTypeIDsMapSpec
+	if err != nil {
+		return nil, fmt.Errorf("failed to create go_runtime_type_ids map: %w", err)
+	}
+	defer func() {
+		if goRuntimeTypeIDsMap != nil {
+			goRuntimeTypeIDsMap.Close()
+		}
+	}()
+	goRuntimeTypesMapSpec, goRuntimeTypesMap, err := makeArrayMap(
+		goRuntimeTypesMapName, grts.goRuntimeTypes, allowMultipleMapEntries,
+	)
+	spec.Maps[goRuntimeTypesMapName] = goRuntimeTypesMapSpec
+	if err != nil {
+		return nil, fmt.Errorf("failed to create go_runtime_types map: %w", err)
+	}
+	defer func() {
+		if goRuntimeTypesMap != nil {
+			goRuntimeTypesMap.Close()
+		}
+	}()
+	if err := setVariable(
+		spec, "num_go_runtime_types", numGoRuntimeTypes,
+	); err != nil {
+		return nil, fmt.Errorf("failed to set num_go_runtime_types: %w", err)
+	}
+	if err := setVariable(
+		spec, "OFFSET_runtime_dot_moduledata__types",
+		serialized.goModuledataInfo.TypesOffset,
+	); err != nil {
+		return nil, fmt.Errorf("failed to set OFFSET_runtime_dot_moduledata__types: %w", err)
+	}
+	if err := setVariable(
+		spec, "VARIABLE_runtime_dot_firstmoduledata",
+		serialized.goModuledataInfo.FirstModuledataAddr,
+	); err != nil {
+		return nil, fmt.Errorf("failed to set VARIABLE_runtime_dot_firstmoduledata: %w", err)
+	}
 
-	mapSpec, throttlerMap, err := makeArrayMap(throttlerMapName, serialized.throttlerParams, false /* singleEntry */)
-	spec.Maps[throttlerMapName] = mapSpec
+	mapSpec, throttlerMap, err := makeArrayMap(
+		throttlerMapName, serialized.throttlerParams, allowMultipleMapEntries,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create throttler_params map: %w", err)
 	}
+	spec.Maps[throttlerMapName] = mapSpec
 	defer func() {
 		if throttlerMap != nil {
 			throttlerMap.Close()
 		}
 	}()
-	err = setVariable(spec, "num_throttlers", uint32(len(serialized.throttlerParams)))
-	if err != nil {
+	if err := setVariable(
+		spec, "num_throttlers", uint32(len(serialized.throttlerParams)),
+	); err != nil {
 		return nil, fmt.Errorf("failed to set num_throttlers: %w", err)
 	}
 
@@ -355,7 +414,9 @@ func (l *Loader) loadData(
 	}
 	mapSpec.MaxEntries = uint32(len(serialized.throttlerParams))
 
-	mapSpec, probeParamsMap, err := makeArrayMap(probeParamsMapName, serialized.probeParams, false /* singleEntry */)
+	mapSpec, probeParamsMap, err := makeArrayMap(
+		probeParamsMapName, serialized.probeParams, allowMultipleMapEntries,
+	)
 	spec.Maps[probeParamsMapName] = mapSpec
 	if err != nil {
 		return nil, fmt.Errorf("failed to create probe_params map: %w", err)
@@ -378,21 +439,34 @@ func (l *Loader) loadData(
 	}
 
 	m := map[string]*ebpf.Map{
-		codeMapName:        codeMap,
-		typeIDsMapName:     typeIDsMap,
-		typeInfoMapName:    typeInfoMap,
-		throttlerMapName:   throttlerMap,
-		probeParamsMapName: probeParamsMap,
+		codeMapName:             codeMap,
+		typeIDsMapName:          typeIDsMap,
+		typeInfoMapName:         typeInfoMap,
+		throttlerMapName:        throttlerMap,
+		probeParamsMapName:      probeParamsMap,
+		goRuntimeTypeIDsMapName: goRuntimeTypeIDsMap,
+		goRuntimeTypesMapName:   goRuntimeTypesMap,
 	}
 	codeMap = nil
 	typeIDsMap = nil
 	typeInfoMap = nil
 	throttlerMap = nil
 	probeParamsMap = nil
+	goRuntimeTypeIDsMap = nil
+	goRuntimeTypesMap = nil
 	return m, nil
 }
 
-func makeArrayMap[T any](name string, data []T, singleEntry bool) (*ebpf.MapSpec, *ebpf.Map, error) {
+type arrayMapConfig bool
+
+const (
+	forceSingleEntryMap     arrayMapConfig = true
+	allowMultipleMapEntries arrayMapConfig = false
+)
+
+func makeArrayMap[T any](
+	name string, data []T, cfg arrayMapConfig,
+) (*ebpf.MapSpec, *ebpf.Map, error) {
 	var val T
 	elemSize := uint32(unsafe.Sizeof(val))
 	mapSpec := &ebpf.MapSpec{
@@ -404,12 +478,15 @@ func makeArrayMap[T any](name string, data []T, singleEntry bool) (*ebpf.MapSpec
 		Flags:      features.BPF_F_MMAPABLE,
 	}
 	// singleEntry makes the map have a single element holding all the data.
-	if singleEntry {
+	if cfg == forceSingleEntryMap {
 		mapSpec.ValueSize = mapSpec.MaxEntries * mapSpec.ValueSize
 		mapSpec.MaxEntries = 1
 	}
-	if mapSpec.ValueSize%8 != 0 && !singleEntry {
-		return nil, nil, fmt.Errorf("map %s has value size %d which is not a multiple of 8", name, mapSpec.ValueSize)
+	if mapSpec.ValueSize%8 != 0 && cfg == allowMultipleMapEntries {
+		return nil, nil, fmt.Errorf(
+			"map %s has value size %d which is not a multiple of 8",
+			name, mapSpec.ValueSize,
+		)
 	}
 	m, err := ebpf.NewMap(mapSpec)
 	if err != nil {
@@ -437,7 +514,9 @@ func makeArrayMap[T any](name string, data []T, singleEntry bool) (*ebpf.MapSpec
 	return mapSpec, m, nil
 }
 
-func setVariable(spec *ebpf.CollectionSpec, name string, value uint32) error {
+func setVariable[I uint32 | uint64](
+	spec *ebpf.CollectionSpec, name string, value I,
+) error {
 	vari, ok := spec.Variables[name]
 	if !ok {
 		return fmt.Errorf("variable %s not found in spec", name)

--- a/pkg/dyninst/loader/serialize.go
+++ b/pkg/dyninst/loader/serialize.go
@@ -13,6 +13,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
@@ -31,6 +32,26 @@ type serializedProgram struct {
 
 	probeParams     []probeParams
 	bpfAttachPoints []BPFAttachPoint
+
+	goRuntimeTypeIDs goRuntimeTypeIDs
+	goModuledataInfo ir.GoModuledataInfo
+}
+
+type goRuntimeTypeIDs struct {
+	goRuntimeTypes []uint64
+	typeIDs        []uint64
+}
+
+var _ sort.Interface = (*goRuntimeTypeIDs)(nil)
+
+func (g *goRuntimeTypeIDs) Len() int { return len(g.goRuntimeTypes) }
+func (g *goRuntimeTypeIDs) Less(i int, j int) bool {
+	return g.goRuntimeTypes[i] < g.goRuntimeTypes[j]
+}
+func (g *goRuntimeTypeIDs) Swap(i int, j int) {
+	grts, tids := g.goRuntimeTypes, g.typeIDs
+	grts[i], grts[j] = grts[j], grts[i]
+	tids[i], tids[j] = tids[j], tids[i]
 }
 
 // BPFAttachPoint specifies how the eBPF program should be attached to the user process.
@@ -96,13 +117,41 @@ func serializeProgram(
 	})
 	serialized.typeIDs = make([]uint64, len(program.Types))
 	serialized.typeInfos = make([]typeInfo, len(program.Types))
+	serialized.goRuntimeTypeIDs = goRuntimeTypeIDs{
+		goRuntimeTypes: make([]uint64, 0, len(program.Types)),
+		typeIDs:        make([]uint64, 0, len(program.Types)),
+	}
+	grts := &serialized.goRuntimeTypeIDs
 	for i, t := range program.Types {
-		serialized.typeIDs[i] = uint64(t.GetID())
+		typeID := uint64(t.GetID())
+		serialized.typeIDs[i] = typeID
 		serialized.typeInfos[i] = typeInfo{
 			Byte_len:   t.GetByteSize(),
 			Enqueue_pc: metadata.FunctionLoc[compiler.ProcessType{Type: t}],
 		}
+		if goRuntimeType, ok := t.GetGoRuntimeType(); ok {
+			grts.goRuntimeTypes = append(grts.goRuntimeTypes, uint64(goRuntimeType))
+			// If the t is a reference type, the value is not indirected when
+			// put into an interface box. Put differently, the data being
+			// pointed to is the pointee of the reference type. For all other
+			// kinds of types, the box will contain a pointer to that type.
+			switch t := t.(type) {
+			case *ir.PointerType:
+				grts.typeIDs = append(grts.typeIDs, uint64(t.Pointee.GetID()))
+			case *ir.GoMapType:
+				grts.typeIDs = append(grts.typeIDs, uint64(t.HeaderType.GetID()))
+			case *ir.GoChannelType, *ir.GoSubroutineType:
+				// TODO: Handle these kinds of types. Right now this is going to
+				// be incorrect when we stumble upon them, but we don't have
+				// anything more correct to say is underneath the pointer.
+				grts.typeIDs = append(grts.typeIDs, typeID)
+			default:
+				grts.typeIDs = append(grts.typeIDs, typeID)
+			}
+		}
 	}
+	sort.Sort(grts)
+	serialized.goModuledataInfo = program.GoModuledataInfo
 
 	serialized.throttlerParams = make([]throttlerParams, len(program.Throttlers))
 	for i, t := range program.Throttlers {

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.out
@@ -156,16 +156,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -556,12 +558,12 @@ Package: main
 		Field: a: sync/atomic.Int32
 	Type: main.firstBehavior
 		Field: s: string
-		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
-			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [28:29]
+			Arg: b: main.firstBehavior (declared at line 0, available: [28-29])
 	Type: main.secondBehavior
 		Field: i: int
-		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
-			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
+			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
@@ -687,5 +689,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.out
@@ -155,16 +155,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -543,12 +545,12 @@ Package: main
 		Field: a: sync/atomic.Int32
 	Type: main.firstBehavior
 		Field: s: string
-		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
-			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [28:29]
+			Arg: b: main.firstBehavior (declared at line 0, available: [28-29])
 	Type: main.secondBehavior
 		Field: i: int
-		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
-			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
+			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
@@ -674,5 +676,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.out
@@ -156,16 +156,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -556,12 +558,12 @@ Package: main
 		Field: a: sync/atomic.Int32
 	Type: main.firstBehavior
 		Field: s: string
-		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
-			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [28:29]
+			Arg: b: main.firstBehavior (declared at line 0, available: [28-29])
 	Type: main.secondBehavior
 		Field: i: int
-		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
-			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
+			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
@@ -687,5 +689,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.out
@@ -155,16 +155,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -543,12 +545,12 @@ Package: main
 		Field: a: sync/atomic.Int32
 	Type: main.firstBehavior
 		Field: s: string
-		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [26:27]
-			Arg: b: main.firstBehavior (declared at line 0, available: [26-27])
+		Function: DoSomething (main.firstBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [28:29]
+			Arg: b: main.firstBehavior (declared at line 0, available: [28-29])
 	Type: main.secondBehavior
 		Field: i: int
-		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [30:31]
-			Arg: b: main.secondBehavior (declared at line 0, available: [30-31])
+		Function: DoSomething (main.secondBehavior.DoSomething) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [32:33]
+			Arg: b: main.secondBehavior (declared at line 0, available: [32-33])
 	Type: main.structWithMap
 		Field: m: map[int]int
 	Type: main.node
@@ -674,5 +676,7 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])
 		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:23]
 			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 0, available: )

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -156,16 +156,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -673,3 +675,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -155,16 +155,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -660,3 +662,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -156,16 +156,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: scanner: *bufio.Scanner (declared at line 23, available: )
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
@@ -673,3 +675,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -155,16 +155,18 @@ Package: main
 		Var: x: int (declared at line 99, available: )
 		Var: y: int (declared at line 100, available: [97-106])
 		Var: a: [5]int (declared at line 98, available: [97-106])
-	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [48:55]
-		Arg: b: main.behavior (declared at line 48, available: [48-51])
-		Arg: ~r0: string (declared at line 48, available: )
-		Var: hash: string (declared at line 51, available: [48-55])
-		Var: inter: string (declared at line 52, available: [48-55])
-		Var: iType: string (declared at line 53, available: [48-55])
-		Var: iFun: string (declared at line 54, available: [48-48], [55-55])
-	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [60:60]
-		Arg: e: error (declared at line 60, available: [60-60])
-	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [63:67]
+	Function: testInterface (main.testInterface) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [50:51]
+		Arg: b: main.behavior (declared at line 50, available: [50-51])
+		Arg: ~r0: string (declared at line 50, available: )
+	Function: testAny (main.testAny) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [56:57]
+		Arg: a: interface {} (declared at line 56, available: [56-57])
+		Arg: ~r0: string (declared at line 56, available: )
+	Function: testError (main.testError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [62:62]
+		Arg: e: error (declared at line 62, available: [62-62])
+	Function: executeInterfaceFuncs (main.executeInterfaceFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go [65:83]
+		Var: &one: *int (declared at line 76, available: [65-83])
+		Var: &foo: *string (declared at line 79, available: [65-83])
+		Var: .autotmp_8: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 74, available: [65-83])
 	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go [19:48]
 		Var: t: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type (declared at line 39, available: [19-48])
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989]
@@ -660,3 +662,6 @@ Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
 	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18]
+	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type
+		Function: MyMethod (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.(*V2Type).MyMethod) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [22:24]
+			Arg: v: *github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.V2Type (declared at line 22, available: [22-23])

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -1,0 +1,622 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 70
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 71
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 72
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 73
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 74
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 75
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 77
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 78
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 80
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testAny",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testAny",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 56
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 81
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testAny",
+          "location": {
+            "method": "main.testAny"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "a": {
+                "type": "interface {}",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testAny.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAny.json
@@ -51,8 +51,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -113,8 +113,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -175,8 +175,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -237,8 +237,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -299,8 +299,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -361,8 +361,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -423,8 +423,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "int",
+                "value": "1"
               }
             }
           }
@@ -485,8 +485,9 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "*int",
+                "address": "[addr]",
+                "value": "1"
               }
             }
           }
@@ -547,8 +548,8 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "string",
+                "value": "foo"
               }
             }
           }
@@ -609,8 +610,9 @@
           "entry": {
             "arguments": {
               "a": {
-                "type": "interface {}",
-                "notCapturedReason": "unimplemented"
+                "type": "*string",
+                "address": "[addr]",
+                "value": "foo"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
+++ b/pkg/dyninst/testdata/decoded/sample/testBigStruct.json
@@ -69,8 +69,8 @@
                     "value": "5"
                   },
                   "writer": {
-                    "type": "io.Writer",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   }
                 }
               }

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -18,12 +18,12 @@
           {
             "function": "main.testError",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 60
+            "lineNumber": 62
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 66
+            "lineNumber": 82
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testError.json
+++ b/pkg/dyninst/testdata/decoded/sample/testError.json
@@ -51,8 +51,8 @@
           "entry": {
             "arguments": {
               "e": {
-                "type": "error",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -66,12 +66,12 @@
                         "notCapturedReason": "unimplemented"
                       },
                       "val": {
-                        "type": "interface {}",
-                        "notCapturedReason": "unimplemented"
+                        "type": "int",
+                        "value": "42"
                       },
                       "work": {
-                        "type": "main.something",
-                        "notCapturedReason": "unimplemented"
+                        "type": "UnknownType(0x[GoRuntimeType])",
+                        "notCapturedReason": "missing type information"
                       },
                       "foo": {
                         "type": "func()",

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericStack.json
@@ -62,12 +62,12 @@
                     "notCapturedReason": "unimplemented"
                   },
                   "val": {
-                    "type": "interface {}",
-                    "notCapturedReason": "unimplemented"
+                    "type": "int",
+                    "value": "42"
                   },
                   "work": {
-                    "type": "main.something",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "foo": {
                     "type": "func()",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -18,12 +18,198 @@
           {
             "function": "main.testInterface",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 48
+            "lineNumber": 50
           },
           {
             "function": "main.executeInterfaceFuncs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
-            "lineNumber": 64
+            "lineNumber": 66
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInterface",
+          "location": {
+            "method": "main.testInterface"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "b": {
+                "type": "main.behavior",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInterface",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInterface",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 67
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInterface",
+          "location": {
+            "method": "main.testInterface"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "b": {
+                "type": "main.behavior",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInterface",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInterface",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 68
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 46
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInterface",
+          "location": {
+            "method": "main.testInterface"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "b": {
+                "type": "main.behavior",
+                "notCapturedReason": "unimplemented"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInterface",
+      "version": 0,
+      "thread_id": 0,
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInterface",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 50
+          },
+          {
+            "function": "main.executeInterfaceFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/interfaces.go",
+            "lineNumber": 69
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/sample/testInterface.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInterface.json
@@ -51,8 +51,8 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.behavior",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -113,8 +113,8 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.behavior",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -175,8 +175,8 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.behavior",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }
@@ -237,8 +237,8 @@
           "entry": {
             "arguments": {
               "b": {
-                "type": "main.behavior",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               }
             }
           }

--- a/pkg/dyninst/testdata/e2e/rc_tester.json
+++ b/pkg/dyninst/testdata/e2e/rc_tester.json
@@ -25,8 +25,8 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "net/http.ResponseWriter",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               },
               "r": {
                 "type": "*net/http.Request",
@@ -137,8 +137,8 @@
                     ]
                   },
                   "Body": {
-                    "type": "io.ReadCloser",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -201,8 +201,8 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "context.Context",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -328,8 +328,8 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "net/http.ResponseWriter",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               },
               "r": {
                 "type": "*net/http.Request",
@@ -440,8 +440,8 @@
                     ]
                   },
                   "Body": {
-                    "type": "io.ReadCloser",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -504,8 +504,8 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "context.Context",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "pat": {
                     "type": "*net/http.pattern",
@@ -631,8 +631,8 @@
           "entry": {
             "arguments": {
               "w": {
-                "type": "net/http.ResponseWriter",
-                "notCapturedReason": "unimplemented"
+                "type": "UnknownType(0x[GoRuntimeType])",
+                "notCapturedReason": "missing type information"
               },
               "r": {
                 "type": "*net/http.Request",
@@ -743,8 +743,8 @@
                     ]
                   },
                   "Body": {
-                    "type": "io.ReadCloser",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "GetBody": {
                     "type": "func() (io.ReadCloser, error)",
@@ -807,8 +807,8 @@
                     "value": "/"
                   },
                   "ctx": {
-                    "type": "context.Context",
-                    "notCapturedReason": "unimplemented"
+                    "type": "UnknownType(0x[GoRuntimeType])",
+                    "notCapturedReason": "missing type information"
                   },
                   "pat": {
                     "type": "*net/http.pattern",

--- a/pkg/dyninst/testprogs/progs/sample/interfaces.go
+++ b/pkg/dyninst/testprogs/progs/sample/interfaces.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"unsafe"
+
+	lib_v2 "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2"
 )
 
 type behavior interface {
@@ -46,13 +48,13 @@ type itab struct {
 //nolint:all
 //go:noinline
 func testInterface(b behavior) string {
-	ptr := unsafe.Pointer(&b)
-	iface := (*iface)(ptr)
-	hash := fmt.Sprintf("iface.tab.hash = %#x", iface.tab.hash)
-	inter := fmt.Sprintf("iface.tab.inter = %#x", iface.tab.inter)
-	iType := fmt.Sprintf("iface.tab._type = %#x", iface.tab._type)
-	iFun := fmt.Sprintf("iface.tab.fun = %#x", iface.tab.fun)
-	return fmt.Sprintln(hash, inter, iType, iFun)
+	return b.DoSomething()
+}
+
+//nolint:all
+//go:noinline
+func testAny(a any) string {
+	return fmt.Sprintf("%v", a)
 }
 
 //nolint:all
@@ -62,6 +64,20 @@ func testError(e error) {}
 //nolint:all
 func executeInterfaceFuncs() {
 	testInterface(firstBehavior{"foo"})
+	testInterface(&firstBehavior{"foo"})
 	testInterface(secondBehavior{42})
+	testInterface(&secondBehavior{42})
+	testAny(firstBehavior{"foo"})
+	testAny(&firstBehavior{"foo"})
+	testAny(secondBehavior{42})
+	testAny(&secondBehavior{42})
+	testAny(lib_v2.V2Type{})
+	testAny(&lib_v2.V2Type{})
+	one := 1
+	testAny(one)
+	testAny(&one)
+	foo := "foo"
+	testAny(foo)
+	testAny(&foo)
 	testError(errors.New("blah"))
 }

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -427,11 +427,18 @@ probes:
   captureSnapshot: true
 - id: testInterface
   type: LOG_PROBE
-  tags:
-    - "foo:bar"
   where:
     methodName: main.testInterface
   captureSnapshot: true
+  sampling:
+    snapshotsPerSecond: 10
+- id: testAny
+  type: LOG_PROBE
+  where:
+    methodName: main.testAny
+  captureSnapshot: true
+  sampling:
+    snapshotsPerSecond: 10
 - id: testError
   type: LOG_PROBE
   tags:


### PR DESCRIPTION
This is the first part of [DEBUG-4043](https://datadoghq.atlassian.net/browse/DEBUG-4043). This just wires up the ebpf and decoding.

There are several followups after to resolve interface names and to augment irgen with the ability to resolve the implementations of interfaces with methods. 

[DEBUG-4043]: https://datadoghq.atlassian.net/browse/DEBUG-4043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ