### PR TITLE
check installer code signature

### DIFF
--- a/releasenotes/notes/install-datadog-ps1-code-sign-check-10f8e6e3b403894d.yaml
+++ b/releasenotes/notes/install-datadog-ps1-code-sign-check-10f8e6e3b403894d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    ``Install-Datadog.ps1`` now checks that the downloaded ``datadog-installer-x86_64.exe`` has a valid Datadog code signature.

--- a/test/new-e2e/tests/installer/windows/install_script.go
+++ b/test/new-e2e/tests/installer/windows/install_script.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
@@ -183,6 +185,11 @@ func (d *DatadogInstallScript) Run(opts ...Option) (string, error) {
 	// Prepare environment variables
 	envVars := d.baseInstaller.prepareEnvVars(params)
 	if installerPath != "" {
+		// skip code signature verification if it's disabled in the profile (for local testing)
+		verify, _ := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.VerifyCodeSignature, true)
+		if !verify {
+			envVars["DD_SKIP_CODE_SIGNING_CHECK"] = "true"
+		}
 		envVars["DD_INSTALLER_URL"] = installerPath
 	}
 

--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -79,6 +79,24 @@ function Send-Telemetry($payload) {
    }
 }
 
+function Test-InstallerIntegrity($installer) {
+   if ($env:DD_SKIP_CODE_SIGNING_CHECK) {
+      Write-Host "Skipping code signing check"
+      return $true
+   }
+   $signature = Get-AuthenticodeSignature -FilePath $installer
+
+   # We don't expect this value to be localized, it is an enum name
+   # https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.signaturestatus
+   if ($signature.Status -ne "Valid") {
+      throw "Installer signature is not valid: $($signature.StatusMessage)"
+   }
+   if (-Not ($signature.SignerCertificate.Subject.Contains('CN="Datadog, Inc"'))) {
+      throw "Installer is not signed by CN=`"Datadog, Inc`": $($signature.SignerCertificate.Subject)"
+   }
+   return $true
+}
+
 function Show-Error($errorMessage, $errorCode) {
    Write-Host -ForegroundColor Red @"
 Datadog Install script failed:
@@ -309,6 +327,12 @@ try {
       Write-Host "Downloading installer from $ddInstallerUrl"
       [System.Net.WebClient]::new().DownloadFile($ddInstallerUrl, $installer)
    }
+
+   Write-Host "Verifying installer integrity..."
+   if (-Not (Test-InstallerIntegrity $installer)) {
+      throw "Installer is not signed by Datadog"
+   }
+   Write-Host "Installer integrity verified."
 
    # set so `default-packages` won't contain the Datadog Agent
    # as it is now installed during the beginning of the bootstrap process


### PR DESCRIPTION
### What does this PR do?
`Install-Datadog.ps1` now checks that the downloaded `datadog-installer-x86_64.exe` has a valid Datadog code signature.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1778

### Describe how you validated your changes (if not by through tests)
e2e tests will now check the signature too
check can be disabled for local testing

### Additional notes
The [SignatureStatus Enum](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.signaturestatus?view=powershellsdk-7.4.0) MSDN page has a concerning statement
> The file has a valid signature. This means only that the signature is syntactically valid. It does not imply trust in any way

I am unable to find the source of or additional details regarding this statement. Empirically, it appears to be false.
We can test with a self-signed cert, which will be a valid signature but won't be signed by a trusted root.
```PowerShell
cp .\bin\agent\agent.exe .\bin\agent\agent-signed.exe

$cert=New-SelfSignedCertificate -KeyUsage DigitalSignature -KeySpec Signature -KeyAlgorithm RSA -KeyLength 2048 -DNSName "YourAppName.com" -CertStoreLocation Cert:\CurrentUser\My -Type CodeSigningCert -Subject "CN=Your App Publisher, O=Your Organization, C=US"

signtool.exe sign /sha1 ($cert.Thumbprint) /fd sha256 /tr http://timestamp.digicert.com/ /td sha256 C:\mnt\bin\agent\agent-signed.exe
```
And `Get-AuthenticodeSignature` does NOT report `Valid`, it reports an error as we would hope
```
> Get-AuthenticodeSignature .\bin\agent\agent-signed.exe | fl

SignerCertificate      : [Subject]
                           CN=Your App Publisher, O=Your Organization, C=US

                         [Issuer]
                           CN=Your App Publisher, O=Your Organization, C=US

                         [Serial Number]
                           2CA1A8C718FF0B904E007C7B4735AB1E

                         [Not Before]
                           9/2/2025 12:51:04 PM

                         [Not After]
                           9/2/2026 1:11:04 PM

                         [Thumbprint]
                           9C7C5030F52D89D3DEA41BDD3C0CFD21E3987773

<snipped>

Status                 : UnknownError
StatusMessage          : A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider
Path                   : C:\mnt\bin\agent\agent-signed.exe
SignatureType          : Authenticode
IsOSBinary             : False
```
We see the same result when checking a test-signed driver build
```
> Get-AuthenticodeSignature C:\Users\branden.clark\Downloads\ddnpm.sys | fl

SignerCertificate      : [Subject]
                           CN="Test Signing Cert, DO NOT TRUST"

                         [Issuer]
                           CN="Test Signing Cert, DO NOT TRUST"

                         [Serial Number]
                           19C7A7A07A675CA04C07448B69F7E611

                         [Not Before]
                           4/24/2020 7:19:00 PM

                         [Not After]
                           1/1/2041 1:59:40 AM

                         [Thumbprint]
                           8498CC51007CB72FF648E4289E15DD8FAF7B1D57

<snipped>

Status                 : UnknownError
StatusMessage          : A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
Path                   : C:\Users\branden.clark\Downloads\ddnpm.sys
SignatureType          : Authenticode
IsOSBinary             : False
```

There are various tools/methods to "steal" a valid cert blob from one binary and apply it to another, but without additional OS modifications, the status is still `HasMismatch`, NOT `Valid`, for more information see https://axelarator.github.io/posts/codesigningcerts/
