### PR TITLE
feat(Tagger.EnrichTags): detect container ID mismatch

### DIFF
--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -61,6 +61,10 @@ type Store struct {
 	// to generate a container ID from Origin Info.
 	OriginInfoRequests telemetry.Counter
 
+	// OriginInfoContainerIDMismatch tracks the number of times container IDs from Origin Info
+	// were mismatched during enrichment.
+	OriginInfoContainerIDMismatch telemetry.Counter
+
 	LowCardinalityQueries          CardinalityTelemetry
 	OrchestratorCardinalityQueries CardinalityTelemetry
 	HighCardinalityQueries         CardinalityTelemetry
@@ -126,6 +130,12 @@ func NewStore(telemetryComp telemetry.Component) *Store {
 		// to generate a container ID from origin info.
 		OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
 			[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
+			commonOpts),
+
+		// OriginInfoContainerIDMismatch tracks the number of times container IDs from Origin Info
+		// were mismatched during enrichment.
+		OriginInfoContainerIDMismatch: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_container_id_mismatch",
+			[]string{}, "Number of times container IDs from Origin Info where mismatched during enrichment.",
 			commonOpts),
 
 		LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),


### PR DESCRIPTION
<!-- This is just a template. Please delete all unneeded sections and add others if appropriate. -->

### What does this PR do?
Adds a debug log and telemetry to detect when we have a mismatch in container IDs during tag enrichment.

### Motivation
This is done to help debug potential issues around Origin Detection in cases where we suspect PID reuse.

### Describe how you validated your changes (if not by through tests)
Changes are validated by unit tests and E2E tests.

### Possible Drawbacks / Trade-offs
N/A