### PR TITLE
[CWS] Add tracer and regs to shouldSend functions

### DIFF
--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -78,7 +78,7 @@ type CWSPtracerCtx struct {
 
 type syscallHandlerFunc func(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error
 
-type shouldSendFunc func(msg *ebpfless.SyscallMsg) bool
+type shouldSendFunc func(msg *ebpfless.SyscallMsg, tracer *Tracer, regs syscall.PtraceRegs) bool
 
 type syscallID struct {
 	ID   int
@@ -93,9 +93,9 @@ type syscallHandler struct {
 }
 
 // defaults funcs for ShouldSend:
-func shouldSendAlways(_ *ebpfless.SyscallMsg) bool { return true }
+func shouldSendAlways(_ *ebpfless.SyscallMsg, _ *Tracer, _ syscall.PtraceRegs) bool { return true }
 
-func isAcceptedRetval(msg *ebpfless.SyscallMsg) bool {
+func isAcceptedRetval(msg *ebpfless.SyscallMsg, _ *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM)
 }
 

--- a/pkg/security/ptracer/hooks.go
+++ b/pkg/security/ptracer/hooks.go
@@ -131,7 +131,7 @@ func (ctx *CWSPtracerCtx) handlePostHooks(nr int, ppid int, regs syscall.PtraceR
 		}
 		if handler.ShouldSend != nil {
 			syscallMsg.Retval = ctx.ReadRet(regs)
-			if handler.ShouldSend(syscallMsg) && syscallMsg.Type != ebpfless.SyscallTypeUnknown {
+			if handler.ShouldSend(syscallMsg, &ctx.Tracer, regs) && syscallMsg.Type != ebpfless.SyscallTypeUnknown {
 				ctx.sendSyscallMsg(process, syscallMsg)
 			}
 		}

--- a/pkg/security/ptracer/network_handlers.go
+++ b/pkg/security/ptracer/network_handlers.go
@@ -264,15 +264,15 @@ func handleSocketRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg,
 }
 
 // Should send messages
-func shouldSendConnect(msg *ebpfless.SyscallMsg) bool {
+func shouldSendConnect(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNREFUSED) || msg.Retval == -int64(syscall.ETIMEDOUT) || msg.Retval == -int64(syscall.EINPROGRESS)
 }
 
-func shouldSendAccept(msg *ebpfless.SyscallMsg) bool {
+func shouldSendAccept(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNABORTED)
 }
 
-func shouldSendBind(msg *ebpfless.SyscallMsg) bool {
+func shouldSendBind(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.EADDRINUSE) || msg.Retval == -int64(syscall.EFAULT)
 }
 

--- a/pkg/security/ptracer/network_handlers.go
+++ b/pkg/security/ptracer/network_handlers.go
@@ -264,15 +264,15 @@ func handleSocketRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg,
 }
 
 // Should send messages
-func shouldSendConnect(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
+func shouldSendConnect(msg *ebpfless.SyscallMsg, _ *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNREFUSED) || msg.Retval == -int64(syscall.ETIMEDOUT) || msg.Retval == -int64(syscall.EINPROGRESS)
 }
 
-func shouldSendAccept(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
+func shouldSendAccept(msg *ebpfless.SyscallMsg, _ *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNABORTED)
 }
 
-func shouldSendBind(msg *ebpfless.SyscallMsg, tracer *Tracer, _ syscall.PtraceRegs) bool {
+func shouldSendBind(msg *ebpfless.SyscallMsg, _ *Tracer, _ syscall.PtraceRegs) bool {
 	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.EADDRINUSE) || msg.Retval == -int64(syscall.EFAULT)
 }
 

--- a/pkg/security/ptracer/process_handlers.go
+++ b/pkg/security/ptracer/process_handlers.go
@@ -128,11 +128,11 @@ func registerProcessHandlers(handlers map[int]syscallHandler) []string {
 	return syscallList
 }
 
-func shouldSendExec(msg *ebpfless.SyscallMsg) bool {
+func shouldSendExec(msg *ebpfless.SyscallMsg, tracer *Tracer, regs syscall.PtraceRegs) bool {
 	if msg.Retval == -int64(syscall.ENOSYS) {
 		msg.Retval = 0
 	}
-	return isAcceptedRetval(msg)
+	return isAcceptedRetval(msg, tracer, regs)
 }
 
 //


### PR DESCRIPTION
This is just a template. Please delete all unneeded sections and add others if appropriate.

### What does this PR do?
Adds tracer and regs parameters to `shouldSend` functions.
### Motivation
Previously, the `shouldSend` functions did not have access to `regs`, making it impossible to decide whether an eBPF-less event should be sent based on syscall parameters. The `tracer` is added because we need it to access the values.

Example:
For setrlimit, we only want to send an event when the limit is modified (not when it is read). To determine this, we need to check that `arg2 != NULL`.
### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
Adds two additional arguments that are rarely used in this type of function.