### PR TITLE
[CWS] Do not display warning when computing SBOM for a deleted container

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -369,12 +369,14 @@ func (r *Resolver) analyzeWorkload(sbom *SBOM) error {
 
 	seclog.Infof("analyzing sbom '%s'", sbom.ContainerID)
 
-	if sbom.state.Load() != pendingState {
+	if currentState := sbom.state.Load(); currentState != pendingState {
 		r.removePendingScan(sbom.ContainerID)
 
-		// should not append, ignore
-		seclog.Warnf("trying to analyze a sbom not in pending state for '%s': %d", sbom.ContainerID, sbom.state.Load())
-		return nil
+		if currentState != stoppedState {
+			// should not append, ignore
+			seclog.Warnf("trying to analyze a sbom not in pending state for '%s': %d", sbom.ContainerID, currentState)
+			return nil
+		}
 	}
 
 	// bail out if the workload has been analyzed while queued up


### PR DESCRIPTION
### What does this PR do?

Do not display warning when computing SBOM for a deleted container.

### Motivation

This is an expected behavior so it doesn't make sense to display a warning.

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
