### PR TITLE
Fix RAR shutdown test

### DIFF
--- a/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
@@ -360,7 +360,7 @@ func buildRemoteAgentServer(t *testing.T, remoteAgentServer *testRemoteAgentServ
 
 	go func() {
 		err := server.Serve(listener)
-		require.NoError(t, err)
+		assert.True(t, err == nil || errors.Is(err, grpc.ErrServerStopped), "unexpected error from server.Serve: %v", err)
 	}()
 
 	_, portStr, err := net.SplitHostPort(listener.Addr().String())


### PR DESCRIPTION
### What does this PR do?
Updates the test to only care about errors that are not `grpc.ErrServerStopped`

### Motivation
Fix flaky test

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
