### PR TITLE
Bump the Python version for linters to Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 # character.
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 exclude = [
     ".git",
     ".github",
@@ -50,7 +50,7 @@ ban-relative-imports = "all"
 quote-style = "preserve"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 # Follows imports and type-check imported modules.
 follow_imports = "normal"
 # Ignore errors about imported packages that don't provide type hints.

--- a/tasks/kernel_matrix_testing/init_kmt.py
+++ b/tasks/kernel_matrix_testing/init_kmt.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import getpass
 import os
 import shutil
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,11 +31,6 @@ def init_kernel_matrix_testing_system(
 
     info("[+] Installing OS-specific general requirements...")
     kmt_os.install_requirements(ctx)
-
-    if sys.version_info >= (3, 12):
-        resp = ask("Python 3.12+ is not tested yet with KMT, some packages might not be available. Continue? (y/N)? ")
-        if resp.lower().strip() != "y":
-            raise Exit("Aborted by user")
 
     # trigger install of dependencies
     if is_installed("dda"):


### PR DESCRIPTION
### What does this PR do?

Bump the Python version for linters to Python 3.12

### Motivation

- We already use Python 3.12 on the Agent, this was left behind

### Describe how you validated your changes (if not by through tests)

- `dda -- inv linter.python`
- CI

### Note

I asked @gjulianm and we can remove the block in the KMT tests
