### PR TITLE
dyninst: remove PrintStack

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"iter"
 	"math"
-	"runtime/debug"
 	"slices"
 	"sort"
 	"strings"
@@ -1543,7 +1542,6 @@ func (b *packagesIterator) parseAbstractFunction(offset dwarf.Offset) (*abstract
 func (b *packagesIterator) parseAbstractVariable(entry *dwarf.Entry) (Variable, typeInfo, error) {
 	name, ok := entry.Val(dwarf.AttrName).(string)
 	if !ok {
-		debug.PrintStack()
 		return Variable{}, typeInfo{}, fmt.Errorf("variable without name at 0x%x", entry.Offset)
 	}
 	declLine, ok := entry.Val(dwarf.AttrDeclLine).(int64)


### PR DESCRIPTION
I think a call to PrintStack was inadvertently left in on an error case.

