### PR TITLE
[ABLD-135] Use available `bazel` spawn strategy on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,7 +4,9 @@ build --disk_cache=/tmp/bazel
 build --verbose_failures
 # Do not leak local environment variables into the build context
 build --incompatible_strict_action_env
-build --strategy=sandboxed
+build:linux --strategy=sandboxed
+build:macos --strategy=sandboxed
+build:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 
 # Caching
 common:cache --remote_instance_name=remote-caching


### PR DESCRIPTION
### Motivation
The `sandboxed` spawn strategy is alas [unavailable on Windows](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1101996723) as of `bazel` 8.3.1:
```
ERROR: 'sandboxed' was requested for mnemonic  but no strategy with that identifier was registered.
 Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
```
### What does this PR do?
The present change therefore consists in splitting spawn strategies per OS:
- Darwin & Linux: `sandboxed`, (as earlier)
- Windows: `standalone`. (closest match, that is without involving remote execution)

### Possible Drawbacks / Trade-offs
Despite not being isolated, `standalone` is slightly closer to `sandboxed` than `local` in that it respects _some_ `bazel` restrictions. (working directory, for instance)