### PR TITLE
[cxp] Remove flake marker from tests

### DIFF
--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/DataDog/gopsutil/host"
 	// using process.AllProcesses()
 	"github.com/DataDog/gopsutil/process"
-
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 var (
@@ -983,8 +981,6 @@ func TestBootTimeLocalFS(t *testing.T) {
 }
 
 func TestBootTimeRefresh(t *testing.T) {
-	// https://datadoghq.atlassian.net/browse/PROCS-3981
-	flake.Mark(t)
 	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500*time.Millisecond), WithProcFSRoot("resources/test_procfs/proc/"))
 	defer probe.Close()
 

--- a/test/new-e2e/tests/language-detection/node_test.go
+++ b/test/new-e2e/tests/language-detection/node_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 // nodeMajor is the major version of nodejs that will be installed
@@ -37,7 +35,6 @@ func (s *languageDetectionSuite) installNode() {
 }
 
 func (s *languageDetectionSuite) TestNodeDetection() {
-	flake.Mark(s.T())
 	s.installNode()
 
 	s.Env().RemoteHost.MustExecute(fmt.Sprintf(`echo "%s" > prog.js`, nodeProg))

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -13,16 +13,14 @@ import (
 	"time"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -241,7 +239,6 @@ func (s *windowsTestSuite) TestUnprotectedProcessCheckIO() {
 }
 
 func (s *windowsTestSuite) TestManualProcessCheck() {
-	flake.Mark(s.T())
 	// test can be flaky due to missing CPU stats when cpu usage is extremely low (json output omits 0 values), so we want to re-run a full scan to ensure we have CPU stats
 	s.Env().RemoteHost.MustExecute("Start-MpScan -ScanType FullScan -AsJob")
 	check := s.Env().RemoteHost.


### PR DESCRIPTION
### What does this PR do?

Remove flake marker from:
- procutil.TestBootTimeRefresh
- languagedetection.TestNodeDetection (e2e)
- process.windowsTestSuite.TestManualProcessCheck (e2e)

### Motivation

These tests have had no failures in the past month ([ci product](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.agent_is_marked_flaky%3Atrue%20%40test.codeowners%3A%40DataDog%2Fcontainer-experiences&agg_m=%40test.status%2Ccount&agg_m_source=base%2Cbase&agg_q=%40test.name&agg_q_source=base&agg_t=cardinality%2Ccount&fromUser=false&index=citest&top_n=250&top_o=top&viz=stream&x_missing=true&start=1753707724040&end=1756386124040&paused=false))

<img width="1314" height="183" alt="image" src="https://github.com/user-attachments/assets/0d63fea9-a006-43f4-a7b9-a49e33065560" />

https://datadoghq.atlassian.net/browse/CTK-3981
https://datadoghq.atlassian.net/browse/CTK-4048
https://datadoghq.atlassian.net/browse/CXP-2433

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
