### PR TITLE
[ AGNTLOG-264 ] Enable lazy loading for the Logs Agent

### DIFF
--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -196,7 +196,7 @@ func newLogsAgent(deps dependencies) provides {
 
 	return provides{
 		Comp:           option.New[agent.Component](logsAgent),
-		LogsReciever:   option.New[integrations.Component](integrationsLogs),
+		LogsReciever:   option.New(integrationsLogs),
 		StatusProvider: statusComponent.NewInformationProvider(NewStatusProvider()),
 		FlareProvider:  flaretypes.NewProvider(logsAgent.flarecontroller.FillFlare),
 		APIStreamLogs: api.NewAgentEndpointProvider(streamLogsEvents(logsAgent),

--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -164,6 +164,7 @@ func newLogsAgent(deps dependencies) provides {
 		auditor:            deps.Auditor,
 		sources:            sources,
 		services:           services,
+		schedulers:         schedulers.NewSchedulers(sources, services),
 		tracker:            tailers.NewTailerTracker(),
 		flarecontroller:    flareController.NewFlareController(),
 		wmeta:              deps.WMeta,
@@ -306,7 +307,9 @@ func (a *logAgent) initializeLazyStart(context.Context) error {
 
 func (a *logAgent) startSchedulers() {
 	a.prepareSchedulers.Do(func() {
-		a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
+		if a.schedulers == nil {
+			a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
+		}
 		a.schedulers.Start()
 
 		for _, scheduler := range a.schedulerProviders {

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/listener"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/windowsevent"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
-	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/logs/types"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -76,9 +75,10 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger))
 	lnchrs.AddLauncher(integrationLauncher.NewLauncher(
 		afero.NewOsFs(),
-		a.sources, integrationsLogs))
+		a.sources,
+		integrationsLogs,
+	))
 
-	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
 	a.destinationsCtx = destinationsCtx
 	a.pipelineProvider = pipelineProvider
 	a.launchers = lnchrs

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -232,6 +232,7 @@ func (suite *AgentTestSuite) TestLazyStart() {
 		suite.T().Run(tt.name, func(_ *testing.T) {
 			// Minimal intake config for successful start
 
+			delete(suite.configOverrides, "logs_enabled")
 			deps := suite.createDeps()
 			provides := newLogsAgent(deps)
 
@@ -296,6 +297,22 @@ func (suite *AgentTestSuite) TestLazyStart() {
 			assert.True(suite.T(), ts.stopped.Load())
 		})
 	}
+}
+
+func (suite *AgentTestSuite) TestAgentLazyStop() {
+	deps := suite.createDeps()
+	provides := newLogsAgent(deps)
+	compOpt := provides.Comp
+	comp, ok := compOpt.Get()
+	assert.True(suite.T(), ok)
+
+	a := comp.(*logAgent)
+
+	a.initializeLazyStart(context.TODO())
+	a.stop(context.TODO())
+	assert.Equal(suite.T(), uint32(status.StatusStopped), a.started.Load(), "agent should be stopped")
+	a.start(context.TODO())
+	assert.Equal(suite.T(), uint32(status.StatusStopped), a.started.Load(), "agent should not be running")
 }
 
 func (suite *AgentTestSuite) TestAgentTcp() {

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -144,7 +144,7 @@ func createAgent(suite *AgentTestSuite, endpoints *config.Endpoints) (*logAgent,
 		config:           deps.Config,
 		inventoryAgent:   deps.InventoryAgent,
 		started:          atomic.NewUint32(0),
-		integrationsLogs: integrationsimpl.NewLogsIntegration(),
+		integrationsLogs: integrationsimpl.NewLogsIntegration(deps.Log, deps.Config),
 
 		auditor:         deps.Auditor,
 		sources:         sources,

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -325,6 +325,26 @@ func (mode TailingMode) String() string {
 	return ""
 }
 
+// CopyConfig copies a LogsConfig and returns a new LogsConfig with the given type, identifier, path, service, source, and tags.
+func CopyConfig(ctype string, identifier string, path string, service string, source string, cfg *LogsConfig) *LogsConfig {
+	return &LogsConfig{
+		Type:                        ctype,
+		TailingMode:                 cfg.TailingMode,
+		Identifier:                  identifier,
+		Path:                        path,
+		Service:                     service,
+		Source:                      source,
+		Tags:                        cfg.Tags,
+		ProcessingRules:             cfg.ProcessingRules,
+		FingerprintConfig:           cfg.FingerprintConfig,
+		AutoMultiLine:               cfg.AutoMultiLine,
+		AutoMultiLineSampleSize:     cfg.AutoMultiLineSampleSize,
+		AutoMultiLineMatchThreshold: cfg.AutoMultiLineMatchThreshold,
+		AutoMultiLineOptions:        cfg.AutoMultiLineOptions,
+		AutoMultiLineSamples:        cfg.AutoMultiLineSamples,
+	}
+}
+
 // Validate returns an error if the config is misconfigured
 func (c *LogsConfig) Validate() error {
 	switch {

--- a/comp/logs/integrations/def/component.go
+++ b/comp/logs/integrations/def/component.go
@@ -30,4 +30,7 @@ type Component interface {
 
 	// SendLog allows integrations to send logs to any subscribers.
 	SendLog(log, integrationID string)
+
+	// SetActionCallback sets the callback to be called when integration actions are performed.
+	SetActionCallback(callback func() error)
 }

--- a/comp/logs/integrations/def/types.go
+++ b/comp/logs/integrations/def/types.go
@@ -5,7 +5,7 @@
 
 package integrations
 
-import "github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+import "github.com/DataDog/datadog-agent/pkg/logs/sources"
 
 // IntegrationLog represents the combined Log and IntegrationID for the
 // integration sending the log
@@ -17,5 +17,5 @@ type IntegrationLog struct {
 // IntegrationConfig represents the combined ID and Config for an integration
 type IntegrationConfig struct {
 	IntegrationID string
-	Config        integration.Config
+	Source        *sources.LogSource
 }

--- a/comp/logs/integrations/impl/integrations.go
+++ b/comp/logs/integrations/impl/integrations.go
@@ -31,7 +31,7 @@ type Logsintegration struct {
 
 // NewLogsIntegration creates a new integrations instance
 func NewLogsIntegration(log log.Component, config configComponent.Component) integrations.Component {
-	integrationTimeout := config.GetDuration("logs_config.integrations_logs_timeout")
+	integrationTimeout := time.Duration(config.GetInt("logs_config.integrations_logs_timeout")) * time.Second
 
 	return &Logsintegration{
 		logChan:            make(chan integrations.IntegrationLog),
@@ -39,7 +39,7 @@ func NewLogsIntegration(log log.Component, config configComponent.Component) int
 		log:                log,
 		actionCallback:     func() error { return nil },
 		registrationList:   make(map[string]bool),
-		integrationTimeout: integrationTimeout * time.Second,
+		integrationTimeout: integrationTimeout,
 	}
 }
 

--- a/comp/logs/integrations/impl/integrations.go
+++ b/comp/logs/integrations/impl/integrations.go
@@ -7,46 +7,108 @@
 package integrationsimpl
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/schedulers/ad"
 )
 
 // Logsintegration is the integrations component implementation
 type Logsintegration struct {
-	logChan         chan integrations.IntegrationLog
-	integrationChan chan integrations.IntegrationConfig
+	logChan            chan integrations.IntegrationLog
+	integrationChan    chan integrations.IntegrationConfig
+	log                log.Component
+	actionCallback     func() error
+	registrationList   map[string]bool
+	integrationTimeout time.Duration
 }
 
 // NewLogsIntegration creates a new integrations instance
-func NewLogsIntegration() *Logsintegration {
+func NewLogsIntegration(log log.Component, config configComponent.Component) *Logsintegration {
+	integrationTimeout := config.GetDuration("logs_config.integrations_logs_timeout")
+
 	return &Logsintegration{
-		logChan:         make(chan integrations.IntegrationLog),
-		integrationChan: make(chan integrations.IntegrationConfig),
+		logChan:            make(chan integrations.IntegrationLog),
+		integrationChan:    make(chan integrations.IntegrationConfig),
+		log:                log,
+		actionCallback:     func() error { return nil },
+		registrationList:   make(map[string]bool),
+		integrationTimeout: integrationTimeout * time.Second,
 	}
 }
 
 // RegisterIntegration registers an integration with the integrations component
-func (li *Logsintegration) RegisterIntegration(id string, config integration.Config) {
-	if len(config.LogsConfig) == 0 {
+func (li *Logsintegration) RegisterIntegration(id string, cfg integration.Config) {
+	if len(cfg.LogsConfig) == 0 {
 		return
 	}
 
-	integrationConfig := integrations.IntegrationConfig{
-		IntegrationID: id,
-		Config:        config,
+	sources, err := ad.CreateSources(cfg)
+	if err != nil {
+		li.log.Errorf("Failed to create source for %q: %v", cfg.Name, err)
+		return
 	}
 
-	li.integrationChan <- integrationConfig
+	for _, source := range sources {
+		// TODO: integrations should only be allowed to have one IntegrationType config.
+		if source.Config.Type == config.IntegrationType {
+			if err := li.actionCallback(); err != nil {
+				li.log.Errorf("Unable to register integration %s: %v", id, err)
+				return
+			}
+
+			li.log.Infof("Registering integration %s with source %s", id, source.Config.IntegrationName)
+
+			integrationConfig := integrations.IntegrationConfig{
+				IntegrationID: id,
+				Source:        source,
+			}
+
+			select {
+			case li.integrationChan <- integrationConfig:
+				li.registrationList[id] = true
+			case <-time.After(li.integrationTimeout):
+				li.log.Errorf("Integration could not be registered due to timeout, dropping all further logs for integration %s", id)
+				return
+			}
+
+			// We only support one integration log per id
+			return
+		}
+	}
 }
 
 // SendLog sends a log to any subscribers
 func (li *Logsintegration) SendLog(log, integrationID string) {
+	if _, ok := li.registrationList[integrationID]; !ok {
+		li.log.Warnf("Integration %s is not registered, dropping log", integrationID)
+		return
+	}
+
+	if err := li.actionCallback(); err != nil {
+		li.log.Errorf("Unable to send log for integration %s: %v", integrationID, err)
+		return
+	}
+
 	integrationLog := integrations.IntegrationLog{
 		Log:           log,
 		IntegrationID: integrationID,
 	}
 
-	li.logChan <- integrationLog
+	select {
+	case li.logChan <- integrationLog:
+	case <-time.After(li.integrationTimeout):
+		li.log.Warnf("Integration %s timed out sending a log", integrationID)
+	}
+}
+
+// SetActionCallback sets the callback to be called when integration actions are performed.
+func (li *Logsintegration) SetActionCallback(callback func() error) {
+	li.actionCallback = callback
 }
 
 // Subscribe returns the channel that receives logs from integrations. Currently

--- a/comp/logs/integrations/impl/integrations.go
+++ b/comp/logs/integrations/impl/integrations.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build !serverless
+
 // Package integrationsimpl implements the integrations component interface
 package integrationsimpl
 
@@ -28,7 +30,7 @@ type Logsintegration struct {
 }
 
 // NewLogsIntegration creates a new integrations instance
-func NewLogsIntegration(log log.Component, config configComponent.Component) *Logsintegration {
+func NewLogsIntegration(log log.Component, config configComponent.Component) integrations.Component {
 	integrationTimeout := config.GetDuration("logs_config.integrations_logs_timeout")
 
 	return &Logsintegration{

--- a/comp/logs/integrations/impl/integrations_serverless.go
+++ b/comp/logs/integrations/impl/integrations_serverless.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build serverless
+
+// Package integrationsimpl implements the integrations component interface
+package integrationsimpl
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+)
+
+// Logsintegration is the integrations component implementation
+type Logsintegration struct {
+}
+
+// NewLogsIntegration creates a new integrations instance
+func NewLogsIntegration(_ log.Component, _ configComponent.Component) integrations.Component {
+	return &Logsintegration{}
+}
+
+// RegisterIntegration registers an integration with the integrations component
+func (li *Logsintegration) RegisterIntegration(_ string, _ integration.Config) {
+}
+
+// SendLog sends a log to any subscribers
+func (li *Logsintegration) SendLog(_ string, _ string) {
+}
+
+// SetActionCallback sets the callback to be called when integration actions are performed.
+func (li *Logsintegration) SetActionCallback(_ func() error) {
+}
+
+// Subscribe returns the channel that receives logs from integrations. Currently
+// the integrations component only supports one subscriber, but can be extended
+// later by making a new channel for any number of subscribers.
+func (li *Logsintegration) Subscribe() chan integrations.IntegrationLog {
+	return nil
+}
+
+// SubscribeIntegration returns the channel that receives integration configurations
+func (li *Logsintegration) SubscribeIntegration() chan integrations.IntegrationConfig {
+	return nil
+}

--- a/comp/logs/integrations/impl/integrations_test.go
+++ b/comp/logs/integrations/impl/integrations_test.go
@@ -8,6 +8,7 @@
 package integrationsimpl
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -98,4 +99,64 @@ func TestReceiveEmptyConfig(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.True(t, true, "Channel remained empty.")
 	}
+}
+
+func TestErrorBatching(t *testing.T) {
+	mocklog := logmock.New(t)
+	comp := NewLogsIntegration(mocklog, configmock.New(t))
+	logsIntegration := comp.(*Logsintegration)
+	logsIntegration.errorBatchingInterval = time.Millisecond * 100
+	logsIntegration.SetActionCallback(func() error {
+		return nil
+	})
+
+	// Two sends before registration → counted as registration errors
+	logsIntegration.SendLog("test log", "integration1")
+	logsIntegration.SendLog("test log", "integration1")
+
+	logsIntegration.errorLock.Lock()
+	recRegistration := errorRecord{integrationID: "integration1", errorType: "registration"}
+	countReg := logsIntegration.errorList[recRegistration]
+	logsIntegration.errorLock.Unlock()
+	assert.Equal(t, 2, countReg, "expected 2 registration errors to be batched")
+
+	// Prepare a consumer for a successful send later
+	go func() {
+		<-logsIntegration.Subscribe()
+	}()
+	// Drain the integration registration to avoid sender timeout
+	go func() {
+		<-logsIntegration.SubscribeIntegration()
+	}()
+
+	// Ensure RegisterIntegration has reasonable time to succeed
+	logsIntegration.integrationTimeout = 250 * time.Millisecond
+	logsIntegration.RegisterIntegration("integration1", defaultConfig)
+
+	logsIntegration.SetActionCallback(func() error {
+		return errors.New("test error")
+	})
+	logsIntegration.integrationTimeout = time.Millisecond
+	logsIntegration.SendLog("test log", "integration1")
+	logsIntegration.SendLog("test log", "integration1")
+	logsIntegration.SendLog("test log", "integration1")
+
+	// Assert both registration and startup error counts before the interval flush
+	logsIntegration.errorLock.Lock()
+	recStartup := errorRecord{integrationID: "integration1", errorType: "logs agent startup"}
+	countStartup := logsIntegration.errorList[recStartup]
+	countReg2 := logsIntegration.errorList[recRegistration]
+	logsIntegration.errorLock.Unlock()
+	assert.Equal(t, 3, countStartup, "expected 3 startup errors to be batched")
+	assert.Equal(t, 2, countReg2, "registration error count should still be 2 before flush")
+
+	logsIntegration.SetActionCallback(func() error { return nil })
+	logsIntegration.SendLog("test log", "integration1")
+
+	// After the batching interval elapses, the batched error list should be cleared
+	time.Sleep(logsIntegration.errorBatchingInterval + 50*time.Millisecond)
+	logsIntegration.errorLock.Lock()
+	batchedSize := len(logsIntegration.errorList)
+	logsIntegration.errorLock.Unlock()
+	assert.Equal(t, 0, batchedSize, "batched error list should be cleared after interval")
 }

--- a/comp/logs/integrations/impl/integrations_test.go
+++ b/comp/logs/integrations/impl/integrations_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build !serverless
+
 package integrationsimpl
 
 import (
@@ -14,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
 var defaultConfig = integration.Config{
@@ -30,6 +33,11 @@ func TestNewComponent(t *testing.T) {
 // TestSendandSubscribe tests sending a log through the integrations component.
 func TestSendandSubscribe(t *testing.T) {
 	comp := NewLogsIntegration(logmock.New(t), configmock.New(t))
+	callbackCount := 0
+	comp.SetActionCallback(func() error {
+		callbackCount++
+		return nil
+	})
 
 	go func() {
 		comp.RegisterIntegration("integration1", defaultConfig)
@@ -49,6 +57,25 @@ func TestSendandSubscribe(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.Fail(t, "Expected channel to receive logs, but got nothing")
 	}
+
+	assert.Equal(t, 2, callbackCount, "Callback not called for both register and send.")
+}
+
+func TestSendWithoutRegister(t *testing.T) {
+	comp := NewLogsIntegration(logmock.New(t), configmock.New(t))
+	callbackCalled := false
+	comp.SetActionCallback(func() error {
+		callbackCalled = true
+		return nil
+	})
+
+	// SendLog should not block when the integration is not registered
+	testutil.AssertTrueBeforeTimeout(t, 10*time.Millisecond, 10*time.Millisecond, func() bool {
+		comp.SendLog("test log", "integration1")
+		return true
+	})
+
+	assert.False(t, callbackCalled, "Callback called without registering.")
 }
 
 // TestReceiveEmptyConfig ensures that ReceiveIntegration doesn't send an empty

--- a/comp/logs/integrations/mock/mock.go
+++ b/comp/logs/integrations/mock/mock.go
@@ -7,8 +7,12 @@
 package mock
 
 import (
+	"testing"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	integrationsimpl "github.com/DataDog/datadog-agent/comp/logs/integrations/impl"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 type mockIntegrations struct {
@@ -16,8 +20,8 @@ type mockIntegrations struct {
 }
 
 // Mock returns a mock for integrations component.
-func Mock() integrations.Component {
+func Mock(t *testing.T) integrations.Component {
 	return &mockIntegrations{
-		Logsintegration: integrationsimpl.NewLogsIntegration(),
+		Logsintegration: integrationsimpl.NewLogsIntegration(logmock.New(t), configmock.New(t)),
 	}
 }

--- a/comp/logs/integrations/mock/mock.go
+++ b/comp/logs/integrations/mock/mock.go
@@ -16,12 +16,12 @@ import (
 )
 
 type mockIntegrations struct {
-	*integrationsimpl.Logsintegration
+	integrations.Component
 }
 
 // Mock returns a mock for integrations component.
 func Mock(t *testing.T) integrations.Component {
 	return &mockIntegrations{
-		Logsintegration: integrationsimpl.NewLogsIntegration(logmock.New(t), configmock.New(t)),
+		integrationsimpl.NewLogsIntegration(logmock.New(t), configmock.New(t)),
 	}
 }

--- a/comp/logs/streamlogs/impl/streamlogs.go
+++ b/comp/logs/streamlogs/impl/streamlogs.go
@@ -98,6 +98,9 @@ func exportStreamLogs(la logsAgent.Component, logger logger.Component, streamLog
 	}()
 
 	messageReceiver := la.GetMessageReceiver()
+	if messageReceiver == nil {
+		return errors.New("logs agent is not started")
+	}
 
 	if !messageReceiver.SetEnabled(true) {
 		return errors.New("unable to enable message receiver, another client is already streaming logs")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1792,6 +1792,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.integrations_logs_total_usage", 100)
 	// Do not store logs on disk when the disk usage exceeds 80% of the disk capacity.
 	config.BindEnvAndSetDefault("logs_config.integrations_logs_disk_ratio", 0.80)
+	// Timeout for integration logs to be registered/sent
+	config.BindEnvAndSetDefault("logs_config.integrations_logs_timeout", 10)
 
 	// SDS logs blocking mechanism
 	config.BindEnvAndSetDefault("logs_config.sds.wait_for_configuration", "")

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1793,7 +1793,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// Do not store logs on disk when the disk usage exceeds 80% of the disk capacity.
 	config.BindEnvAndSetDefault("logs_config.integrations_logs_disk_ratio", 0.80)
 	// Timeout for integration logs to be registered/sent
-	config.BindEnvAndSetDefault("logs_config.integrations_logs_timeout", 10)
+	config.BindEnvAndSetDefault("logs_config.integrations_logs_timeout", "10s")
 
 	// SDS logs blocking mechanism
 	config.BindEnvAndSetDefault("logs_config.sds.wait_for_configuration", "")

--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -77,6 +77,10 @@ func (b *BufferedMessageReceiver) SetEnabled(e bool) bool {
 	b.m.Lock()
 	defer b.m.Unlock()
 
+	if b.inputChan == nil {
+		return false
+	}
+
 	if b.enabled == e {
 		return false
 	}

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -120,24 +120,9 @@ func (tf *factory) makeDockerFileSource(source *sources.LogSource) (*sources.Log
 	f.Close()
 
 	sourceName, serviceName := tf.defaultSourceAndService(source, containersorpods.LogContainers)
-
+	newConfig := config.CopyConfig(config.FileType, containerID, path, serviceName, sourceName, source.Config)
 	// New file source that inherits most of its parent's properties
-	fileSource := sources.NewLogSource(source.Name, &config.LogsConfig{
-		Type:                        config.FileType,
-		TailingMode:                 source.Config.TailingMode,
-		Identifier:                  containerID,
-		Path:                        path,
-		Service:                     serviceName,
-		Source:                      sourceName,
-		Tags:                        source.Config.Tags,
-		ProcessingRules:             source.Config.ProcessingRules,
-		FingerprintConfig:           source.Config.FingerprintConfig,
-		AutoMultiLine:               source.Config.AutoMultiLine,
-		AutoMultiLineSampleSize:     source.Config.AutoMultiLineSampleSize,
-		AutoMultiLineMatchThreshold: source.Config.AutoMultiLineMatchThreshold,
-		AutoMultiLineOptions:        source.Config.AutoMultiLineOptions,
-		AutoMultiLineSamples:        source.Config.AutoMultiLineSamples,
-	})
+	fileSource := sources.NewLogSource(source.Name, newConfig)
 
 	// inform the file launcher that it should expect docker-formatted content
 	// in this file
@@ -229,25 +214,9 @@ func (tf *factory) makeK8sFileSource(source *sources.LogSource) (*sources.LogSou
 	// kubernetes-launcher behavior.
 
 	sourceName, serviceName := tf.defaultSourceAndService(source, containersorpods.LogPods)
+	newConfig := config.CopyConfig(config.FileType, containerID, path, serviceName, sourceName, source.Config)
 	// New file source that inherits most of its parent's properties
-	fileSource := sources.NewLogSource(
-		fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Name),
-		&config.LogsConfig{
-			Type:                        config.FileType,
-			TailingMode:                 source.Config.TailingMode,
-			Identifier:                  containerID,
-			Path:                        path,
-			Service:                     serviceName,
-			Source:                      sourceName,
-			Tags:                        source.Config.Tags,
-			ProcessingRules:             source.Config.ProcessingRules,
-			FingerprintConfig:           source.Config.FingerprintConfig,
-			AutoMultiLine:               source.Config.AutoMultiLine,
-			AutoMultiLineSampleSize:     source.Config.AutoMultiLineSampleSize,
-			AutoMultiLineMatchThreshold: source.Config.AutoMultiLineMatchThreshold,
-			AutoMultiLineOptions:        source.Config.AutoMultiLineOptions,
-			AutoMultiLineSamples:        source.Config.AutoMultiLineSamples,
-		})
+	fileSource := sources.NewLogSource(fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Name), newConfig)
 
 	switch source.Config.Type {
 	case config.DockerType:

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -69,7 +69,6 @@ type oldTailerInfo struct {
 
 // NewLauncher returns a new launcher.
 func NewLauncher(tailingLimit int, tailerSleepDuration time.Duration, validatePodContainerID bool, scanPeriod time.Duration, wildcardMode string, flarecontroller *flareController.FlareController, tagger tagger.Component, fingerprintConfig types.FingerprintConfig) *Launcher {
-
 	var wildcardStrategy fileprovider.WildcardSelectionStrategy
 	switch wildcardMode {
 	case "by_modification_time":

--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -157,6 +157,10 @@ func (s *Launcher) run() {
 // receiveSources handles receiving incoming sources
 func (s *Launcher) receiveSources(cfg integrations.IntegrationConfig) {
 	source := cfg.Source
+	if source == nil {
+		ddLog.Warn("Received a nil source for integration ID:", cfg.IntegrationID)
+		return
+	}
 
 	// This check avoids duplicating files that have already been created
 	// by scanInitialFiles

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -15,6 +15,10 @@ import (
 var (
 	// LogsExpvars contains metrics for the logs agent.
 	LogsExpvars *expvar.Map
+
+	// TlmLogsHungStart is incremented when the logs agent did not start within the expected amount of time
+	TlmLogsHungStart = telemetry.NewCounter("logs", "hung_start",
+		nil, "Incremented when the logs agent did not start within the expected amount of time")
 	// LogsDecoded is the total number of decoded logs
 	LogsDecoded = expvar.Int{}
 	// TlmLogsDecoded is the total number of decoded logs

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -31,6 +31,8 @@ const (
 	StatusNotStarted = 0
 	// StatusRunning means that the logs agent is running and fully operational
 	StatusRunning = 1
+	// StatusStopped means that the logs agent is stopped
+	StatusStopped = 2
 )
 
 var (

--- a/releasenotes/notes/logs-agent-lazy-load-8c76a20c3a1ec6f7.yaml
+++ b/releasenotes/notes/logs-agent-lazy-load-8c76a20c3a1ec6f7.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    In a default configuration with no `logs_enabled` set, the Logs Agent is now lazy loaded and won't start until the first log is received.
+    In a default configuration without `logs_enabled` set, the Logs Agent is now lazy-loaded and doesn't start until the first log is received.

--- a/releasenotes/notes/logs-agent-lazy-load-8c76a20c3a1ec6f7.yaml
+++ b/releasenotes/notes/logs-agent-lazy-load-8c76a20c3a1ec6f7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    In a default configuration with no `logs_enabled` set, the Logs Agent is now lazy loaded and won't start until the first log is received.

--- a/test/regression/cases/ddot_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/ddot_logs/datadog-agent/datadog.yaml
@@ -5,7 +5,7 @@ auth_token_file_path: /tmp/agent-auth-token
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/ddot_metrics/datadog-agent/datadog.yaml
+++ b/test/regression/cases/ddot_metrics/datadog-agent/datadog.yaml
@@ -5,7 +5,7 @@ auth_token_file_path: /tmp/agent-auth-token
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/docker_containers_cpu/datadog-agent/datadog.yaml
+++ b/test/regression/cases/docker_containers_cpu/datadog-agent/datadog.yaml
@@ -15,8 +15,8 @@ telemetry:
 checks_tag_cardinality: high
 dogstatsd_origin_detection: true
 dogstatsd_tag_cardinality: high
-log_enabled: true
-logs_enabled: true
+
+
 container_labels_as_tags:
   foo: label_foo
   bar: label_bar

--- a/test/regression/cases/docker_containers_memory/datadog-agent/datadog.yaml
+++ b/test/regression/cases/docker_containers_memory/datadog-agent/datadog.yaml
@@ -15,8 +15,8 @@ telemetry:
 checks_tag_cardinality: high
 dogstatsd_origin_detection: true
 dogstatsd_tag_cardinality: high
-log_enabled: true
-logs_enabled: true
+
+
 container_labels_as_tags:
   foo: label_foo
   bar: label_bar

--- a/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   file_scan_period: 1

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   file_scan_period: 1

--- a/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   file_scan_period: 1

--- a/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   file_scan_period: 1

--- a/test/regression/cases/file_tree/datadog-agent/datadog.yaml
+++ b/test/regression/cases/file_tree/datadog-agent/datadog.yaml
@@ -5,7 +5,7 @@ auth_token_file_path: /tmp/agent-auth-token
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 
 dd_url: http://127.0.0.1:9091
 telemetry:

--- a/test/regression/cases/otlp_ingest_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/otlp_ingest_logs/datadog-agent/datadog.yaml
@@ -5,7 +5,7 @@ auth_token_file_path: /tmp/agent-auth-token
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/otlp_ingest_metrics/datadog-agent/datadog.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/datadog-agent/datadog.yaml
@@ -5,7 +5,7 @@ auth_token_file_path: /tmp/agent-auth-token
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/quality_gate_idle/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle/datadog-agent/datadog.yaml
@@ -10,3 +10,5 @@ cloud_provider_metadata: []
 
 telemetry.enabled: true
 telemetry.checks: '*'
+
+logs_enabled: false

--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/datadog.yaml
@@ -12,7 +12,7 @@ dogstatsd_socket: '/tmp/dsd.socket'
 telemetry.enabled: true
 telemetry.checks: '*'
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9091
   logs_no_ssl: true

--- a/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_logs/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/quality_gate_metrics_logs/datadog-agent/datadog.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/datadog-agent/datadog.yaml
@@ -7,7 +7,7 @@ cloud_provider_metadata: []
 
 dd_url: http://127.0.0.1:9091
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/datadog-agent/datadog.yaml
@@ -11,7 +11,7 @@ telemetry.checks: '*'
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9091
   logs_no_ssl: true

--- a/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/datadog-agent/datadog.yaml
@@ -11,7 +11,7 @@ telemetry.checks: '*'
 # has network access.
 cloud_provider_metadata: []
 
-logs_enabled: true
+
 logs_config:
   logs_dd_url: 127.0.0.1:9092
   logs_no_ssl: true


### PR DESCRIPTION
The Logs Agent currently defaults to a disabled state, which makes onboarding new users more difficult. An idle logs agent takes a small but real amount of system resources, and we would prefer to not change the default behavior completely for users who do not want the logs agent but have not explicitly altered the configuration to disable. Logs agent lazy loading is a middle ground - by default when the logs agent is neither enabled nor disabled, it will exist in a partially initiated state. In this state it will use only the bare minimum amount of resources to watch for viable log configs to be provided to the agent - when one is, the entire logs agent will startup and operate normally.

### What does this PR do?
If the logs agent detects that it should be lazily loaded, it will start up its schedulers and initialize the required FX dependencies. Once in that state, there are three pathways to enable the full agent:
1. New sources are added by the schedulers. This is the primary way the agent will start up, as both local configuration and autodiscovery pathways route through this functionality.
2. A new logs integration is detected and registered. The integrations.go file has been modified slightly to support operations performed before the integrations launcher has been started by the logs agent.
3. A pipeline provider is requested (via the otel agent). The agent is started rather than returning a nil pipeline due to the agent's presence in fx components - unless fully disabled, the otel agent may expect that the logs agent can safely provide a new pipeline.

There are additionally three exposed functions that will not trigger an agent startup when called
1. AddScheduler - this function modifies scheduler state, which will always be started even in lazy load status
2. GetSources - the sources entity is fully initiated alongside the agent fx dependencies and should be safe to manipulate even if the agent is not yet started
3. GetMessageReceiver - utilized by the stream logs flow, the message receiver will be nil if the agent is not yet started. Slight modifications have been made to callers in order to fully support this flow, which will correctly cause streamlogs to treat the logs agent as disabled when it is not yet started.

As a result of these changes, SMP regression tests have been modified to better represent the new Logs Agent defaults. The 'quality_gate_idle' test is designed to test the most minimal feature set and so now has the logs agent explicitly disabled rather than implicitly disabled. All tests that had `logs_enabled` set to true have also had that configuration option removed - the expectation is that the new lazy loading feature will provide equivalent functionality for all of these tests.

### Describe how you validated your changes (if not by through tests)
In addition to testing expansion, the two confguration-based enablement pathways were manually tested in both host and kubernetes deployments. Tests were structured with lazy loading enabled (no logs_enabled configuration field defined), and making sure the agent was disabled at startup but safely enabled and ingested logs once the enablement pathway being tested was called. Sample configurations are provided below.
In addition, stream logs was manually tested in a number of agent states.

#### New Source Additions:
Option 1: static configuration present at agent startup
have a conf.yaml set up in the relevant conf.d folder:
```
logs:
  - type: file
    path: "/Users/username/trial_log.txt"
    source: "test_source"
    service: "test-service"
```

Option 2: utilize annotations in a kubernetes environment:
```
     annotations:
        ad.datadoghq.com/app2.logs: |
          [{
            "source":"test_source",
            "service":"test-service",
          }]    
```

#### Logs Integration
define a custom python check configuration (e.g. conf.d/custom_checks/custom_checks.yaml):
```
init_config:
instances:
  - min_collection_interval: 1

logs:
  - type: integration
    service: custom_checks
    source: custom_checks
```

and a corresponding python file (e.g. checks.d/custom_check.py)
```
from datadog_checks.base.checks import AgentCheck

class HelloCheck(AgentCheck):
  def check(self, instance): 
    log = {"message": "hello world"}
    self.send_log(log)
```
### Possible Drawbacks / Trade-offs
Memory usage will increase in the default configuration on the order of hundreds of kilobytes. Both the fully enabled and the fully disabled configurations will experience no operational change.

Additionally, one of the primary risks for a change of this nature is that an unexpected interaction occurs between another piece of code and an unstarted logs agent that either disables or hangs the log agent startup behavior. A new metric `logs.hung_start` has been added to add visibility to any cases where the logs agent was asked to startup following a lazy initialization but failed/hung in the attempt.
