### PR TITLE
[NDMII-3569] Reset autodiscovery failures when device is reachable

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -206,6 +206,8 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 			continue
 		}
 
+		job.subnet.deviceFailures[entityID] = 0
+
 		deviceInfo := l.checkDeviceInfo(authentication, job.subnet.config.Port, deviceIP)
 		l.createService(entityID, job.subnet, deviceIP, deviceInfo, authIndex, true)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a autodiscovery failures count reset when a device is successfully reached to track consecutive failures instead of every failures since the start.

### Motivation

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
