### PR TITLE
Allow passing arbitrary extra args to go test command

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -339,7 +339,9 @@ def test(
         '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt}'
     )
     govet_flags = '-vet=off'
-    gotest_flags = '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
+    gotest_flags = (
+        '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
+    )
     cmd = f'gotestsum {gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
     args = {
         "go_mod": go_mod,

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -269,6 +269,7 @@ def test(
     skip_flakes=False,
     build_stdlib=False,
     test_washer=False,
+    extra_args=None,
     run_on=None,  # noqa: U100, F841. Used by the run_on_devcontainer decorator
 ):
     """
@@ -338,7 +339,7 @@ def test(
         '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt}'
     )
     govet_flags = '-vet=off'
-    gotest_flags = '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache}'
+    gotest_flags = '{verbose} {test_cpus} -timeout {timeout}s -short {covermode_opt} {test_run_arg} {nocache} {extra_args}'
     cmd = f'gotestsum {gotestsum_flags} -- {gobuild_flags} {govet_flags} {gotest_flags}'
     args = {
         "go_mod": go_mod,
@@ -357,6 +358,9 @@ def test(
         "skip_flakes": "--skip-flake" if skip_flakes else "",
         "gotestsum_format": "standard-verbose" if verbose else "pkgname",
     }
+
+    if extra_args:
+        args["extra_args"] = extra_args
 
     # Test
     if build_stdlib:

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -357,10 +357,8 @@ def test(
         "rerun_fails": f"--rerun-fails={rerun_fails}" if rerun_fails else "",
         "skip_flakes": "--skip-flake" if skip_flakes else "",
         "gotestsum_format": "standard-verbose" if verbose else "pkgname",
+        "extra_args": extra_args or "",
     }
-
-    if extra_args:
-        args["extra_args"] = extra_args
 
     # Test
     if build_stdlib:


### PR DESCRIPTION
### What does this PR do?
Allow passing arbitrary extra args to go test command.

### Motivation
I needed to pass the `-o` flag to `go test` so that test binaries are kept (in order to debug a core dump generated in a test), which means adding an extra (very uncommon) argument to the test.

### Describe how you validated your changes
Local testing.

### Additional Notes
Allowing passing arbitrary arguments to `go` subcommands is very useful for local uses.
