### PR TITLE
[EBPF] kmt: fix permissions for /go in compiler container

### DIFF
--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -218,6 +218,9 @@ class CompilerImage:
                 user="root",
             )
 
+        # We need to make the /go directory writable by the compiler user
+        self.exec("chmod -R a+rw /go", user="root")
+
         cross_arch = ARCH_ARM64 if self.arch == ARCH_AMD64 else ARCH_AMD64
         self.exec("chmod a+rx /root", user="root")  # Some binaries will be in /root and need to be readable
         self.exec(f"dpkg --add-architecture {cross_arch.go_arch}", user="root")


### PR DESCRIPTION
### What does this PR do?

Fixes the permissions inside of the docker compiler container for KMT.

### Motivation

Fix local building in KMT.

### Describe how you validated your changes (if not by through tests)

Started the compiler and checked that it can compile tests.

I created a ticket to follow up with CI tests https://datadoghq.atlassian.net/browse/EBPF-805

### Possible Drawbacks / Trade-offs
