### PR TITLE
Bump memory limit on windows zip-building jobs

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -98,7 +98,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
     - mkdir omnibus\pkg
     - >
       docker run --rm
-      -m 8192M
+      -m 24576M
       -v "$(Get-Location):c:\mnt"
       -e CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}


### PR DESCRIPTION
### What does this PR do?

Bumps the memory limit passed to `docker run` for jobs that are based on the zip building template.

This was probably missed on https://github.com/DataDog/datadog-agent/pull/31489, which bumped such limits in other Windows jobs.

### Motivation

We've been seeing plenty (6-7% job failure rate) of memory errors and timeouts from the windows_zip_ddot_x64 since it was introduced on [this PR](https://github.com/DataDog/datadog-agent/pull/39287). The failures were more or less "hidden" thanks to retries (i.e. they seldom resulted in actual failed pipelines). This job relies on the template that this PR is changing.

### Describe how you validated your changes (if not by through tests)

Green CI is sufficient. I'll monitor this after merge to make sure the errors are indeed gone.

### Possible Drawbacks / Trade-offs

No significant risk, this is a limit so we shouldn't see an increase in overall memory usage just from this change.