### PR TITLE
EKS test for container now use AL2023

### DIFF
--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/eks.go
@@ -131,6 +131,7 @@ func EKSRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 			params.agentOptions = append(params.agentOptions, kubernetesagentparams.WithDeployWindows())
 		}
 
+		params.agentOptions = append(params.agentOptions, kubernetesagentparams.WithClusterName(cluster.ClusterName))
 		kubernetesAgent, err = helm.NewKubernetesAgent(&awsEnv, "eks", cluster.KubeProvider, params.agentOptions...)
 		if err != nil {
 			return err

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 	tifeks "github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 )
@@ -23,7 +22,6 @@ type eksSuite struct {
 }
 
 func TestEKSSuite(t *testing.T) {
-	flake.MarkOnLog(t, "cgroup config for procHooks process: unable to freeze: unknown")
 	e2e.Run(t, &eksSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(
 		awskubernetes.WithEKSOptions(
 			tifeks.WithLinuxNodeGroup(),

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -30,6 +30,7 @@ func TestEKSSuite(t *testing.T) {
 			tifeks.WithWindowsNodeGroup(),
 			tifeks.WithBottlerocketNodeGroup(),
 			tifeks.WithLinuxARMNodeGroup(),
+			tifeks.WithUseAL2023Nodes(),
 		),
 		awskubernetes.WithDeployDogstatsd(),
 		awskubernetes.WithDeployTestWorkload(),


### PR DESCRIPTION
This is just a template. Please delete all unneeded sections and add others if appropriate.

### What does this PR do?

Move containers test to new AL2023 nodes. It should remove some flakiness due to a bug in the AL2 AMI

Note: The cluster name is explicitly set in the Agent configuration, because the agent is not able to retrieve it properly with the new AL2023 nodes.
The cluster name detection is made by doing a call to EC2 API and it is failing with
```
EC2: GetNetworkID failed to get mac addresses: could not fetch token from IMDSv2: Put "http://169.254.169.254/latest/api/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

### Motivation

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
