### PR TITLE
dyninst: go 1.25 fixes

### DIFF
--- a/pkg/dyninst/object/elf_file_with_dwarf.go
+++ b/pkg/dyninst/object/elf_file_with_dwarf.go
@@ -198,21 +198,11 @@ func (d *dwarfData) init(f File) (retErr error) {
 		return err
 	}
 	d.dwarfData = *dwarfData
-	_, _, dwarfVersion, byteOrder := dlvdwarf.ReadDwarfLengthVersion(info)
+	_, _, _, byteOrder := dlvdwarf.ReadDwarfLengthVersion(info)
 	if byteOrder != binary.LittleEndian {
 		return fmt.Errorf("unexpected DWARF byte order: %v", byteOrder)
 	}
 	unitVersions := dlvdwarf.ReadUnitVersions(d.debugSections.Info())
-	if dwarfVersion >= 5 {
-		// Delve unit offset calculations are 1 byte off.
-		// If tests fail, and following code now handles DWARF5, just remove this adjustment:
-		// https://github.com/go-delve/delve/blob/946e4885b69396512958b2774402e86acd530bbe/pkg/dwarf/parseutil.go#L126-L142
-		uv := make(map[dwarf.Offset]uint8, len(unitVersions))
-		for k, v := range unitVersions {
-			uv[k-1] = v
-		}
-		unitVersions = uv
-	}
 	d.reader = loclist.MakeReader(
 		d.debugSections.Loc(),
 		d.debugSections.LocLists(),

--- a/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEsotericHeap.json
@@ -80,21 +80,7 @@
                     }
                   },
                   "mu": "[sync.Mutex (different in different versions)]",
-                  "once": {
-                    "type": "sync.Once",
-                    "fields": {
-                      "done": {
-                        "type": "sync/atomic.Uint32",
-                        "fields": {
-                          "v": {
-                            "type": "uint32",
-                            "value": "0"
-                          }
-                        }
-                      },
-                      "m": "[sync.Mutex (different in different versions)]"
-                    }
-                  },
+                  "once": "[sync.Once (different in different versions)]",
                   "wg": {
                     "type": "sync.WaitGroup",
                     "fields": {


### PR DESCRIPTION
Some fixes for Go 1.25; see individual commits. These are not sufficient, through -- there are more things broken for Go 1.25.

DEBUG-4385