### PR TITLE
otel poc

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
@@ -10,16 +10,18 @@ import (
 	"context"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/otel"
 
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 	exp "go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 )
 
 const (
@@ -37,6 +39,20 @@ type Config struct {
 	OtelSource    string
 	LogSourceName string
 	QueueSettings exporterhelper.QueueBatchConfig
+
+	OrchestratorConfig OrchestratorConfig
+}
+
+type OrchestratorConfig struct {
+	// ClusterName is the name of the Kubernetes cluster to associate with the orchestrator data.
+	ClusterName string
+	Hostname    hostnameinterface.Component
+	Key         string
+	Site        string
+
+	// Endpoints is a map of orchestrator endpoints to send data to.
+	// The key is the endpoint URL, the value is the API key to use for that
+	Endpoints map[string]string
 }
 
 type factory struct {

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -1,9 +1,9 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter
 
-go 1.23.0
+go 1.24.0
 
 require (
-	github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312
+	github.com/DataDog/agent-payload/v5 v5.0.169
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.57.0-devel.0.20240718200853-81bf3b2e412d

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -3,14 +3,18 @@ module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/lo
 go 1.23.0
 
 require (
+	github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312
+	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.57.0-devel.0.20240718200853-81bf3b2e412d
 	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0
+	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.69.0
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.64.0
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.26.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs v0.26.0
+	github.com/google/uuid v1.6.0
 	github.com/stormcat24/protodep v0.1.8
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.30.0
@@ -18,6 +22,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.123.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.123.0
 	go.opentelemetry.io/collector/pdata v1.30.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -53,6 +58,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
+	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
@@ -69,6 +75,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/option v0.64.0-devel // indirect
@@ -79,10 +86,12 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.35.0 // indirect
+	github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.26.0 // indirect
 	github.com/DataDog/sketches-go v1.4.7 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
+	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
@@ -96,10 +105,11 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683 // indirect
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -108,6 +118,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
@@ -116,6 +127,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.3 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tinylib/msgp v1.2.5 // indirect
@@ -136,8 +148,9 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/dig v1.18.1 // indirect
+	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
@@ -252,6 +265,11 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/networkdevice/profile => ../../../../../../pkg/networkdevice/profile
 	github.com/DataDog/datadog-agent/pkg/networkpath/payload => ../../../../../../pkg/networkpath/payload
 	github.com/DataDog/datadog-agent/pkg/obfuscate => ../../../../../../pkg/obfuscate
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata => ../../../../../../pkg/opentelemetry-mapping-go/inframetadata
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest => ../../../../../../pkg/opentelemetry-mapping-go/inframetadata/gohai/internal/gohaitest
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes => ../../../../../../pkg/opentelemetry-mapping-go/otlp/attributes
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs => ../../../../../../pkg/opentelemetry-mapping-go/otlp/logs
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics => ../../../../../../pkg/opentelemetry-mapping-go/otlp/metrics
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model => ../../../../../../pkg/orchestrator/model
 	github.com/DataDog/datadog-agent/pkg/process/util/api => ../../../../../../pkg/process/util/api
 	github.com/DataDog/datadog-agent/pkg/proto => ../../../../../../pkg/proto
@@ -288,6 +306,8 @@ replace (
 	github.com/DataDog/datadog-agent/pkg/util/otel => ../../../../../../pkg/util/otel
 	github.com/DataDog/datadog-agent/pkg/util/pointer => ../../../../../../pkg/util/pointer
 	github.com/DataDog/datadog-agent/pkg/util/prometheus => ../../../../../../pkg/util/prometheus
+	github.com/DataDog/datadog-agent/pkg/util/quantile => ../../../../../../pkg/util/quantile
+	github.com/DataDog/datadog-agent/pkg/util/quantile/sketchtest => ../../../../../../pkg/util/quantile/sketchtest
 	github.com/DataDog/datadog-agent/pkg/util/scrubber => ../../../../../../pkg/util/scrubber
 	github.com/DataDog/datadog-agent/pkg/util/sort => ../../../../../../pkg/util/sort
 	github.com/DataDog/datadog-agent/pkg/util/startstop => ../../../../../../pkg/util/startstop

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312 h1:5Qed+J3s0h5c+iwmbC4zpQVYQn9mOpvFTbsvT82T+yU=
-github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312/go.mod h1:U2XeTRBMNHddAf4C1g2MnYXiaHQhBNQuItMYZ+PFJh4=
+github.com/DataDog/agent-payload/v5 v5.0.169 h1:fhUMUxOqAd/OhfewQ8Iq+WTV5peH4fpf2eUs6Q4W2sE=
+github.com/DataDog/agent-payload/v5 v5.0.169/go.mod h1:9PtvPKsgZVTTvqgYtcwB4bjXAkxYzC2wzSXSadPRHv8=
 github.com/DataDog/datadog-api-client-go/v2 v2.35.0 h1:Fj0C0HH5nAolFVdagLOBYMqaYPQ7iy7hLEmS/6gJ9QE=
 github.com/DataDog/datadog-api-client-go/v2 v2.35.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.sum
@@ -1,7 +1,11 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312 h1:5Qed+J3s0h5c+iwmbC4zpQVYQn9mOpvFTbsvT82T+yU=
+github.com/DataDog/agent-payload/v5 v5.0.164-0.20250828093710-e6d1e87f5312/go.mod h1:U2XeTRBMNHddAf4C1g2MnYXiaHQhBNQuItMYZ+PFJh4=
 github.com/DataDog/datadog-api-client-go/v2 v2.35.0 h1:Fj0C0HH5nAolFVdagLOBYMqaYPQ7iy7hLEmS/6gJ9QE=
 github.com/DataDog/datadog-api-client-go/v2 v2.35.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
+github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53ygRHxKKo+KM+nw+zz0hEdKztMo=
+github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.26.0 h1:QE9zSsO9/9SNi42QqreAuSF/p4WqqxuOA8ZopcAISbY=
 github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.26.0/go.mod h1:wQqLncH+WX3SGmbXXhNHGYrMbGBNfxgdZeAdadv2c6M=
 github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.26.0 h1:GlvoS6hJN0uANUC3fjx72rOgM4StAKYo2HtQGaasC7s=
@@ -14,6 +18,8 @@ github.com/DataDog/viper v1.14.0 h1:dIjTe/uJiah+QFqFZ+MXeqgmUvWhg37l37ZxFWxr3is=
 github.com/DataDog/viper v1.14.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
+github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f/go.mod h1:oXfOhM/Kr8OvqS6tVqJwxPBornV0yrx3bc+l0BDr7PQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -50,6 +56,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -144,6 +151,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
 github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/providers/confmap v0.1.0 h1:gOkxhHkemwG4LezxxN8DMOFopOPghxRVp7JbIvdvqzU=
@@ -191,6 +200,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -235,6 +246,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shirou/gopsutil/v4 v4.25.3 h1:SeA68lsu8gLggyMbmCn8cmp97V1TI9ld9sVzAUcKcKE=
 github.com/shirou/gopsutil/v4 v4.25.3/go.mod h1:xbuxyoZj+UsgnZrENu3lQivsngRR5BdjbJwf2fv4szA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -114,12 +114,12 @@ func toManifest(ctx context.Context, logRecord plog.LogRecord, resource pcommon.
 
 func toManifestPayload(ctx context.Context, manifests []*agentmodel.Manifest, hostName, clusterName, clusterID string) *agentmodel.CollectorManifest {
 	return &agentmodel.CollectorManifest{
-		ClusterName: clusterName,
-		ClusterId:   clusterID,
-		HostName:    hostName,
-		Manifests:   manifests,
-		Tags:        buildCommonTags(),
-		Source:      "datadog-exporter",
+		ClusterName:     clusterName,
+		ClusterId:       clusterID,
+		HostName:        hostName,
+		Manifests:       manifests,
+		Tags:            buildCommonTags(),
+		OriginCollector: agentmodel.OriginCollector_datadogExporter,
 	}
 }
 

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -1,0 +1,286 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package logsagentexporter
+
+import (
+	"bytes"
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stormcat24/protodep/pkg/logger"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/zap"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+	orchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
+)
+
+func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err error) {
+	var manifests []*agentmodel.Manifest
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		resourceLogs := ld.ResourceLogs().At(i)
+		resource := resourceLogs.Resource()
+
+		for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
+			scopeLogs := resourceLogs.ScopeLogs().At(j)
+
+			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
+				logRecord := scopeLogs.LogRecords().At(k)
+
+				// Convert Kubernetes resource manifest to orchestrator payload format
+				manifest, err := toManifest(ctx, logRecord, resource)
+				if err != nil {
+					logger.Error("Failed to convert to manifest", zap.Error(err))
+					continue
+				}
+
+				// ToDo: add 3m TTL cache to avoid sending the same manifest multiple times in a short period
+				manifests = append(manifests, manifest)
+			}
+		}
+	}
+
+	hostname, err := e.orchestratorConfig.Hostname.Get(ctx)
+	if err != nil || hostname == "" {
+		logger.Error("Failed to get hostname from config", zap.Error(err))
+	}
+
+	clusterID := buildClusterID(e.orchestratorConfig.ClusterName)
+
+	payload := toManifestPayload(ctx, manifests, hostname, e.orchestratorConfig.ClusterName, clusterID)
+
+	if err := sendManifestPayload(ctx, e.orchestratorConfig, payload, hostname, clusterID); err != nil {
+		logger.Error("Failed to send collector manifest", zap.Error(err))
+	}
+	return nil
+}
+
+func toManifest(ctx context.Context, logRecord plog.LogRecord, resource pcommon.Resource) (*agentmodel.Manifest, error) {
+	// Extract the Kubernetes resource data from the log record body
+	var k8sResource map[string]interface{}
+	if err := json.Unmarshal([]byte(logRecord.Body().AsString()), &k8sResource); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal k8s resource: %w", err)
+	}
+
+	// Todo: check if k8sResource is supported, for example if kind is configmap, secret, etc, we skip it
+
+	// Convert the Kubernetes resource to JSON bytes for the manifest content
+	content, err := json.Marshal(k8sResource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal k8s resource content: %w", err)
+	}
+
+	// Extract resource type and version from the Kubernetes resource
+	apiVersion, _ := k8sResource["apiVersion"].(string)
+	kind, _ := k8sResource["kind"].(string)
+	metadata, _ := k8sResource["metadata"].(map[string]interface{})
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+
+	// Determine manifest type based on the Kubernetes resource kind
+	manifestType := getManifestType(kind)
+
+	// Build tags from resource and log record attributes
+	// ToDo: add more meaningful tags
+	tags := buildTags(resource, logRecord)
+
+	// Create the manifest
+	manifest := &agentmodel.Manifest{
+		Type:            int32(manifestType),
+		ResourceVersion: resourceVersion,
+		Uid:             uid,
+		Content:         content,
+		ContentType:     "application/json",
+		Version:         "v1",
+		Tags:            tags,
+		IsTerminated:    false,
+		ApiVersion:      apiVersion,
+		Kind:            kind,
+	}
+	return manifest, nil
+}
+
+func toManifestPayload(ctx context.Context, manifests []*agentmodel.Manifest, hostName, clusterName, clusterID string) *agentmodel.CollectorManifest {
+	return &agentmodel.CollectorManifest{
+		ClusterName: clusterName,
+		ClusterId:   clusterID,
+		HostName:    hostName,
+		Manifests:   manifests,
+		Tags:        buildCommonTags(),
+		Source:      "datadog-exporter",
+	}
+}
+
+func sendManifestPayload(ctx context.Context, config OrchestratorConfig, payload *agentmodel.CollectorManifest, hostName, clusterID string) error {
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	endpoints := getEndpoints(config)
+
+	encoded, err := agentmodel.EncodeMessage(agentmodel.Message{
+		Header: agentmodel.MessageHeader{
+			Version:  agentmodel.MessageV3,
+			Encoding: agentmodel.MessageEncodingZstdPBxNoCgo,
+			Type:     agentmodel.TypeCollectorManifest,
+		}, Body: payload})
+	if err != nil {
+		return fmt.Errorf("failed to encode payload: %w", err)
+	}
+
+	for endpoint, apiKey := range endpoints {
+		// Create the request
+		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(encoded))
+		if err != nil {
+			logger.Error("Failed to create request", zap.Error(err))
+			continue
+		}
+
+		// Set headers
+		req.Header.Set("Content-Type", "application/x-protobuf")
+		req.Header.Set("DD-API-KEY", string(apiKey))
+		req.Header.Set("X-Dd-Hostname", hostName)
+		req.Header.Set("X-DD-Agent-Timestamp", strconv.Itoa(int(time.Now().Unix())))
+		req.Header.Set("X-Dd-Orchestrator-ClusterID", clusterID)
+		req.Header.Set("DD-EVP-ORIGIN", "agent")
+		req.Header.Set("DD-EVP-ORIGIN-VERSION", "1.0.0") // ToDo: set the actual version
+
+		// Send the request
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			logger.Error("Failed to send request", zap.String("endpoint", endpoint), zap.Error(err))
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+			logger.Error("Orchestrator endpoint returned non-200 status", zap.String("endpoint", endpoint), zap.Int("status", resp.StatusCode))
+			continue
+		}
+		err = resp.Body.Close()
+		if err != nil {
+			logger.Error("Failed to close response body", zap.String("endpoint", endpoint), zap.Error(err))
+		}
+	}
+	return nil
+}
+
+// ToDo: in cluster agent, we use kube-system namespace UID as cluster ID, here we only have cluster name
+// If two clusters have the same name, it will generate the same cluster ID, which is not ideal
+// Find a better way to generate cluster ID
+func buildClusterID(clusterName string) string {
+	hash := md5.New()
+	hash.Write([]byte(clusterName))
+	hashString := hex.EncodeToString(hash.Sum(nil))
+	uuid, err := uuid.FromBytes([]byte(hashString[0:16]))
+	if err != nil {
+		logger.Error("Failed to generate UUID", zap.Error(err))
+		return ""
+	}
+	return uuid.String()
+}
+
+// ToDo: add more types if needed
+func getManifestType(kind string) int {
+	switch kind {
+	case "Pod":
+		return int(orchestratormodel.K8sPod)
+	case "Deployment":
+		return int(orchestratormodel.K8sDeployment)
+	case "Service":
+		return int(orchestratormodel.K8sService)
+	case "Node":
+		return int(orchestratormodel.K8sNode)
+	case "Namespace":
+		return int(orchestratormodel.K8sNamespace)
+	case "ReplicaSet":
+		return int(orchestratormodel.K8sReplicaSet)
+	case "DaemonSet":
+		return int(orchestratormodel.K8sDaemonSet)
+	case "StatefulSet":
+		return int(orchestratormodel.K8sStatefulSet)
+	case "Job":
+		return int(orchestratormodel.K8sJob)
+	case "CronJob":
+		return int(orchestratormodel.K8sCronJob)
+	case "PersistentVolume":
+		return int(orchestratormodel.K8sPersistentVolume)
+	case "PersistentVolumeClaim":
+		return int(orchestratormodel.K8sPersistentVolumeClaim)
+	case "Ingress":
+		return int(orchestratormodel.K8sIngress)
+	case "NetworkPolicy":
+		return int(orchestratormodel.K8sNetworkPolicy)
+	case "StorageClass":
+		return int(orchestratormodel.K8sStorageClass)
+	case "LimitRange":
+		return int(orchestratormodel.K8sLimitRange)
+	case "PodDisruptionBudget":
+		return int(orchestratormodel.K8sPodDisruptionBudget)
+	default:
+		// For unknown types, use the generic manifest type
+		return int(orchestratormodel.K8sUnsetType)
+	}
+}
+
+// ToDo: add more common tags
+func buildCommonTags() []string {
+	return []string{
+		"otel_receiver:k8sobjectsreceiver",
+	}
+}
+
+// ToDo: add more meaningful tags
+func buildTags(resource pcommon.Resource, logRecord plog.LogRecord) []string {
+	tags := buildCommonTags()
+
+	// Add resource attributes as tags
+	resource.Attributes().Range(func(key string, value pcommon.Value) bool {
+		tags = append(tags, fmt.Sprintf("%s:%s", key, value.AsString()))
+		return true
+	})
+
+	// Add log record attributes as tags
+	logRecord.Attributes().Range(func(key string, value pcommon.Value) bool {
+		tags = append(tags, fmt.Sprintf("%s:%s", key, value.AsString()))
+		return true
+	})
+
+	return tags
+}
+
+// ToDo: consider using some common function we already have in the agent codebase if possible
+func getEndpoints(config OrchestratorConfig) map[string]string {
+	suffix := "api/v2/orchmanif"
+
+	endpoints := make(map[string]string)
+	for ep, apiKey := range config.Endpoints {
+		if ep != "" {
+			if !strings.HasSuffix(ep, suffix) {
+				if strings.HasSuffix(ep, "/") {
+					ep = ep + suffix
+				} else {
+					ep = fmt.Sprintf("%s/%s", ep, suffix)
+				}
+
+			}
+			endpoints[ep] = apiKey
+		}
+	}
+
+	if len(endpoints) == 0 {
+		endpoints[fmt.Sprintf("https://orchestrator.%s/%s", config.Site, suffix)] = config.Key
+	}
+	return endpoints
+}


### PR DESCRIPTION
updating the current Datadog logs exporter with logic to check the scope name of incoming logs:

- If the scope name is k8sobject receiver → the logs will be routed to our team’s custom processing logic and sent to our backend.
- Otherwise → the logs will follow the existing log processing flow.