### PR TITLE
[DJM][GPUM] Add EnableNvmlDetection option

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -147,6 +147,7 @@ type DatadogConfig struct {
 	LogsConfig           LogsConfig                 `yaml:"logs_config,omitempty"`
 	CollectGPUTags       bool                       `yaml:"collect_gpu_tags,omitempty"`
 	GPUCheck             GPUCheckConfig             `yaml:"gpu,omitempty"`
+	EnableNvmlDetection  bool                       `yaml:"enable_nvml_detection,omitempty"` // Deprecated: this field won't be used after agent v7.70, GPUCheck.Enabled will be enough.
 	SBOM                 SBOMConfig                 `yaml:"sbom,omitempty"`
 }
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -238,6 +238,7 @@ func setupGPUIntegration(s *common.Setup) {
 
 	s.Config.DatadogYAML.CollectGPUTags = true
 	s.Config.DatadogYAML.GPUCheck.Enabled = true
+	s.Config.DatadogYAML.EnableNvmlDetection = true
 
 	if s.Config.SystemProbeYAML == nil {
 		s.Config.SystemProbeYAML = &config.SystemProbeConfig{}


### PR DESCRIPTION
### What does this PR do?

This PR restores the `enabled_nvml_detection` configuration option that was eagerly removed in https://github.com/DataDog/datadog-agent/pull/38593/files#diff-9e88689ebd80a83954e63f2b5a2c648c9fb657d37dc6b8c8fab5aee05787eac4

This configuration option will be deprecated in 7.70 but is still necessary today to get the GPU checks to work.

### Motivation

At Data Jobs Monitoring, we have a large prospect customer for whom monitoring GPU usage on their Databricks cluster is an essential part of the product.

### Describe how you validated your changes

Tested on my own cluster by running the install scripts generated by this CI pipeline.
Finally getting GPU metrics again after using the install script generated by this PR:
<img width="1920" height="934" alt="image" src="https://github.com/user-attachments/assets/9df15d37-631a-41f4-a825-a0fc3a7735fa" />

### Additional Notes

We will remove the deprecated config once 7.70 is released and has made its way to our customer(s) enviornment.
