### PR TITLE
Only install legacy-build tasks on windows builds

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -134,7 +134,7 @@ function Expand-ModCache() {
 function Install-Deps() {
     Write-Host "Installing python requirements"
     pip3.exe install dda
-    dda self dep sync -f legacy-tasks
+    dda self dep sync -f legacy-build
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to install python requirements"
         exit 1


### PR DESCRIPTION
### What does this PR do?

It reduces the set of dda deps sets installed to `legacy-build`, which is what should already [installed in the runner](https://github.com/DataDog/datadog-agent-buildimages/blob/ce00c3c1c5a42f4dfacc98e5bbe958bf65d82b94/windows/helpers/phase2/install_python.ps1#L79).

These affects linting, testing and building jobs on Windows.

### Motivation

Avoiding failures such as [this one](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1105015507), which come from fetching and building python dependencies during the job, dependencies that don't seem relevant for building the Agent.

This reduces possible points of failure and might save about a minute from every windows job.

### Describe how you validated your changes (if not by through tests)

CI Passing is enough.

### Possible Drawbacks / Trade-offs

Installing dda and these deps is essentially a no-op on CI (pip will realize the requirements are satisfied and do nothing, as far as I can tell). We could probably just skip passing the flag that enables this code path instead of this; I don't know enough about the code, so I'm proposing this just as a quick improvement over what we have.
