### PR TITLE
feat(github): Remove usage of GithubApp in Github workflows

### DIFF
--- a/.github/workflows/add_dependabot_pr_to_mq.yml
+++ b/.github/workflows/add_dependabot_pr_to_mq.yml
@@ -13,19 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: dependabot
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
 
     steps:
-      # Use a token as only the github App can push to the merge queue
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+          scope: DataDog/datadog-agent
+          policy: self.add-dependabot-pr-to-mq.comment-pr
       - name: Check if the PR is mergeable
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         id: check-mergeable
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
             const { data: pullRequest } = await github.rest.pulls.get({
@@ -59,7 +60,7 @@ jobs:
         if: ${{ steps.check-mergeable.outputs.result == 'true' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
             const commentBody = "/merge";

--- a/.github/workflows/add_reviewer_bot_pr.yml
+++ b/.github/workflows/add_reviewer_bot_pr.yml
@@ -26,17 +26,14 @@ jobs:
   add_reviewers:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
+          scope: DataDog/datadog-agent
+          policy: self.add-reviewer-bot-pr.review-pr
 
       - name: Install dda
         uses: ./.github/actions/install-dda
@@ -46,5 +43,5 @@ jobs:
       - name: Add reviewers
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: dda inv -- -e issue.add-reviewers -p $PR_NUMBER

--- a/.github/workflows/ask_review_bot_pr.yml
+++ b/.github/workflows/ask_review_bot_pr.yml
@@ -18,12 +18,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     environment:
       name: main
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+          scope: DataDog/datadog-agent
+          policy: self.ask-review-bot-pr.label-pr
       - name: 'Download artifact'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -49,7 +51,7 @@ jobs:
       - name: 'Add the ask-review label to the PR'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('./NR'));

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,6 +1,6 @@
 name: Backport PR
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
@@ -14,21 +14,23 @@ jobs:
       && (
         github.event.action == 'closed'
         || (
-         github.event.action == 'labeled'
+          github.event.action == 'labeled'
           && contains(github.event.label.name, 'backport')
         )
       )
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+          scope: DataDog/datadog-agent
+          policy: self.backport-pr.create-pr
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$"
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
           body_template: |
             Backport <%- mergeCommitSha %> from #<%- number %>.
 

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -15,15 +15,16 @@ jobs:
   backport:
     name: Update golang.org/x/... dependencies
     runs-on: ubuntu-latest
-    permissions: {} # the workflow uses the GitHub App token to create the PR so no specific permissions needed here
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
     environment:
       name: main
     steps:
-      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+          scope: DataDog/datadog-agent
+          policy: self.update-dependencies.create-pr
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # credentials are needed to create the PR at the end of the workflow
@@ -53,7 +54,7 @@ jobs:
         with:
           commit-message: "chore(deps): update all golang.org/x/... dependencies"
           branch: update-golang-org-x-${{ github.run_id }}-${{ github.run_attempt }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.octo-sts.outputs.token }}
           sign-commits: true
           title: "[automated] Update golang.org/x/... dependencies"
           body: |


### PR DESCRIPTION
### What does this PR do?
Switch token fetching from Github app to octo-sts on the workflows using it.

### Motivation
Security improvement to remove the Github App secret from the repository
https://datadoghq.atlassian.net/browse/ACIX-652

### Describe how you validated your changes
Tested a [backport request](https://github.com/DataDog/datadog-agent/actions/runs/17438840399/job/49516060484?pr=40386) from this precise PR.

### Additional Notes
follow-up of #39060 
