### PR TITLE
[CXP-2597] Remove `process_config.run_in_core_agent` from agent config template

### DIFF
--- a/comp/process/agent/agent_linux.go
+++ b/comp/process/agent/agent_linux.go
@@ -62,11 +62,10 @@ func enabledHelper(config config.Component, checkComponents []types.CheckCompone
 		}
 
 		if runInCoreAgent {
-			l.Info("The process checks will run in the core agent")
+			l.Info("The process checks will run in the core agent via the process-component")
 		} else if processEnabled {
 			l.Info("Process/Container Collection in the Process Agent will be deprecated in a future release " +
-				"and will instead be run in the Core Agent. " +
-				"Set process_config.run_in_core_agent.enabled to true to switch now.")
+				"and will instead be run in the Core Agent. ")
 		}
 
 		return !runInCoreAgent || npmEnabled

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1692,15 +1692,6 @@ api_key:
 #
 # process_config:
 
-  {{- if (eq .OS "linux")}}
-  ## @param run_in_core_agent - custom object - optional
-  ## Controls whether the process Agent or core Agent collects process and/or container information (Linux only).
-  # run_in_core_agent:
-    ## @param enabled - boolean - optional - default: true
-    ## Enables process/container collection on the core Agent instead of the process Agent.
-    # enabled: true
-  {{ end }}
-
   ## @param process_collection - custom object - optional
   ## Specifies settings for collecting processes.
   # process_collection:

--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util/api"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -274,7 +275,12 @@ func (l *CheckRunner) Run() error {
 		}
 	}
 	status.UpdateEnabledChecks(checkNames)
-	log.Infof("Starting process-agent with enabled checks=%v", checkNames)
+
+	runnerName := "process-agent"
+	if flavor.GetFlavor() == flavor.DefaultAgent {
+		runnerName = "process-component"
+	}
+	log.Infof("Starting %s with enabled checks=%v", runnerName, checkNames)
 
 	if realTimeAllowed && l.rtNotifierChan != nil {
 		l.listenForRTUpdates()


### PR DESCRIPTION
### What does this PR do?
* Removes `process_config.run_in_core_agent` from agent config template
* Improves logging when process checks will run in the core agent

### Motivation

We are beginning to baseline/deprecate this config, so we want discourage manual usage of it.

### Describe how you validated your changes

### Additional Notes
