### PR TITLE
[SBOM] implement spread refresher logic

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -200,7 +200,12 @@ func (c *Check) Run() error {
 	c.sendUsageMetrics()
 
 	containerRefreshPeriod := time.Duration(c.instance.ContainerPeriodicRefreshSeconds) * time.Second
-	containerRefresher := newBatchRefresher(containerRefreshPeriod, c.workloadmetaStore, c.processor)
+	var containerRefresher containerPeriodicRefresher
+	if c.cfg.GetBool("sbom.container_image.use_spread_refresher") {
+		containerRefresher = newSpreadRefresher(containerRefreshPeriod, c.workloadmetaStore, c.processor)
+	} else {
+		containerRefresher = newBatchRefresher(containerRefreshPeriod, c.workloadmetaStore, c.processor)
+	}
 	defer containerRefresher.stop()
 
 	procfsSbomChan := make(chan sbom.ScanResult) // default value to listen to nothing

--- a/pkg/collector/corechecks/sbom/spread_refresher.go
+++ b/pkg/collector/corechecks/sbom/spread_refresher.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+//go:build trivy || (windows && wmi)
+
+package sbom
+
+import (
+	"slices"
+	"time"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+type spreadRefresher struct {
+	ticker       *time.Ticker
+	refreshTimes map[workloadmeta.EntityID]time.Time
+
+	wmStore workloadmeta.Component
+	proc    *processor
+}
+
+var _ containerPeriodicRefresher = (*spreadRefresher)(nil)
+
+const spreadSteps = 10
+
+func newSpreadRefresher(period time.Duration, wmStore workloadmeta.Component, proc *processor) *spreadRefresher {
+	innerPeriod := period / spreadSteps
+
+	return &spreadRefresher{
+		ticker: time.NewTicker(innerPeriod),
+
+		wmStore: wmStore,
+		proc:    proc,
+	}
+}
+
+func (br *spreadRefresher) stop() {
+	br.ticker.Stop()
+}
+
+func (br *spreadRefresher) tick() <-chan time.Time {
+	return br.ticker.C
+}
+
+// step performs a single refresh step
+func (br *spreadRefresher) step() {
+	images := br.wmStore.ListImages()
+
+	// first step: we compute the refresh times for all images
+	// and sort them by refresh time
+
+	workingSet := make([]*imageWithRefreshTime, 0, len(images))
+	for _, img := range images {
+		id := img.EntityID
+		refreshTime, ok := br.refreshTimes[id]
+		if !ok {
+			refreshTime = time.Time{}
+		}
+		workingSet = append(workingSet, &imageWithRefreshTime{
+			image:       img,
+			refreshTime: refreshTime,
+		})
+	}
+	slices.SortFunc(workingSet, func(a, b *imageWithRefreshTime) int {
+		return a.refreshTime.Compare(b.refreshTime)
+	})
+
+	// second step: we process the oldest images
+	amountOfImagesToProcess := len(images) / spreadSteps
+	for _, img := range workingSet[:amountOfImagesToProcess] {
+		br.proc.processImageSBOM(img.image)
+		img.refreshTime = time.Now()
+	}
+
+	// third step: we update the refresh times map for next step
+	newRefreshTimes := make(map[workloadmeta.EntityID]time.Time, len(images))
+	for _, img := range workingSet {
+		newRefreshTimes[img.image.EntityID] = img.refreshTime
+	}
+
+	br.refreshTimes = newRefreshTimes
+}
+
+type imageWithRefreshTime struct {
+	image       *workloadmeta.ContainerImageMetadata
+	refreshTime time.Time
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -962,6 +962,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.container_image.exclude_pause_container", true)
 	config.BindEnvAndSetDefault("sbom.container_image.allow_missing_repodigest", false)
 	config.BindEnvAndSetDefault("sbom.container_image.additional_directories", []string{})
+	config.BindEnvAndSetDefault("sbom.container_image.use_spread_refresher", false)
 
 	// Container file system SBOM configuration
 	config.BindEnvAndSetDefault("sbom.container.enabled", false)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new strategy for refreshing the SBOM of stored container images. Instead of refreshing all images every 1h (which is what the batch refresher is doing), this new spread refresher is refreshing 1/10 of all images every 1h/10 (6min). The 1/10 set of images are selected to be the oldest images. This guarantees that all images will still be updated in ~1h.

This new strategy is under a config flag (disabled by default) while this undergoes further internal testing.

### Motivation

### Describe how you validated your changes (if not by through tests)

### Possible Drawbacks / Trade-offs
