### PR TITLE
[Serverless-Init] Change Cloud Run Jobs origin tag; refactor logs source

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -52,6 +52,11 @@ func (a *AppService) GetTags() map[string]string {
 	return tags
 }
 
+// GetDefaultLogsSource returns the default logs source if `DD_SOURCE` is not set
+func (a *AppService) GetDefaultLogsSource() string {
+	return AppServiceOrigin
+}
+
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (a *AppService) GetOrigin() string {

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -131,6 +131,11 @@ func (c *CloudRun) getFunctionTags(tags map[string]string) map[string]string {
 	return tags
 }
 
+// GetDefaultLogsSource returns the default logs source if `DD_SOURCE` is not set
+func (c *CloudRun) GetDefaultLogsSource() string {
+	return CloudRunOrigin
+}
+
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (c *CloudRun) GetOrigin() string {

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -79,6 +79,12 @@ func (c *CloudRunJobs) GetTags() map[string]string {
 	return tags
 }
 
+// GetDefaultLogsSource returns the default logs source if `DD_SOURCE` is not set
+func (c *CloudRunJobs) GetDefaultLogsSource() string {
+	// Use the default log pipeline for Cloud Run.
+	return CloudRunOrigin
+}
+
 // GetOrigin returns the `origin` attribute type for the given cloud service.
 func (c *CloudRunJobs) GetOrigin() string {
 	return CloudRunJobsOrigin

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -45,6 +45,7 @@ type CloudRunJobs struct {
 // GetTags returns a map of gcp-related tags for Cloud Run Jobs.
 func (c *CloudRunJobs) GetTags() map[string]string {
 	tags := metadataHelperFunc(GetDefaultConfig(), false)
+	tags["origin"] = CloudRunJobsOrigin
 	tags["_dd.origin"] = CloudRunJobsOrigin
 
 	jobNameVal := os.Getenv(cloudRunJobNameEnvVar)

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CloudRunJobsOrigin origin tag value
-const CloudRunJobsOrigin = "cloudrun"
+const CloudRunJobsOrigin = "cloudrunjobs"
 
 const (
 	cloudRunJobNameEnvVar     = "CLOUD_RUN_JOB"

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
@@ -33,6 +33,7 @@ func TestGetCloudRunJobsTagsWithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"container_id":        "test_container",
 		"location":            "test_region",
+		"origin":              "cloudrun",
 		"_dd.origin":          "cloudrun",
 		"project_id":          "test_project",
 		"job_name":            "test_job",

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
@@ -48,7 +48,7 @@ func TestGetCloudRunJobsTagsWithEnvironmentVariables(t *testing.T) {
 
 func TestCloudRunJobsGetOrigin(t *testing.T) {
 	service := &CloudRunJobs{}
-	assert.Equal(t, "cloudrun", service.GetOrigin())
+	assert.Equal(t, "cloudrunjobs", service.GetOrigin())
 }
 
 func TestCloudRunJobsInit(t *testing.T) {

--- a/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_jobs_test.go
@@ -33,8 +33,8 @@ func TestGetCloudRunJobsTagsWithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"container_id":        "test_container",
 		"location":            "test_region",
-		"origin":              "cloudrun",
-		"_dd.origin":          "cloudrun",
+		"origin":              "cloudrunjobs",
+		"_dd.origin":          "cloudrunjobs",
 		"project_id":          "test_project",
 		"job_name":            "test_job",
 		"gcrj.job_name":       "test_job",

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -101,6 +101,11 @@ func (c *ContainerApp) GetTags() map[string]string {
 	return tags
 }
 
+// GetDefaultLogsSource returns the default logs source if `DD_SOURCE` is not set
+func (c *ContainerApp) GetDefaultLogsSource() string {
+	return ContainerAppOrigin
+}
+
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (c *ContainerApp) GetOrigin() string {

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -61,7 +61,7 @@ func (l *LocalService) GetTags() map[string]string {
 
 // GetDefaultLogsSource is a default implementation that returns an empty logs source
 func (l *LocalService) GetDefaultLogsSource() string {
-	return ""
+	return "unknown"
 }
 
 // GetOrigin is a default implementation that returns a local empty origin

--- a/cmd/serverless-init/cloudservice/service.go
+++ b/cmd/serverless-init/cloudservice/service.go
@@ -17,6 +17,10 @@ type CloudService interface {
 	// the logs, traces, and metrics.
 	GetTags() map[string]string
 
+	// GetDefaultLogsSource returns the value that will be used for the logs source
+	// if `DD_SOURCE` is not set by the user.
+	GetDefaultLogsSource() string
+
 	// GetOrigin returns the value that will be used for the `origin` attribute for
 	// all logs, traces, and metrics.
 	GetOrigin() string
@@ -53,6 +57,11 @@ const defaultPrefix = "datadog.serverless_agent"
 // GetTags is a default implementation that returns a local empty tag set
 func (l *LocalService) GetTags() map[string]string {
 	return map[string]string{}
+}
+
+// GetDefaultLogsSource is a default implementation that returns an empty logs source
+func (l *LocalService) GetDefaultLogsSource() string {
+	return ""
 }
 
 // GetOrigin is a default implementation that returns a local empty origin

--- a/cmd/serverless-init/cloudservice/service_test.go
+++ b/cmd/serverless-init/cloudservice/service_test.go
@@ -30,7 +30,7 @@ func TestGetCloudServiceType(t *testing.T) {
 func TestGetCloudServiceTypeForCloudRunJob(t *testing.T) {
 	t.Setenv("CLOUD_RUN_JOB", "test-job")
 	cloudService := GetCloudServiceType()
-	assert.Equal(t, "cloudrun", cloudService.GetOrigin())
+	assert.Equal(t, "cloudrunjobs", cloudService.GetOrigin())
 
 	// Verify it's the correct type
 	_, ok := cloudService.(*CloudRunJobs)

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -41,10 +41,10 @@ type Config struct {
 }
 
 // CreateConfig builds and returns a log config
-func CreateConfig(origin string) *Config {
+func CreateConfig(defaultSource string) *Config {
 	var source string
 	if source = strings.ToLower(os.Getenv(sourceEnvVar)); source == "" {
-		source = origin
+		source = defaultSource
 	}
 	return &Config{
 		FlushTimeout: defaultFlushTimeout,

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestCreateConfig(t *testing.T) {
-	config := CreateConfig("fake-origin")
+	config := CreateConfig("fake-logs-source")
 	assert.Equal(t, 5*time.Second, config.FlushTimeout)
-	assert.Equal(t, "fake-origin", config.source)
+	assert.Equal(t, "fake-logs-source", config.source)
 }
 
 func TestCreateConfigWithSource(t *testing.T) {

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -141,9 +141,8 @@ func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Com
 			cloudService.GetTags()),
 		modeConf.TagVersionMode)
 
-	origin := cloudService.GetOrigin()
-
-	agentLogConfig := serverlessInitLog.CreateConfig(origin)
+	defaultSource := cloudService.GetDefaultLogsSource()
+	agentLogConfig := serverlessInitLog.CreateConfig(defaultSource)
 
 	// The datadog-agent requires Load to be called or it could
 	// panic down the line.
@@ -152,6 +151,7 @@ func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Com
 		log.Debugf("Error loading config: %v\n", err)
 	}
 
+	origin := cloudService.GetOrigin()
 	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags, tagger, compression, hostname, origin)
 
 	functionTags := strings.Join(configuredTags, ",")


### PR DESCRIPTION
### What does this PR do?

- Renames the origin for cloud run jobs to `cloudrunjobs` (for billing purposes)
- Adds the `origin:cloudrunjobs` tag to be used on the frontend
- Create a `GetDefaultLogsSource()` that will be used when creating the agent log config, because we want Cloud Run Jobs to have `origin:cloudrunjobs` but a logs source value of `cloudrun`
- Also, origin and source are not the same thing. The previous implementation was confusing and seems to imply that the two values are equivalent, when they are actually very different. This makes it clear that we are just falling back to `GetDefaultLogsSource()` when `DD_SOURCE` is not defined
- Although this is technically breaking (since we're changing the tag value), this should not be considered breaking because Cloud Run Jobs is not officially supported or released yet.

### Motivation

- Separate Cloud Run services and Cloud Run Jobs for billing purposes
- Expose the `origin` tag for the frontend

### Describe how you validated your changes

Built serverless-init locally and deployed it to a test Cloud Run Job.

As you can see, the tag is `origin:cloudrunjobs`, and the log source is `cloudrun`:
<img width="500" height="349" alt="Screenshot 2025-08-27 at 1 36 51 PM" src="https://github.com/user-attachments/assets/72c4b7ad-be0a-4913-8e3c-4ddb18b24fd7" />

### Possible Drawbacks / Trade-offs

None

### Additional Notes
