### PR TITLE
pass `/norestart` to msiexec

### DIFF
--- a/pkg/fleet/installer/msi/msiexec.go
+++ b/pkg/fleet/installer/msi/msiexec.go
@@ -509,6 +509,10 @@ func Cmd(options ...MsiexecOption) (*Msiexec, error) {
 		a.msiAction,
 		fmt.Sprintf(`"%s"`, a.target),
 		"/qn",
+		// Prevent Windows from automatically restarting the machine after the installation is complete.
+		// https://learn.microsoft.com/en-us/windows/win32/msi/standard-installer-command-line-options#norestart
+		// https://learn.microsoft.com/en-us/windows/win32/msi/reboot
+		"/norestart",
 		"/log", fmt.Sprintf(`"%s"`, a.logFile),
 	}, a.additionalArgs...)
 

--- a/pkg/fleet/installer/msi/msiexec_test.go
+++ b/pkg/fleet/installer/msi/msiexec_test.go
@@ -249,7 +249,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 	t.Run("install with args", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
 
-		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1=value1 ARG2="value2" DDAGENTUSER_NAME="ddagent" DDAGENTUSER_PASSWORD="password" MSIFASTINSTALL="7"`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /norestart /log "test.log" ARG1=value1 ARG2="value2" DDAGENTUSER_NAME="ddagent" DDAGENTUSER_PASSWORD="password" MSIFASTINSTALL="7"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(
@@ -273,7 +273,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 
 	t.Run("uninstall with args", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
-		expectedCmdLine := fmt.Sprintf(`"%s" /x "test.msi" /qn /log "test.log"`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /x "test.msi" /qn /norestart /log "test.log"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(
@@ -291,7 +291,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 
 	t.Run("admin install", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
-		expectedCmdLine := fmt.Sprintf(`"%s" /a "test.msi" /qn /log "test.log"`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /a "test.msi" /qn /norestart /log "test.log"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(
@@ -310,7 +310,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 	t.Run("install args with spaces", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
 
-		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1="value 1" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password is long" MSIFASTINSTALL="7"`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /norestart /log "test.log" ARG1="value 1" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password is long" MSIFASTINSTALL="7"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(
@@ -332,7 +332,7 @@ func TestMsiexec_CommandLineConstruction(t *testing.T) {
 	t.Run("install args with escaped quotes", func(t *testing.T) {
 		mockRunner := &mockCmdRunner{}
 
-		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /log "test.log" ARG1="value has ""quotes""" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password has ""quotes""" MSIFASTINSTALL="7"`, msiexecPath)
+		expectedCmdLine := fmt.Sprintf(`"%s" /i "test.msi" /qn /norestart /log "test.log" ARG1="value has ""quotes""" ARG2="value2" DDAGENTUSER_NAME="NT AUTHORITY\SYSTEM" DDAGENTUSER_PASSWORD="password has ""quotes""" MSIFASTINSTALL="7"`, msiexecPath)
 		mockRunner.On("Run", msiexecPath, expectedCmdLine).Return(nil)
 
 		cmd, err := Cmd(

--- a/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
+++ b/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+fixes:
   - |
     Remote Agent updates on Windows now uses the ``/norestart`` MSI option
     to prevent Windows from automatically rebooting the host in rare cases

--- a/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
+++ b/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Remote Agent updates on Windows now uses the ``/norestart`` MSI option
+    to prevent Windows from automatically rebooting the host in rare cases
+    when files are in use.

--- a/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
+++ b/releasenotes/notes/remote-update-msi-norestart-232d7ce3fe5416f2.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Remote Agent updates on Windows now uses the ``/norestart`` MSI option
+    Remote Agent updates on Windows now use the ``/norestart`` MSI option
     to prevent Windows from automatically rebooting the host in rare cases
     when files are in use.


### PR DESCRIPTION
### What does this PR do?
Pass `/norestart` to msiexec commands to prevent Windows from automatically rebooting the host

https://learn.microsoft.com/en-us/windows/win32/msi/standard-installer-command-line-options#norestart
https://learn.microsoft.com/en-us/windows/win32/msi/reboot

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1683

### Describe how you validated your changes (if not by through tests)
e2e tests will make sure there are no regressions, but a follow up PR will be required to gracefully handle the 3010 exit code

### Additional notes
see flags and exit codes in our [chocolatey installer](https://github.com/DataDog/datadog-agent/blob/c7a047e7155fede3903ecd4a1a1cb4092fe7fa2b/chocolatey/datadog-agent/tools/chocolateyinstall.ps1#L13)
