### PR TITLE
Remove unnecessary RAR server creation in tests

### DIFF
--- a/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
+++ b/comp/core/remoteagentregistry/impl/remoteagentregistry_test.go
@@ -61,14 +61,10 @@ func TestRecommendedRefreshInterval(t *testing.T) {
 
 	component := provides.Comp
 
-	remoteAgentServer := &testRemoteAgentServer{}
-	server, port := buildRemoteAgentServer(t, remoteAgentServer)
-	defer server.Stop()
-
 	registrationData := &remoteagent.RegistrationData{
 		AgentID:     "test-agent",
 		DisplayName: "Test Agent",
-		APIEndpoint: fmt.Sprintf("localhost:%d", port),
+		APIEndpoint: "localhost:1234",
 	}
 
 	actualRefreshIntervalSecs, err := component.RegisterRemoteAgent(registrationData)
@@ -84,14 +80,10 @@ func TestGetRegisteredAgents(t *testing.T) {
 	provides, _, _, _ := buildComponent(t)
 	component := provides.Comp
 
-	remoteAgentServer := &testRemoteAgentServer{}
-	server, port := buildRemoteAgentServer(t, remoteAgentServer)
-	defer server.Stop()
-
 	registrationData := &remoteagent.RegistrationData{
 		AgentID:     "test-agent",
 		DisplayName: "Test Agent",
-		APIEndpoint: fmt.Sprintf("localhost:%d", port),
+		APIEndpoint: "localhost:1234",
 	}
 
 	_, err := component.RegisterRemoteAgent(registrationData)


### PR DESCRIPTION
### What does this PR do?
Removes the server creation for tests that do not need to spawn the remote agent server.

### Motivation
Fix flaky tests that do not need the server creation. 

### Describe how you validated your changes (if not by through tests)
Unit tests should still pass.
### Possible Drawbacks / Trade-offs
