### PR TITLE
Revert "Upgrades lading to 0.27 (#40120)"

### DIFF
--- a/test/regression/cases/ddot_metrics/lading/lading.yaml
+++ b/test/regression/cases/ddot_metrics/lading/lading.yaml
@@ -10,8 +10,7 @@ generator:
       method:
         post:
           maximum_prebuild_cache_size_bytes: "512 MiB"
-          variant:
-            opentelemetry_metrics: {}
+          variant: "opentelemetry_metrics"
 
 blackhole:
   - http:

--- a/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
@@ -10,8 +10,7 @@ generator:
       method:
         post:
           maximum_prebuild_cache_size_bytes: "512 MiB"
-          variant:
-            opentelemetry_metrics: {}
+          variant: "opentelemetry_metrics"
 
 blackhole:
   - http:

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.27.0
+  version: 0.25.9
 
 target:
 


### PR DESCRIPTION
This reverts commit 4ac0d03a1bdb1580c6ab9170384863f517bca414 (https://github.com/DataDog/datadog-agent/pull/40120).

This update is correlated with the start of an SMP incident, #incident-42310, where a small number of SMP runners are getting stuck at the end of replicate execution and are causing job timeouts. This revert is a short term workaround while investigation continues.