### PR TITLE
dyninst/decode: fix always 0 address

### DIFF
--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -368,7 +368,7 @@ var simpleBigMapArgExpected = map[string]any{
 				map[string]any{"type": "string", "value": "b"},
 				map[string]any{
 					"type":    "*main.bigStruct", // This shouldn't be a pointer
-					"address": "0x0",             // and the address is suspect.
+					"address": "0x700000007",     // or carry this address.
 					"fields": map[string]any{
 						"Field1": map[string]any{"type": "int", "value": "1"},
 						"Field2": map[string]any{"type": "int", "value": "0"},
@@ -550,7 +550,7 @@ func simpleBigMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 var simplePointerChainArgExpected = map[string]any{
 	"ptr": map[string]any{
 		"type":    "*****int",
-		"address": "0x0",
+		"address": "0xa0000005",
 		"value":   "17",
 	},
 }

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -774,7 +774,6 @@ func encodePointer(
 		return nil
 	}
 
-	var address uint64
 	pointedValue, dataItemExists := d.dataItems[pointeeKey]
 	if !dataItemExists {
 		return writeTokens(enc,
@@ -785,7 +784,7 @@ func encodePointer(
 	if writeAddress {
 		if err := writeTokens(enc,
 			jsontext.String("address"),
-			jsontext.String("0x"+strconv.FormatInt(int64(address), 16)),
+			jsontext.String("0x"+strconv.FormatUint(addr, 16)),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
The address used to be always 0 because of erroneous use of a variable. This is now fixed and tested both in the unit tests and the integration tests.