### PR TITLE
[FUZZ] Add fuzz test for dogstatsd

### DIFF
--- a/comp/dogstatsd/server/enrich_fuzz_test.go
+++ b/comp/dogstatsd/server/enrich_fuzz_test.go
@@ -12,6 +12,7 @@ import (
 	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
+// Run locally with `go test -fuzz=FuzzParseEventWithEnrich -run=FuzzParseEventWithEnrich -tags=test`
 func FuzzParseEventWithEnrich(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -22,7 +23,7 @@ func FuzzParseEventWithEnrich(f *testing.F) {
 	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"), "origin", uint32(1), true, true)
 	f.Add([]byte("_e{10,0}:test title||t:warning"), "origin", uint32(1), true, true)
-	f.Fuzz(func(t *testing.T, rawEvent []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(_ *testing.T, rawEvent []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
 		parsed, err := parser.parseEvent(rawEvent)
 		if err != nil {
 			return
@@ -34,6 +35,7 @@ func FuzzParseEventWithEnrich(f *testing.F) {
 	})
 }
 
+// Run locally with `go test -fuzz=FuzzParseMetricWithEnrich -run=FuzzParseMetricWithEnrich -tags=test`
 func FuzzParseMetricWithEnrich(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -42,7 +44,7 @@ func FuzzParseMetricWithEnrich(f *testing.F) {
 
 	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
 	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
-	f.Fuzz(func(t *testing.T, rawMetric []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(_ *testing.T, rawMetric []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
 		parsed, err := parser.parseMetricSample(rawMetric)
 		if err != nil {
 			return
@@ -55,6 +57,7 @@ func FuzzParseMetricWithEnrich(f *testing.F) {
 	})
 }
 
+// Run locally with `go test -fuzz=FuzzParseServiceCheckWithEnrich -run=FuzzParseServiceCheckWithEnrich -tags=test`
 func FuzzParseServiceCheckWithEnrich(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -62,7 +65,7 @@ func FuzzParseServiceCheckWithEnrich(f *testing.F) {
 
 	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"), "origin", uint32(1), true, true)
 	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"), "origin", uint32(1), true, true)
-	f.Fuzz(func(t *testing.T, rawServiceCheck []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+	f.Fuzz(func(_ *testing.T, rawServiceCheck []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
 		parsed, err := parser.parseServiceCheck(rawServiceCheck)
 		if err != nil {
 			return

--- a/comp/dogstatsd/server/enrich_fuzz_test.go
+++ b/comp/dogstatsd/server/enrich_fuzz_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
+)
+
+func FuzzParseEventWithEnrich(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+
+	f.Add([]byte("_e{10,9}:test title|test text"), "origin", uint32(1), true, true)
+	f.Add([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"), "origin", uint32(1), true, true)
+	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"), "origin", uint32(1), true, true)
+	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"), "origin", uint32(1), true, true)
+	f.Add([]byte("_e{10,0}:test title||t:warning"), "origin", uint32(1), true, true)
+	f.Fuzz(func(t *testing.T, rawEvent []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		parsed, err := parser.parseEvent(rawEvent)
+		if err != nil {
+			return
+		}
+		_ = enrichEvent(parsed, origin, processID, enrichConfig{
+			entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
+			serverlessMode:            serverlessMode,
+		})
+	})
+}
+
+func FuzzParseMetricWithEnrich(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	filter := utilstrings.NewMatcher([]string{"custom.metric.a", "custom.metric.b"}, false)
+
+	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
+	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"), "origin", uint32(1), true, true)
+	f.Fuzz(func(t *testing.T, rawMetric []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		parsed, err := parser.parseMetricSample(rawMetric)
+		if err != nil {
+			return
+		}
+		dest := make([]metrics.MetricSample, 0, 1)
+		_ = enrichMetricSample(dest, parsed, origin, processID, "", enrichConfig{
+			entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
+			serverlessMode:            serverlessMode,
+		}, &filter)
+	})
+}
+
+func FuzzParseServiceCheckWithEnrich(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+
+	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"), "origin", uint32(1), true, true)
+	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"), "origin", uint32(1), true, true)
+	f.Fuzz(func(t *testing.T, rawServiceCheck []byte, origin string, processID uint32, serverlessMode bool, entityIDPrecedenceEnabled bool) {
+		parsed, err := parser.parseServiceCheck(rawServiceCheck)
+		if err != nil {
+			return
+		}
+		_ = enrichServiceCheck(parsed, origin, processID, enrichConfig{
+			entityIDPrecedenceEnabled: entityIDPrecedenceEnabled,
+			serverlessMode:            serverlessMode,
+		})
+	})
+}

--- a/comp/dogstatsd/server/parse_events_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_events_fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// Run locally with `go test -fuzz=FuzzParseEvent -run=FuzzParseEvent -tags=test`
 func FuzzParseEvent(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -19,7 +20,7 @@ func FuzzParseEvent(f *testing.F) {
 	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"))
 	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
 	f.Add([]byte("_e{10,0}:test title||t:warning"))
-	f.Fuzz(func(t *testing.T, rawEvent []byte) {
+	f.Fuzz(func(_ *testing.T, rawEvent []byte) {
 		_, err := parser.parseEvent(rawEvent)
 		if err != nil {
 			// we expect errors, we just don't want to panic(), or timeout

--- a/comp/dogstatsd/server/parse_events_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_events_fuzz_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+)
+
+func FuzzParseEvent(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+
+	f.Add([]byte("_e{10,9}:test title|test text"))
+	f.Add([]byte("_e{10,24}:test|title|test\\line1\\nline2\\nline3"))
+	f.Add([]byte("_e{10,9}:test title|test text|s:this is the source"))
+	f.Add([]byte("_e{10,9}:test title|test text|t:warning|d:12345|p:low|h:some.host|k:aggKey|s:source test|#tag1,tag2:test"))
+	f.Add([]byte("_e{10,0}:test title||t:warning"))
+	f.Fuzz(func(t *testing.T, rawEvent []byte) {
+		_, err := parser.parseEvent(rawEvent)
+		if err != nil {
+			// we expect errors, we just don't want to panic(), or timeout
+			return
+		}
+	})
+}

--- a/comp/dogstatsd/server/parse_metrics_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_metrics_fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// Run locally with `go test -fuzz=FuzzParseMetricSample -run=FuzzParseMetricSample -tags=test`
 func FuzzParseMetricSample(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -19,7 +20,7 @@ func FuzzParseMetricSample(f *testing.F) {
 	f.Add([]byte("metric:1234|g|@0.21|T1657100440"))
 	f.Add([]byte("example.metric:2.39283|d|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f"))
 	f.Add([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f|f:wowthisisacoolfeature"))
-	f.Fuzz(func(t *testing.T, rawSample []byte) {
+	f.Fuzz(func(_ *testing.T, rawSample []byte) {
 		_, _ = parser.parseMetricSample(rawSample)
 	})
 }

--- a/comp/dogstatsd/server/parse_metrics_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_metrics_fuzz_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+)
+
+func FuzzParseMetricSample(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+	f.Add([]byte("custom_counter:1|c|#protocol:http,bench"))
+	f.Add([]byte("♬†øU†øU¥ºuT0♪:666|g|#intitulé:T0µ"))
+	f.Add([]byte("metric:1234|g|#onetag|T1657100430"))
+	f.Add([]byte("metric:1234|g|@0.21|T1657100440"))
+	f.Add([]byte("example.metric:2.39283|d|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f"))
+	f.Add([]byte("example.metric:2.39283|d|T1657100540|@1.000000|#environment:dev|c:2a25f7fc8fbf573d62053d7263dd2d440c07b6ab4d2b107e50b0d4df1f2ee15f|f:wowthisisacoolfeature"))
+	f.Fuzz(func(t *testing.T, rawSample []byte) {
+		_, _ = parser.parseMetricSample(rawSample)
+	})
+}

--- a/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+)
+
+func FuzzParseServiceCheck(f *testing.F) {
+	deps := newServerDeps(f)
+	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
+	parser := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
+
+	f.Add([]byte("_sc|agent.up|0"))
+	f.Add([]byte("_sc|agent.up|0|d:12345|h:some.host|#tag1,tag2:test"))
+	f.Add([]byte("_sc|agent.up|0|d:12345|h:some.host|#tag1,tag2:test|m:some message"))
+	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"))
+	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"))
+
+	f.Fuzz(func(t *testing.T, rawServiceCheck []byte) {
+		_, _ = parser.parseServiceCheck(rawServiceCheck)
+	})
+}

--- a/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
+++ b/comp/dogstatsd/server/parse_service_checks_fuzz_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 )
 
+// Run locally with `go test -fuzz=FuzzParseServiceCheck -run=FuzzParseServiceCheck -tags=test`
 func FuzzParseServiceCheck(f *testing.F) {
 	deps := newServerDeps(f)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
@@ -20,7 +21,7 @@ func FuzzParseServiceCheck(f *testing.F) {
 	f.Add([]byte("_sc|agent.up|0|#tag1,tag2:test,tag3"))
 	f.Add([]byte("_sc|agent.up|0|d:21|h:localhost|h:localhost2|d:22"))
 
-	f.Fuzz(func(t *testing.T, rawServiceCheck []byte) {
+	f.Fuzz(func(_ *testing.T, rawServiceCheck []byte) {
 		_, _ = parser.parseServiceCheck(rawServiceCheck)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This adds more fuzz test to the agent, now focusing on dogstatsd package.

These will be picked up automatically by the internal fuzzing infra and run them regularly, based on the main branch!

### Motivation

Improve reliability, find bugs and be more confident during updates.
A few years back there was a couple out of bound panic in the ancestors of this parser. This should help make sure we don't have or introduce bugs going forward.

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
