### PR TITLE
Update default otel-config.yaml

### DIFF
--- a/cmd/otel-agent/dist/otel-config.yaml
+++ b/cmd/otel-agent/dist/otel-config.yaml
@@ -1,73 +1,44 @@
-# To limit exposure to denial of service attacks, change the host in endpoints below from 0.0.0.0 to a specific network interface.
-# See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
-
-extensions:
-  health_check:
-    endpoint: localhost:13133
-  pprof:
-    endpoint: localhost:1777
-  zpages:
-    endpoint: localhost:55679
-  ddflare:
-    endpoint: localhost:7777
-
-
 receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "otelcol"
+          scrape_interval: 60s
+          static_configs:
+            - targets: ["0.0.0.0:8888"]
   otlp:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
-    # Collect own metrics
-  prometheus:
-    config:
-      scrape_configs:
-      - job_name: 'otel-collector'
-        fallback_scrape_protocol: PrometheusText0.0.4
-        metric_name_validation_scheme: legacy
-        metric_name_escaping_scheme: underscores
-        scrape_interval: 60s
-        scrape_protocols:
-          - PrometheusText0.0.4
-        static_configs:
-        - targets: ['0.0.0.0:8888']
-        metric_relabel_configs:
-        - source_labels: [__name__]
-          regex: ".*grpc_io.*"
-          action: drop
 exporters:
+  debug:
+    verbosity: detailed
   datadog:
-    hostname: "otelcol-docker"
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
 processors:
   infraattributes:
+    cardinality: 2
   batch:
-  # using the sampler
-  probabilistic_sampler:
-    sampling_percentage: 30
+    timeout: 10s
 connectors:
-  # Use datadog connector to compute stats for pre-sampled traces
   datadog/connector:
     traces:
-      compute_stats_by_span_kind: true
+      compute_top_level_by_span_kind: true
       peer_tags_aggregation: true
+      compute_stats_by_span_kind: true
 service:
-  extensions: [health_check, pprof, zpages, ddflare]
   pipelines:
-    traces: # this pipeline computes APM stats
+    traces:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [datadog/connector]
-    traces/sampling: # this pipeline uses sampling and sends traces
-      receivers: [otlp]
-      processors: [probabilistic_sampler, infraattributes,batch]
-      exporters: [datadog]
+      processors: [infraattributes, batch]
+      exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector, prometheus]
-      processors: [infraattributes,batch]
+      processors: [infraattributes, batch]
       exporters: [datadog]
     logs:
       receivers: [otlp]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Updates `cmd/otel-agent/dist/otel-config.yaml` to match the default used by Kubernetes customers: https://github.com/DataDog/datadog-operator/blob/main/internal/controller/datadogagent/feature/otelcollector/defaultconfig/defaultconfig.go.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->