### PR TITLE
[CONTP-939] Fix autodiscovery check de-duplication for docker listeners in k8s environments

### DIFF
--- a/comp/core/autodiscovery/listeners/container.go
+++ b/comp/core/autodiscovery/listeners/container.go
@@ -139,6 +139,18 @@ func (l *ContainerListener) createContainerService(entity workloadmeta.Entity) {
 			workloadmetafilter.CreateContainer(container, workloadmetafilter.CreatePod(pod)),
 			workloadfilter.GetAutodiscoveryFilters(workloadfilter.LogsFilter),
 		)
+
+		adIdentifier := container.Name
+		if customADID, found := utils.ExtractCheckIDFromPodAnnotations(pod.Annotations, container.Name); found {
+			adIdentifier = customADID
+			svc.adIdentifiers = append(svc.adIdentifiers, customADID)
+		}
+
+		checkNames, err := utils.ExtractCheckNamesFromPodAnnotations(pod.Annotations, adIdentifier)
+		if err != nil {
+			log.Errorf("error extracting check names from pod annotations: %s", err)
+		}
+		svc.checkNames = checkNames
 	} else {
 		checkNames, err := utils.ExtractCheckNamesFromContainerLabels(container.Labels)
 		if err != nil {

--- a/comp/core/autodiscovery/listeners/container_test.go
+++ b/comp/core/autodiscovery/listeners/container_test.go
@@ -166,6 +166,9 @@ func TestCreateContainerService(t *testing.T) {
 	podWithTolerateUnreadyAnnotation := pod.DeepCopy().(*workloadmeta.KubernetesPod)
 	podWithTolerateUnreadyAnnotation.Annotations["ad.datadoghq.com/tolerate-unready"] = "true"
 
+	podWithCheck := pod.DeepCopy().(*workloadmeta.KubernetesPod)
+	podWithCheck.Annotations["ad.datadoghq.com/foobar.checks"] = `{"redisdb": {"instances": [{"host": "%%host%%", "port": 6379}]}}`
+
 	// Define a container excluded by the "container_exclude" config setting
 	containerExcludeConfigSetting := []string{"image:gcr.io/excluded:.*"}
 	mockConfig := configmock.New(t)
@@ -333,6 +336,73 @@ func TestCreateContainerService(t *testing.T) {
 			name:             "excluded by config setting",
 			container:        containerExcludedByConfigSetting,
 			expectedServices: map[string]wlmListenerSvc{},
+		},
+		{
+			name:      "pod check annotation added to check names",
+			container: kubernetesContainer,
+			pod:       podWithCheck,
+			expectedServices: map[string]wlmListenerSvc{
+				"container://foo": {
+					service: &service{
+						tagger: taggerComponent,
+						entity: kubernetesContainer,
+						adIdentifiers: []string{
+							"docker://foo",
+							"gcr.io/foobar",
+							"foobar",
+						},
+						hosts:      map[string]string{"pod": podWithCheck.IP},
+						ports:      []ContainerPort{},
+						ready:      false,
+						checkNames: []string{"redisdb"},
+					},
+				},
+			},
+		},
+		{
+			name:      "pod check id accounted for in check names resolution",
+			container: kubernetesContainer,
+			pod: &workloadmeta.KubernetesPod{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindKubernetesPod,
+					ID:   podID,
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						"ad.datadoghq.com/bar.checks":      `{"postgresql": {}}`,
+						"ad.datadoghq.com/foobar.check.id": `bar`,
+					},
+				},
+				Containers: []workloadmeta.OrchestratorContainer{
+					{
+						ID:    kubernetesContainer.ID,
+						Name:  kubernetesContainer.Name,
+						Image: kubernetesContainer.Image,
+					},
+				},
+				IP:    "127.0.0.1",
+				Ready: true,
+			},
+			expectedServices: map[string]wlmListenerSvc{
+				"container://foo": {
+					service: &service{
+						tagger: taggerComponent,
+						entity: kubernetesContainer,
+						adIdentifiers: []string{
+							"docker://foo",
+							"gcr.io/foobar",
+							"foobar",
+							"bar",
+						},
+						hosts:      map[string]string{"pod": "127.0.0.1"},
+						ports:      []ContainerPort{},
+						ready:      true,
+						checkNames: []string{"postgresql"},
+					},
+				},
+			},
 		},
 	}
 

--- a/releasenotes/notes/autodiscovery_dedup_docker-e7cb1ac40368444a.yaml
+++ b/releasenotes/notes/autodiscovery_dedup_docker-e7cb1ac40368444a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    De-duplicates service checks when auto-discovery is enabled with the docker listener. Ensuring
+    pod annotated services only have one check and ignores configuration from the default file source.


### PR DESCRIPTION
### What does this PR do?

This PR adds the check names of user configured pod annotations to `svc.checkNames` so that auto-discovery checks are properly de-duplicated during the [filterTemplatesOverridenChecks](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/listeners/service.go#L165) reconciliation process.

### Motivation

A customer has auto-discovery enabled within their k8s agent environments but has opted to enable the docker listener (`DD_EXTRA_LISTENERS=docker`). As a result, the docker listener would not account for the pod level annotations defining a check on their elasticsearch container.

As a result, auto-discovery was scheduling a check and the pod annotation check wasn't overriding this default leading to duplicate checks.

See: https://datadoghq.atlassian.net/browse/CONS-7412

### Describe how you validated your changes

#### Unit Tests
Added two tests to validate that `svc.checkNames` is populated with the same names as the checks found in the pod annotations.

#### Manual Verification

1. Configure datadog agent with `DD_EXTRA_LISTENERS: "docker"`.
<details><summary>agent config</summary>
<p>

```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: mathewe-dev
  clusterChecks:
    enabled: true
  logLevel: INFO
  kubeStateMetricsCore:
    enabled: true
    # useClusterCheckRunners: true
  envDict:
    DD_TAGS: "version:510"
    DD_EXTRA_LISTENERS: "docker"
agents:
  image:
    repository: us-east4-docker.pkg.dev/datadog-sandbox/mathewe/agent
    tag: mathewe-arm64-dedup
    # pullPolicy: Always
clusterAgent:
  # image:
  #   repository: us-east4-docker.pkg.dev/datadog-sandbox/gabedos/cluster-agent
  #   tag: 7.59-gabedos-arm64-p
  #   pullPolicy: Always
  enabled: true
  replicas: 1
```

</p>
</details> 

2. Deploy service supported by auto-discovery.
<details><summary>elasticsearch service</summary>
<p>

```
apiVersion: v1
kind: Pod
metadata:
  name: elsearch
  annotations:
    ad.datadoghq.com/elasticsearch.checks: '{"elastic":{"init_config":{},"instances":[{"url":"http://127.0.0.1:999"}]}}'
spec:
  containers:
    - name: elasticsearch
      image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
      command: ["sleep", "3600"]
```

</p>
</details> 

3. Check agent checks configuration **only** has the pod annotated check config.
<details><summary>Agent check config showing one schedule</summary>
<p>

<img width="858" height="520" alt="image" src="https://github.com/user-attachments/assets/d4fc2b04-88f2-4e20-adc5-1da247677252" />


</p>
</details> 

### Additional Notes
