### PR TITLE
[CIEXE-1103] Migrate datadog-agent amd jobs to dedicated runners only

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -32,7 +32,7 @@
 cluster_agent-build_amd64:
   extends: .cluster_agent-build_common
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
 
 cluster_agent-build_arm64:
   extends: .cluster_agent-build_common

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -5,7 +5,7 @@ cluster_agent_cloudfoundry-build_amd64:
     - when: on_success
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_mod_tidy_check", "go_deps"]
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/binary_build/cws_instrumentation.yml
+++ b/.gitlab/binary_build/cws_instrumentation.yml
@@ -15,7 +15,7 @@ cws_instrumentation-build_amd64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     ARCH: amd64

--- a/.gitlab/binary_build/fakeintake.yml
+++ b/.gitlab/binary_build/fakeintake.yml
@@ -6,6 +6,6 @@ build_fakeintake:
     - !reference [.on_fakeintake_changes]
   needs: []
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - dda inv -- fakeintake.build

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -2,7 +2,7 @@
 build_dogstatsd_static-binary_x64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   variables:
     ARCH: amd64
@@ -36,7 +36,7 @@ build_dogstatsd-binary_x64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
@@ -69,7 +69,7 @@ build_iot_agent-binary_x64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   variables:
     KUBERNETES_CPU_REQUEST: 4

--- a/.gitlab/binary_build/otel_agent.yml
+++ b/.gitlab/binary_build/otel_agent.yml
@@ -19,7 +19,7 @@
 
 build_otel_agent_binary_x64:
   extends: .build_otel_agent_binary_common
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 build_otel_agent_binary_arm64:

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -15,7 +15,7 @@ build_serverless-deb_x64:
   variables:
     BINARY_NAME: datadog-agent-x64
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   artifacts:
     expire_in: 1 day

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -22,7 +22,7 @@
 build_system-probe-x64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   extends: .system-probe_build_common
   variables:

--- a/.gitlab/check_deploy/check_deploy.yml
+++ b/.gitlab/check_deploy/check_deploy.yml
@@ -11,7 +11,7 @@ check_already_deployed_version_7:
   rules: !reference [.on_deploy]
   stage: check_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   dependencies: ["agent_deb-x64-a7", "agent_deb-arm64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/check_merge/do_not_merge.yml
+++ b/.gitlab/check_merge/do_not_merge.yml
@@ -1,7 +1,7 @@
 do-not-merge:
   stage: check_merge
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_dev_branches]
     - when: always

--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -8,7 +8,7 @@
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     <<: *docker_variables
     IMG_VARIABLES: ""

--- a/.gitlab/common/skip_ci_check.yml
+++ b/.gitlab/common/skip_ci_check.yml
@@ -4,7 +4,7 @@ skip-ci-check:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: []
   stage: setup
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_mergequeue]
   script:

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -111,7 +111,7 @@
 
 .docker_build_amd64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: amd64
 

--- a/.gitlab/container_build/fakeintake.yml
+++ b/.gitlab/container_build/fakeintake.yml
@@ -7,7 +7,7 @@ docker_build_fakeintake:
     - !reference [.on_fakeintake_changes_on_main]
   needs: []
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10-py3
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     TARGET: registry.ddbuild.io/ci/datadog-agent/fakeintake:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     DOCKERFILE: test/fakeintake/Dockerfile

--- a/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/deploy_packages/cluster_agent_cloudfoundry.yml
@@ -4,7 +4,7 @@ deploy_cluster_agent_cloudfoundry:
     !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["cluster_agent_cloudfoundry-build_amd64"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -2,7 +2,7 @@
 .deploy_packages:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   stage: deploy_packages
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     !reference [.on_deploy]
   variables:
@@ -74,7 +74,7 @@ deploy_installer_install_scripts:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   stage: deploy_packages
   needs: ["installer-install-scripts"]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/deploy_packages/e2e.yml
+++ b/.gitlab/deploy_packages/e2e.yml
@@ -5,7 +5,7 @@
 qa_installer_script_linux:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   stage: deploy_packages
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]
@@ -20,7 +20,7 @@ qa_installer_script_linux:
 qa_installer_script_windows:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   stage: deploy_packages
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_installer_or_e2e_changes]
     - !reference [.manual]

--- a/.gitlab/deploy_packages/nix.yml
+++ b/.gitlab/deploy_packages/nix.yml
@@ -200,7 +200,7 @@ deploy_staging_dsd:
     !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["build_dogstatsd-binary_x64"]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
@@ -213,7 +213,7 @@ deploy_staging_iot_agent:
     !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["build_iot_agent-binary_x64"]
   script:
     - $S3_CP_CMD $S3_ARTIFACTS_URI/iot/agent ./agent

--- a/.gitlab/deploy_packages/oci.yml
+++ b/.gitlab/deploy_packages/oci.yml
@@ -4,7 +4,7 @@ include:
 
 .deploy_packages_oci:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: deploy_packages
   rules:
     - !reference [.on_deploy]

--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -7,7 +7,7 @@ deploy_packages_windows-x64-7:
     !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
@@ -27,7 +27,7 @@ deploy_staging_windows_tags-7:
     !reference [.on_deploy_stable_or_beta_repo_branch]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
@@ -48,7 +48,7 @@ deploy_installer_packages_windows-x64:
     - !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["windows-installer-amd64", "powershell_script_signing"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID
@@ -69,7 +69,7 @@ deploy_packages_windows-x64-7-fips:
     !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["windows_msi_and_bosh_zip_x64-a7-fips"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -96,7 +96,7 @@
 build_clang_x64:
   extends: .build_clang_common
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: amd64
     CMAKE_ARCH: x86_64
@@ -115,7 +115,7 @@ build_processed_btfhub_archive:
     - !reference [.manual]
   stage: deps_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$CI_IMAGE_BTF_GEN_SUFFIX:$CI_IMAGE_BTF_GEN
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     KUBERNETES_CPU_REQUEST: 32
   script:

--- a/.gitlab/deps_fetch/deps_fetch.yml
+++ b/.gitlab/deps_fetch/deps_fetch.yml
@@ -18,7 +18,7 @@
 .cache:
   stage: deps_fetch
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["setup_agent_version"]
   variables:
     KUBERNETES_CPU_REQUEST: 16
@@ -109,7 +109,7 @@ go_e2e_deps:
 
 fetch_openjdk:
   needs: []
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.manual]
   stage: deps_fetch

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -4,7 +4,7 @@
 .new_e2e_template:
   stage: e2e
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - !reference [.needs_new_e2e_template]
   before_script:
@@ -119,7 +119,7 @@
 go_e2e_test_binaries:
   stage: binary_build
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - go_e2e_deps
   variables:
@@ -983,7 +983,7 @@ generate-flakes-finder-pipeline:
     - qa_agent
     - qa_agent_full
     - tests_windows_sysprobe_x64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - dda inv -- -e testwasher.generate-flake-finder-pipeline
@@ -1041,7 +1041,7 @@ generate-fips-e2e-pipeline:
     - qa_agent_fips
     - qa_agent_fips_jmx
     - tests_windows_sysprobe_x64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - dda inv -- -e fips.generate-fips-e2e-pipeline
@@ -1069,7 +1069,7 @@ trigger-fips-e2e:
 
 new-e2e-cleanup-on-failure:
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: e2e_cleanup
   dependencies: [go_e2e_deps]
   script:

--- a/.gitlab/e2e_install_packages/installer.yml
+++ b/.gitlab/e2e_install_packages/installer.yml
@@ -1,7 +1,7 @@
 qa_installer_script_main:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   stage: e2e_install_packages
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.only_main] # Disable non-main branch. Must be first.
     - !reference [.on_installer_or_e2e_changes]

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -42,7 +42,7 @@
 .deploy_deb_testing-a7:
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
@@ -105,7 +105,7 @@ deploy_deb_testing-a7_arm64:
 .deploy_rpm_testing-a7:
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
@@ -159,7 +159,7 @@ deploy_suse_rpm_testing_x64-a7:
     - when: on_success
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     [
       "installer_suse_rpm-amd64",
@@ -189,7 +189,7 @@ deploy_suse_rpm_testing_arm64-a7:
     - !reference [.manual]
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "agent_suse-arm64-a7-fips", "lint_linux-arm64", "ddot_suse_rpm-arm64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -210,7 +210,7 @@ deploy_windows_testing-a7:
     - when: on_success
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   retry: 2
   needs:
     ["lint_windows-x64", "windows_msi_and_bosh_zip_x64-a7", "windows-installer-amd64"]
@@ -235,7 +235,7 @@ deploy_windows_testing-a7-fips:
     - when: on_success
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   retry: 2
   needs:
     ["lint_windows-x64", "windows_msi_and_bosh_zip_x64-a7-fips"]
@@ -257,7 +257,7 @@ export_testing_public_key:
   needs: []
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - *setup_signing
     - /usr/bin/gpg-vault export-public-key $GPG_TEST_KEY_ID > gpg-testing-public-key.asc
@@ -275,7 +275,7 @@ export_testing_public_key:
      - !reference [.manual]
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/functional_test/oracle.yml
+++ b/.gitlab/functional_test/oracle.yml
@@ -1,6 +1,6 @@
 oracle:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: functional_test
   needs: ["go_deps"]
   rules:

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -6,7 +6,7 @@ single_machine_performance-regression_detector-merge_base_check:
     - !reference [.on_dev_branches]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   artifacts:
     expire_in: 1 day
     paths:
@@ -76,7 +76,7 @@ single-machine-performance-regression_detector:
     - !reference [.on_dev_branches]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - job: single_machine_performance-full-amd64-a7
       artifacts: false
@@ -320,7 +320,7 @@ single-machine-performance-regression_detector-pr-comment:
   image:
     name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3"
     entrypoint: [""] # disable entrypoint script for the pr-commenter image
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - job: single-machine-performance-regression_detector
   artifacts:

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -6,7 +6,7 @@ static_quality_gates:
     - !reference [.on_dev_branches]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - agent_deb-x64-a7
     - agent_deb-x64-a7-fips
@@ -87,7 +87,7 @@ manual_gate_threshold_update:
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - static_quality_gates
   script:

--- a/.gitlab/fuzz/infra.yaml
+++ b/.gitlab/fuzz/infra.yaml
@@ -3,7 +3,7 @@ test_fuzz:
     - !reference [.on_scheduled_main]
     - !reference [.manual]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: source_test
   needs: []
   allow_failure: true

--- a/.gitlab/install_script_testing/install_script_testing.yml
+++ b/.gitlab/install_script_testing/install_script_testing.yml
@@ -2,7 +2,7 @@
 test_install_script:
   stage: install_script_testing
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - set +x
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN

--- a/.gitlab/integration_test/dogstatsd.yml
+++ b/.gitlab/integration_test/dogstatsd.yml
@@ -5,7 +5,7 @@
 dogstatsd_x64_size_test:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["build_dogstatsd_static-binary_x64"]
   before_script:
     - mkdir -p $STATIC_BINARIES_DIR

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -5,7 +5,7 @@
 integration_tests_otel:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   script:
     - !reference [.retrieve_linux_go_deps]
@@ -44,7 +44,7 @@ docker_image_build_otel:
 datadog_otel_components_ocb_build:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   artifacts:
     paths:

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -7,7 +7,7 @@
   stage: internal_image_deploy
   rules: !reference [.on_deploy_internal_or_manual]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     # Constant variables
     - export RELEASE_STAGING="true"

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -37,7 +37,7 @@ internal_kubernetes_deploy_experimental:
       artifacts: false
       optional: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     OPTION_AUTOMATIC_ROLLOUT: "true"
     OPTION_PRE_SCRIPT: "patch-cluster-images-operator.sh env=ci ${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}-jmx ${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -24,7 +24,7 @@ rc_kubernetes_deploy:
       artifacts: false
       optional: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   # TODO: @agent-delivery to update this job when concuctor changes are properly verified
   allow_failure: true
   variables:

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -111,7 +111,7 @@
   before_script:
     - !reference [.kmt_new_profile]
     - !reference [.write_ssh_key_file]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     # upload dependencies
     - !reference [.wait_for_instance]
@@ -135,7 +135,7 @@
   stage: kernel_matrix_testing_prepare
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     AWS_REGION: us-east-1
     STACK_DIR: $CI_PROJECT_DIR/stack.dir
@@ -207,7 +207,7 @@
 .kmt_cleanup:
   stage: kernel_matrix_testing_cleanup
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   before_script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
     - !reference [.kmt_new_profile]
@@ -306,7 +306,7 @@
 .notify_ebpf_complexity_changes:
   extends: .notify-job
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   timeout: 15m
   needs:
     # We need to specify the jobs that generate complexity explicitly, else we hit the limit of "needs"

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -86,7 +86,7 @@ upload_secagent_tests_x64:
     - .upload_secagent_tests
   needs: ["go_deps", "prepare_secagent_ebpf_functional_tests_x64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: m5d.metal
@@ -122,7 +122,7 @@ kmt_run_secagent_tests_x64:
   extends:
     - .kmt_run_secagent_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
@@ -165,7 +165,7 @@ kmt_run_secagent_tests_x64_peds:
   extends:
     - .kmt_run_secagent_tests_required
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
@@ -208,7 +208,7 @@ kmt_run_secagent_tests_x64_required:
   extends:
     - .kmt_run_secagent_tests_required
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
@@ -228,7 +228,7 @@ kmt_run_secagent_tests_x64_ad:
   extends:
     - .kmt_run_secagent_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
@@ -248,7 +248,7 @@ kmt_run_secagent_tests_x64_ebpfless:
   extends:
     - .kmt_run_secagent_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64
@@ -269,7 +269,7 @@ kmt_run_secagent_tests_x64_docker:
   extends:
     - .kmt_run_secagent_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_secagent_x64
     - upload_dependencies_secagent_x64

--- a/.gitlab/kernel_matrix_testing/system_probe.yml
+++ b/.gitlab/kernel_matrix_testing/system_probe.yml
@@ -23,7 +23,7 @@ upload_dependencies_sysprobe_arm64:
 .pull_test_dockers:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   needs: []
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules: !reference [.on_system_probe_or_e2e_changes_or_manual]
   stage: kernel_matrix_testing_prepare
   script:
@@ -55,7 +55,7 @@ pull_test_dockers_arm64:
 .upload_minimized_btfs:
   stage: kernel_matrix_testing_prepare
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     # Build dependencies directory
     - mkdir -p $DEPENDENCIES
@@ -173,7 +173,7 @@ upload_sysprobe_tests_x64:
   needs:
     ["go_deps", "prepare_sysprobe_ebpf_functional_tests_x64", "tests_ebpf_x64"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: x86_64
     INSTANCE_TYPE: r5d.metal
@@ -205,7 +205,7 @@ kmt_run_sysprobe_tests_x64:
   extends:
     - .kmt_run_sysprobe_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - kmt_setup_env_sysprobe_x64
     - upload_dependencies_sysprobe_x64

--- a/.gitlab/lint/linux.yml
+++ b/.gitlab/lint/linux.yml
@@ -17,7 +17,7 @@
   retry: !reference [.retry_only_infra_failure, retry]
 .linux_x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
 
 .linux_arm64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX

--- a/.gitlab/lint/technical_linters.yml
+++ b/.gitlab/lint/technical_linters.yml
@@ -1,7 +1,7 @@
 .lint:
   stage: lint
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: []
   retry: !reference [.retry_only_infra_failure, retry]
 

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -44,7 +44,7 @@ notify:
 send_pipeline_stats:
   extends: .notify-job
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   when: always
   dependencies: []
   script:
@@ -55,7 +55,7 @@ notify_gitlab_ci_changes:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   extends: .notify-job
   needs: [compute_gitlab_ci_config]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - changes:
@@ -72,7 +72,7 @@ notify_gitlab_ci_changes:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   extends: .notify-job
   dependencies: []
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   resource_group: notification
   timeout: 15 minutes # Added to prevent a stuck job blocking the resource_group defined above
 

--- a/.gitlab/package_build/heroku.yml
+++ b/.gitlab/package_build/heroku.yml
@@ -5,7 +5,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_mod_tidy_check", "go_deps"]
   script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -41,7 +41,7 @@ datadog-agent-oci-x64-a7:
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     [
       "go_mod_tidy_check",
@@ -85,7 +85,7 @@ installer-install-scripts:
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     [
       "go_mod_tidy_check",
@@ -172,7 +172,7 @@ installer-amd64:
     - when: on_success
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     PACKAGE_ARCH: amd64

--- a/.gitlab/package_build/linux.yml
+++ b/.gitlab/package_build/linux.yml
@@ -35,7 +35,7 @@
 
 .agent_build_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["build_system-probe-x64", "go_deps", "generate_minimized_btfs_x64"]
   variables:
     PACKAGE_ARCH: amd64
@@ -92,7 +92,7 @@ datadog-agent-7-arm64-fips:
 
 iot-agent-x64:
   extends: .iot-agent-common
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   variables:
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
@@ -145,7 +145,7 @@ iot-agent-armhf:
 dogstatsd-x64:
   extends: .dogstatsd_build_common
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
     DD_CXX: "x86_64-unknown-linux-gnu-g++"
@@ -186,7 +186,7 @@ dogstatsd-arm64:
 datadog-otel-agent-x64:
   extends: .otel_build_common
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
     DD_CXX: "x86_64-unknown-linux-gnu-g++"

--- a/.gitlab/package_deps_build/package_deps_build.yml
+++ b/.gitlab/package_deps_build/package_deps_build.yml
@@ -8,7 +8,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$CI_IMAGE_BTF_GEN_SUFFIX:$CI_IMAGE_BTF_GEN
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - cd $CI_PROJECT_DIR
     - export BTFS_ETAG=$(aws s3api head-object --region us-east-1 --bucket dd-agent-omnibus --key btfs/$BTFHUB_ARCHIVE_BRANCH/btfs-$ARCH.tar --query ETag --output text | tr -d \")

--- a/.gitlab/packaging/deb.yml
+++ b/.gitlab/packaging/deb.yml
@@ -26,7 +26,7 @@ include:
 
 .package_deb_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_PKG_ARCH: x86_64
     PACKAGE_ARCH: amd64

--- a/.gitlab/packaging/oci.yml
+++ b/.gitlab/packaging/oci.yml
@@ -4,7 +4,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   before_script:
     - PACKAGE_VERSION="$(dda inv agent.version --url-safe)-1" || exit $?
     - export INSTALL_DIR=/opt/datadog-packages/${OCI_PRODUCT}/${PACKAGE_VERSION}

--- a/.gitlab/packaging/rpm.yml
+++ b/.gitlab/packaging/rpm.yml
@@ -31,7 +31,7 @@ include:
 
 .package_rpm_x86:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_x64$CI_IMAGE_RPM_X64_SUFFIX:$CI_IMAGE_RPM_X64
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     DD_PKG_ARCH: x86_64
     PACKAGE_ARCH: amd64
@@ -60,7 +60,7 @@ include:
 
 agent_rpm-x64-a7:
   extends: [.package_rpm_common, .package_rpm_x86]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["datadog-agent-7-x64"]
   variables:
     DD_PROJECT: agent
@@ -100,7 +100,7 @@ installer_rpm-amd64:
 
 agent_rpm-x64-a7-fips:
   extends: [.package_rpm_common, .package_rpm_x86]
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["datadog-agent-7-x64-fips"]
   variables:
     OMNIBUS_EXTRA_ARGS: "--flavor fips"

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -5,7 +5,7 @@
 send_pkg_size:
   stage: pkg_metrics
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: always
@@ -79,7 +79,7 @@ send_pkg_size:
 check_pkg_size:
   stage: pkg_metrics
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success

--- a/.gitlab/post_rc_build/post_rc_tasks.yml
+++ b/.gitlab/post_rc_build/post_rc_tasks.yml
@@ -17,7 +17,7 @@ update_rc_build_links:
     - job: publish_internal_container_image-full
       artifacts: false
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - ATLASSIAN_PASSWORD=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE token) || exit $?; export ATLASSIAN_PASSWORD
     - ATLASSIAN_USERNAME=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $ATLASSIAN_WRITE user) || exit $?; export ATLASSIAN_USERNAME

--- a/.gitlab/scan/windows.yml
+++ b/.gitlab/scan/windows.yml
@@ -1,7 +1,7 @@
 .scan_windows_package:
   stage: scan
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     SCAN_ARTIFACT_PATTERN: "datadog-agent-7*.msi"
     OMNIBUS_PIPELINE_DIR: $OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID

--- a/.gitlab/setup/setup.yml
+++ b/.gitlab/setup/setup.yml
@@ -2,7 +2,7 @@
 setup_agent_version:
   stage: setup
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   script:
     - |
       if ! dda inv -- -e agent.version --cache-version > build.env; then
@@ -23,7 +23,7 @@ setup_agent_version:
 github_rate_limit_info:
   stage: .pre
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/source_test/codeql_scan.yml
+++ b/.gitlab/source_test/codeql_scan.yml
@@ -4,7 +4,7 @@
 
 run_codeql_scan:
   image: registry.ddbuild.io/code-scanning:v62112110-4faa53b-datadog-agent 
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: source_test
   rules:
   - !reference [.on_scheduled_main]

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -34,7 +34,7 @@
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: amd64
     TASK_ARCH: x64
@@ -79,7 +79,7 @@ prepare_sysprobe_ebpf_functional_tests_arm64:
 prepare_sysprobe_ebpf_functional_tests_x64:
   extends: .prepare_sysprobe_ebpf_functional_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: amd64
     DD_CC: "x86_64-unknown-linux-gnu-gcc"
@@ -116,7 +116,7 @@ prepare_secagent_ebpf_functional_tests_arm64:
 prepare_secagent_ebpf_functional_tests_x64:
   extends: .prepare_secagent_ebpf_functional_tests
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   variables:
     ARCH: amd64
     DD_CC: "x86_64-unknown-linux-gnu-gcc"

--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -2,7 +2,7 @@
 # check that go generate has been run in the pkg/security directory
 security_go_generate_check:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
   variables:

--- a/.gitlab/source_test/golang_deps_diff.yml
+++ b/.gitlab/source_test/golang_deps_diff.yml
@@ -4,7 +4,7 @@
 golang_deps_diff:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_dev_branches]
     - when: on_success
@@ -26,7 +26,7 @@ golang_deps_diff:
 golang_deps_commenter:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:2
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.on_dev_branches]
     - when: on_success
@@ -56,7 +56,7 @@ golang_deps_commenter:
 golang_deps_send_count_metrics:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -48,7 +48,7 @@
 
 .linux_x64:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
 
 tests_linux-x64-py3:
   extends:
@@ -191,7 +191,7 @@ go_mod_tidy_check:
 new-e2e-unit-tests:
   extends: .linux_tests
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs:
     - go_e2e_deps
     - go_deps

--- a/.gitlab/source_test/notify.yml
+++ b/.gitlab/source_test/notify.yml
@@ -1,7 +1,7 @@
 unit_tests_notify:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.except_main_release_or_mq]
     - !reference [.except_disable_unit_tests]

--- a/.gitlab/source_test/protobuf.yml
+++ b/.gitlab/source_test/protobuf.yml
@@ -1,7 +1,7 @@
 protobuf_test:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: []
   script:
     - dda inv -- install-tools

--- a/.gitlab/source_test/slack.yml
+++ b/.gitlab/source_test/slack.yml
@@ -3,7 +3,7 @@
 slack_teams_channels_check:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: []
   rules:
     - !reference [.except_mergequeue]

--- a/.gitlab/source_test/tooling_unit_tests.yml
+++ b/.gitlab/source_test/tooling_unit_tests.yml
@@ -3,7 +3,7 @@
 invoke_unit_tests:
   stage: source_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   needs: []
   rules:
     - !reference [.on_invoke_tasks_changes]

--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -5,7 +5,7 @@
 .agent_release_management_trigger:
   stage: trigger_release
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   # We don't directly depend/need the package deploy jobs, because
   # that would make us deploy even when there are e2e tests failures etc
   # We only want to allow automatically triggering agent-release-manangement

--- a/.gitlab/trigger_release/installer.yml
+++ b/.gitlab/trigger_release/installer.yml
@@ -7,7 +7,7 @@
 .installer_release_management_trigger:
   stage: trigger_release
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  tags: ["arch:amd64"]
+  tags: ["arch:amd64", "specific:true"]
   # We don't directly depend/need the package deploy jobs, because
   # that would make us deploy even when there are e2e tests failures etc
   # We only want to allow automatically triggering agent-release-manangement


### PR DESCRIPTION
This is just a template. Please delete all unneeded sections and add others if appropriate.

### What does this PR do?

The PR updates the gitlab runner tags for datadog-agent repo to run CI jobs on dedicated runners created for datadog-agent. 

This PR is specifically updating amd tags and arms tags were already migrated in the below stacked PR
https://github.com/DataDog/datadog-agent/pull/40361

See announcement here 
https://dd.slack.com/archives/C079RF25672/p1756221777501579

### Motivation

We want to run datadog-agent CI jobs in dedicated runners so they are not impacted/slowed down by jobs from other repos.

### Describe how you validated your changes (if not by through tests)
We have been running amd jobs for a couple of weeks now ever since the announcement was made(8/26)
https://dd.slack.com/archives/C079RF25672/p1756221777501579

There have been no complaints in agent slack channels and also no unexpected failures( tracked in https://app.datadoghq.com/notebook/12885224/datadog-agent-gitlab-runners)

### Possible Drawbacks / Trade-offs

If CI jobs break, we can revert this diff.
