### PR TITLE
handle non-zero success exit codes

### DIFF
--- a/releasenotes/notes/remote-update-msi-non-zero-success-codes-b40ef5d4e590fb19.yaml
+++ b/releasenotes/notes/remote-update-msi-non-zero-success-codes-b40ef5d4e590fb19.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Remote Agent updates on Windows now consider MSI exit codes 3010 and 1641 to indicate success


### PR DESCRIPTION
### What does this PR do?
Remote Agent updates on Windows now consider MSI exit codes 3010 and 1641 to indicate success

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1683
follow up to https://github.com/DataDog/datadog-agent/pull/40325