### PR TITLE
[OTAGENT-510] remove deprecated otel routing processor

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1825,9 +1825,6 @@ core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourc
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors
-core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor,Apache-2.0,Copyright The OpenTelemetry Authors
-core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor/internal/common,Apache-2.0,Copyright The OpenTelemetry Authors
-core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor/internal/metadata,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/cache,Apache-2.0,Copyright The OpenTelemetry Authors
 core,github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher,Apache-2.0,Copyright The OpenTelemetry Authors

--- a/comp/otelcol/collector-contrib/impl/components.go
+++ b/comp/otelcol/collector-contrib/impl/components.go
@@ -27,7 +27,6 @@ import (
 	probabilisticsamplerprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	resourcedetectionprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	resourceprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
-	routingprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
 	tailsamplingprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	transformprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	filelogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
@@ -137,7 +136,6 @@ func components() (otelcol.Factories, error) {
 		probabilisticsamplerprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
-		routingprocessor.NewFactory(),
 		tailsamplingprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
 	)
@@ -155,7 +153,6 @@ func components() (otelcol.Factories, error) {
 	factories.ProcessorModules[probabilisticsamplerprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.131.0"
 	factories.ProcessorModules[resourcedetectionprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.131.0"
 	factories.ProcessorModules[resourceprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0"
-	factories.ProcessorModules[routingprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0"
 	factories.ProcessorModules[tailsamplingprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0"
 	factories.ProcessorModules[transformprocessor.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.131.0"
 

--- a/comp/otelcol/collector-contrib/impl/go.mod
+++ b/comp/otelcol/collector-contrib/impl/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.131.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.131.0

--- a/comp/otelcol/collector-contrib/impl/go.sum
+++ b/comp/otelcol/collector-contrib/impl/go.sum
@@ -613,8 +613,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.131.0/go.mod h1:N7fZpxyvPLusT15HEGXWtW+yF8xWY+x1uaHYbXZ3jHU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0 h1:RkpPtwe0B6eFR46XQ6eIXDIkpD9IFnZfjCJOW44YelA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0/go.mod h1:zy16qPh5/PIyjWa0c52W+w4jjpEw85vFXHKyaxdcIr4=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0 h1:w7LNvJbNt8L7EmQKSPFVLv8WeHVRD0uxMcRGeSAgCo4=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0/go.mod h1:z+d2a6En6/GazZl6QJKlSwBgykbkAyd6gSPv3/DO9Wg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0 h1:HOIRR7CXVuM433YyuHFIm6ODESNNYeOMehzNYW6LCZo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0/go.mod h1:B9yGMCACiR/hp/b8yWwq4MnYBDwj4xvIAktoeiVsVFc=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.131.0 h1:yZ2u46ANXX1GK6M2snbQ+JdIq802l9npqJzGPAKZHLg=

--- a/go.mod
+++ b/go.mod
@@ -917,7 +917,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.131.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.131.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.131.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.131.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1398,8 +1398,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedete
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.131.0/go.mod h1:N7fZpxyvPLusT15HEGXWtW+yF8xWY+x1uaHYbXZ3jHU=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0 h1:RkpPtwe0B6eFR46XQ6eIXDIkpD9IFnZfjCJOW44YelA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.131.0/go.mod h1:zy16qPh5/PIyjWa0c52W+w4jjpEw85vFXHKyaxdcIr4=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0 h1:w7LNvJbNt8L7EmQKSPFVLv8WeHVRD0uxMcRGeSAgCo4=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.131.0/go.mod h1:z+d2a6En6/GazZl6QJKlSwBgykbkAyd6gSPv3/DO9Wg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0 h1:HOIRR7CXVuM433YyuHFIm6ODESNNYeOMehzNYW6LCZo=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.131.0/go.mod h1:B9yGMCACiR/hp/b8yWwq4MnYBDwj4xvIAktoeiVsVFc=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.131.0 h1:yZ2u46ANXX1GK6M2snbQ+JdIq802l9npqJzGPAKZHLg=

--- a/releasenotes/notes/otel-remove-routing-404525e870b.yaml
+++ b/releasenotes/notes/otel-remove-routing-404525e870b.yaml
@@ -8,4 +8,4 @@
 ---
 deprecations:
   - |
-    Remove the deprecated routing processor from DDOT.
+    Remove the deprecated routing processor from DDOT. Use the routing connector instead.

--- a/releasenotes/notes/otel-remove-routing-404525e870b.yaml
+++ b/releasenotes/notes/otel-remove-routing-404525e870b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    Remove the deprecated routing processor from DDOT.


### PR DESCRIPTION
### What does this PR do?
remove deprecated otel routing processor

### Motivation
The routing processor has been deprecated and removed in upstream: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42154