### PR TITLE
Update and prevent `MODULE.bazel.lock` file from diverging again

### DIFF
--- a/.gitlab/bazel/lint.yaml
+++ b/.gitlab/bazel/lint.yaml
@@ -1,10 +1,21 @@
+bazel:mod-deps:
+  extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
+  stage: lint
+  script:
+    - bazel mod deps --lockfile_mode=error
+  after_script:
+    - |-
+      if [ $CI_JOB_STATUS = failed ]; then
+        echo >&2 "💡 bazel mod deps"
+      fi
+
 bazel:run-buildifier-test:
   extends: [ .bazel:defs, .bazel:runner:linux-amd64 ]
   stage: lint
   script:
     - bazel run //bazel/buildifier:test
   after_script:
-    - >-
+    - |-
       if [ $CI_JOB_STATUS = failed ]; then
         echo >&2 "💡 bazel run //bazel/buildifier"
       fi

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,6 +74,7 @@ git_override(
     commit = "e736410ced16744922c11762783b7c1fdddf620c",
     patch_args = ["-p1"],
     patches = [
+        "//bazel/patches:gcc-toolchain/0000-fix-no-repository-visible-as-@.patch",
         "//bazel/patches:gcc-toolchain/0001-Remove-fortran-related-actions-adapt-to-our-ctng-too.patch",
         "//bazel/patches:gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -348,6 +348,93 @@
         ]
       }
     },
+    "@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "6NYXupGFeHdYYEnMvtPmKCZCQ8BnIUs/VUgIGhwmfhA=",
+        "usagesDigest": "sWe6gvmFpdWalNUJUWNZF23cgclfU+ijKXCf9JEbTjs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "openssl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"srcs\",\n    srcs = glob(\n        include = [\"**\"],\n        exclude = [\"**/* *\"],\n    ),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a",
+              "strip_prefix": "openssl-1.1.1n",
+              "url": "https://www.openssl.org/source/openssl-1.1.1n.tar.gz"
+            }
+          },
+          "lapack": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"srcs\",\n    srcs = glob(\n        include = [\"**\"],\n        exclude = [\"**/* *\"],\n    ),\n    visibility = [\"//visibility:public\"],\n)\n",
+              "patch_cmds": [
+                "cat > make.inc <<EOF\n####################################################################\n#  LAPACK make include file.                                       #\n####################################################################\n\nSHELL = $0\n\nCC ?=\n\nFC ?=\nFFLAGS ?=\nFFLAGS_DRV ?=\nFFLAGS_NOOPT ?=\n\nLDFLAGS ?=\n\nAR ?=\nARFLAGS = cr\nRANLIB = echo\n\nBLASLIB ?=\nCBLASLIB ?=\nLAPACKLIB ?=\nTMGLIB ?=\nLAPACKELIB ?=\n\nDOCSDIR ?=\n\nTIMER ?=\nEOF\n"
+              ],
+              "sha256": "eac9570f8e0ad6f30ce4b963f4f033f0f643e7c3912fc9ee6cd99120675ad48b",
+              "strip_prefix": "lapack-3.12.0",
+              "url": "https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.12.0.tar.gz"
+            }
+          },
+          "avl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@gcc_toolchain+//:examples/avl/avl.BUILD.bazel",
+              "sha256": "6d62e563578b79795a84958cfe4e221a4c9847fbeb4a821d45bc049934fc6a90",
+              "strip_prefix": "Avl",
+              "url": "https://web.mit.edu/drela/Public/web/avl/avl3.40b.tgz"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "gcc_toolchain+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "gcc_toolchain+",
+            "lapack",
+            "gcc_toolchain++non_bazel_dependencies+lapack"
+          ]
+        ]
+      }
+    },
+    "@@pybind11_bazel+//:python_configure.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "OMjJ8aOAn337bDg7jdyvF/juIrC2PpUcX6Dnf+nhcF0=",
+        "usagesDigest": "fycyB39YnXIJkfWCIXLUKJMZzANcuLy9ZE73hRucjFk=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_python": {
+            "repoRuleId": "@@pybind11_bazel+//:python_configure.bzl%python_configure",
+            "attributes": {}
+          },
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11.BUILD",
+              "strip_prefix": "pybind11-2.11.1",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.11.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_flex+//flex/internal:default_toolchain_ext.bzl%default_toolchain_ext": {
       "general": {
         "bzlTransitiveDigest": "IyvJbFvAYvjVrhYqrB8CJ8qfee94/AdZQhknVQYlFb8=",
@@ -716,6 +803,89 @@
             "rules_foreign_cc+",
             "rules_foreign_cc",
             "rules_foreign_cc+"
+          ]
+        ]
+      }
+    },
+    "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "lxvzPQyluk241QRYY81nZHOcv5Id/5U2y6dp42qibis=",
+        "usagesDigest": "wy6ISK6UOcBEjj/mvJ/S3WeXoO67X+1llb9yPyFtPgc=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "platforms": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_python": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "bazel_skylib": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "com_google_absl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "repoRuleId": "@@rules_fuzzing+//fuzzing/private/oss_fuzz:repository.bzl%oss_fuzz_repository",
+            "attributes": {}
+          },
+          "honggfuzz": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_fuzzing+//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_jar",
+            "attributes": {
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_fuzzing+",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -38,6 +38,15 @@ dda bzl run //bazel/buildifier
 bazel run //bazel/buildifier
 ```
 
+### Lock file maintenance
+
+`MODULE.bazel.lock` must exhaustively reflect actually used dependencies. After updating any `bazel` dependency, such as
+with `bazel_dep` in a `MODULE.bazel` file, please run:
+
+```sh
+bazel mod deps
+```
+
 ### Remote cache (internal to Datadog)
 
 If you are on the Datadog internal network and want to take advantage of the remote cache, simply add the following line

--- a/bazel/patches/gcc-toolchain/0000-fix-no-repository-visible-as-@.patch
+++ b/bazel/patches/gcc-toolchain/0000-fix-no-repository-visible-as-@.patch
@@ -1,0 +1,11 @@
+--- a/internal.bzl	2025-10-31 16:00:48.767972855 +0100
++++ b/internal.bzl	2025-11-18 10:16:13.143118991 +0100
+@@ -42,7 +42,7 @@
+ def _avl():
+     http_archive(
+         name = "avl",
+-        build_file = "@//:examples/avl/avl.BUILD.bazel",
++        build_file = "//:examples/avl/avl.BUILD.bazel",
+         sha256 = "6d62e563578b79795a84958cfe4e221a4c9847fbeb4a821d45bc049934fc6a90",
+         strip_prefix = "Avl",
+         url = "https://web.mit.edu/drela/Public/web/avl/avl3.40b.tgz",


### PR DESCRIPTION
### What does this PR do?
1. Run a quick `bazel` command that fails if the `MODULE.bazel.lock` file gets out-of-sync with actually used dependencies,
2. Update `MODULE.bazel.lock` thanks to `bazel mod deps` as advised in the [error message](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1241267622#L40):
```sh
ERROR: The module extension '@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies' does not exist in the lockfile
ERROR: The module extension '@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies' does not exist in the lockfile
ERROR: The module extension '@@pybind11_bazel+//:python_configure.bzl%extension' does not exist in the lockfile
<root> (@_)
ERROR: Results may be incomplete as 3 extensions failed.
Running after script...
$ if [ $CI_JOB_STATUS = failed ]; then
💡 bazel mod deps
```
### Motivation
Faced differences unrelated to my change when invoking `bazel build //...` locally.
### Additional Notes
Currently, there's a problem with the `gcc_toolchain` repo:
```sh
$ bazel mod deps
ERROR: [redacted]/gcc_toolchain+/internal.bzl:43:17: Traceback (most recent call last):
	File "[redacted]/gcc_toolchain+/internal.bzl", line 117, column 9, in _non_bazel_dependencies_ext_impl
		_avl()
	File "[redacted]/gcc_toolchain+/internal.bzl", line 43, column 17, in _avl
		http_archive(
Error in repository_rule: no repository visible as '@' in the extension '@@gcc_toolchain+//:internal.bzl%non_bazel_dependencies', but referenced by label '@//:examples/avl/avl.BUILD.bazel' in attribute 'build_file' of http_archive 'avl'.
ERROR: error evaluating module extension @@gcc_toolchain+//:internal.bzl%non_bazel_dependencies
```
Hence the additional patch, pending:
- f0rmiga/gcc-toolchain#211