### PR TITLE
Fix broken TestWPAController test

### DIFF
--- a/pkg/util/kubernetes/apiserver/controllers/hpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/hpa_controller_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !race && kubeapiserver
+//go:build kubeapiserver
 
 package controllers
 
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	datadogclientmock "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/zorkian/go-datadog-api.v2"
@@ -27,6 +26,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+
+	datadogclientmock "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/mock"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/custommetrics"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
@@ -4,7 +4,6 @@
 // Copyright 2016-present Datadog, Inc.
 
 //go:build kubeapiserver
-// +build kubeapiserver
 
 package controllers
 

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
@@ -245,15 +245,6 @@ func TestWPAController(t *testing.T) {
 			},
 			Scope: pointer.Ptr("foo:bar"),
 		},
-		{
-			Metric: &metricName,
-			Points: []datadog.DataPoint{
-				makePoints(1531492452000, 12.34),
-				makePoints(penTime, 1.01),
-				makePoints(0, 0.902),
-			},
-			Scope: pointer.Ptr("dcos_version:2.1.9"),
-		},
 	}
 
 	datadogClientComp := datadogclientmock.New(t).Comp

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !race && kubeapiserver
-// +build !race,kubeapiserver
+//go:build kubeapiserver
+// +build kubeapiserver
 
 package controllers
 


### PR DESCRIPTION
### What does this PR do?

Fix a unit test that is broken on main

### Motivation

### Describe how you validated your changes (if not by through tests)

For some reason, this test does not appear to be running via CI

Before change:
```
dda inv test --targets=. --module=./pkg/util/kubernetes/apiserver/controllers
✖  pkg/util/kubernetes/apiserver/controllers (8.669s)

=== Failed
=== FAIL: pkg/util/kubernetes/apiserver/controllers TestWPAController (5.11s)
    wpa_controller_test.go:671: 1756409376640263000 [Debug] Updating setting 'kube_resources_namespace' for source 'unknown' with new value. notifying 0 listeners
    wpa_controller_test.go:671: 1756409376640320000 [Info] Could not get the configmap datadog-custom-metrics: configmaps "datadog-custom-metrics" not found
    wpa_controller_test.go:671: 1756409376640350000 [Info] The configmap datadog-custom-metrics does not exist, trying to create it
    wpa_controller_test.go:671: 1756409376643002000 [Info] Retrieved the configmap datadog-custom-metrics
    wpa_controller_test.go:671: 1756409376643099000 [Info] WPA CRD check successful
    wpa_controller_test.go:671: 1756409376643140000 [Info] Enabling WPA controller
    wpa_controller_test.go:671: 1756409376643201000 [Info] Starting WPA Controller ...
    wpa_controller_test.go:671: 1756409376643381000 [Debug] Adding WPA nsfoo/wpa_1
    event.go:377: Event(v1.ObjectReference{Kind:"WatermarkPodAutoscaler", Namespace:"nsfoo", Name:"wpa_1", UID:"1", APIVersion:"datadoghq.com/v1alpha1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'Autoscaler is now handled by the Cluster-Agent'
    wpa_controller_test.go:671: 1756409376744029000 [Trace] Processing nsfoo/wpa_1
    wpa_controller_test.go:671: 1756409376744329000 [Trace] Created a boilerplate for the external metrics foo{map[foo:bar]} for watermark nsfoo/wpa_1
    wpa_controller_test.go:671: 1756409376744467000 [Trace] Local batch cache of WPA is map[external_metric-watermark-nsfoo-wpa_1-foo:{foo map[foo:bar] 1756409376 {watermark wpa_1 nsfoo 1} 0 false}]
    wpa_controller_test.go:671: 1756409376744594000 [Trace] Faithfully dropping key nsfoo/wpa_1
    wpa_controller_test.go:301: hctrl process key:nsfoo/wpa_1
    wpa_controller_test.go:671: 1756409376745728000 [Debug] Processed 1 chunks with 0 chunks in global error
    wpa_controller_test.go:329:
        	Error Trace:	/Users/steven.blumenthal/dd/datadog-agent/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go:329
        	            				/Users/steven.blumenthal/dd/datadog-agent/pkg/util/testutil/timeout.go:41
        	            				/opt/homebrew/Cellar/go@1.24/1.24.6/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Not equal:
        	            	expected: 0
        	            	actual  : 14.123
        	Test:       	TestWPAController
    timeout.go:72:
        	Error Trace:	/Users/steven.blumenthal/dd/datadog-agent/pkg/util/testutil/timeout.go:72
        	            				/Users/steven.blumenthal/dd/datadog-agent/pkg/util/testutil/timeout.go:29
        	            				/Users/steven.blumenthal/dd/datadog-agent/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go:323
        	Error:      	Timeout waiting for condition to happen, function never returned
        	Test:       	TestWPAController

DONE 38 tests, 1 failure in 8.669s
Tests failed (base flavor)
Test failures:
- github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers TestWPAController

```

After change:
```
dda inv test --targets=. --module=./pkg/util/kubernetes/apiserver/controllers
Removing existing 'test_output.json' file
✓  pkg/util/kubernetes/apiserver/controllers (4.316s)

DONE 38 tests in 4.316s
All tests passed
Tests final status (including re-runs): ALL TESTS PASSED
```

### Possible Drawbacks / Trade-offs
