### PR TITLE
Return a non-nil error in python loader

### DIFF
--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -179,7 +179,7 @@ func (cl *PythonCheckLoader) Load(senderManager sender.SenderManager, config int
 	// all failed, return error for last failure
 	if checkModule == nil || checkClass == nil {
 		log.Debugf("PyLoader returning %s for %s", err, moduleName)
-		return nil, err
+		return nil, fmt.Errorf("unable to load python module %s: %v", name, err)
 	}
 
 	wheelVersion := "unversioned"

--- a/pkg/collector/python/loader_test.go
+++ b/pkg/collector/python/loader_test.go
@@ -22,3 +22,7 @@ func TestLoadCustomCheck(t *testing.T) {
 func TestLoadHACheck(t *testing.T) {
 	testLoadHACheck(t)
 }
+
+func TestLoadError(t *testing.T) {
+	testLoadError(t)
+}


### PR DESCRIPTION
### What does this PR do?
Return a non-nil error in Python loader when a check could not be loaded.

### Motivation
In that code block the error can be `nil`, so the loader would end up returning `nil, nil`, and the scheduler tries to use the `nil` check (since there was no error), resulting in a segfault.
Overall we should return a non-`nil` error here, even if we don't know what the underlying rtloader error is.

### Describe how you validated your changes
Added a unit test for the change.
If you revert the change in `pkg/collector/python/loader.go`, the unit test fails, and the scheduler would crash trying to use the `nil` check returned.

### Additional Notes
