### PR TITLE
use DD_SITE to select installer URL

### DIFF
--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -7,13 +7,32 @@ $SCRIPT_VERSION = "1.1.1"
 $GENERAL_ERROR_CODE = 1
 
 # Set some defaults if not provided
-$ddInstallerUrl = $env:DD_INSTALLER_URL
-if (-Not $ddInstallerUrl) {
-   $ddInstallerUrl = "https://install.datadoghq.com/datadog-installer-x86_64.exe"
-}
-
 if (-Not $env:DD_REMOTE_UPDATES) {
    $env:DD_REMOTE_UPDATES = "false"
+}
+
+$ddInstallerUrl = $env:DD_INSTALLER_URL
+if (-Not $ddInstallerUrl) {
+   # Craft the URL to the installer executable
+   #
+   # Use DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE if it's set,
+   # otherwise craft the URL based on the DD_SITE
+   #
+   # We must not set DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE based on DD_SITE
+   # because the environment variable will persist after the script finishes,
+   # and a change to DD_SITE won't update the the variable again, which is confusing.
+   # The go code at pkg\fleet\installer\oci\download.go will use DD_SITE to determine
+   # the registry URL so it's simpler to let it do that.
+   if ($env:DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE) {
+      $ddInstallerRegistryUrl = $env:DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE
+   } else {
+      if ($env:DD_SITE -eq "datad0g.com") {
+         $ddInstallerRegistryUrl = "install.datad0g.com"
+      } else {
+         $ddInstallerRegistryUrl = "install.datadoghq.com"
+      }
+   }
+   $ddInstallerUrl = "https://$ddInstallerRegistryUrl/datadog-installer-x86_64.exe"
 }
 
 # ExitCodeException can be used to report failures from executables that set $LASTEXITCODE


### PR DESCRIPTION
### What does this PR do?
use DD_SITE to select installer URL

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1314
use different latest on staging

### Describe how you validated your changes (if not by through tests)
```powershell
> $env:DD_SITE="datad0g.com"
> .\Install-Datadog.ps1
Welcome to the Datadog Install Script
Forcing web requests to TLS v1.2
Downloading installer from https://install.datad0g.com/datadog-installer-x86_64.exe
```

### Additional notes
`install.datadoghq.com` is used for all other sites
https://github.com/DataDog/datadog-agent/blob/fc596552614b9fca7f2f524c98b0de5c71be123f/pkg/fleet/installer/setup/install.sh#L33