### PR TITLE
[AGENTRUN-689] Use FindBacktrace to detect execinfo availability in rtloader cmake

### DIFF
--- a/rtloader/rtloader/CMakeLists.txt
+++ b/rtloader/rtloader/CMakeLists.txt
@@ -28,19 +28,20 @@ add_library(datadog-agent-rtloader SHARED
     ../common/rtloader_mem.c
 )
 
-# execinfo is not POSIX-compliant and some libc may have libexecinfo as a library.
-find_library(EXECINFO execinfo)
-if(EXECINFO)
-    target_link_libraries(datadog-agent-rtloader execinfo)
-    add_compile_definitions(HAS_BACKTRACE_LIB)
+# https://cmake.org/cmake/help/latest/module/FindBacktrace.html
+find_package(Backtrace)
+if(Backtrace_FOUND)
+    if(NOT TARGET Backtrace::Backtrace)
+        # for pre-3.30 CMake versions
+        add_library(Backtrace::Backtrace INTERFACE IMPORTED)
+        set_target_properties(Backtrace::Backtrace PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${Backtrace_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${Backtrace_INCLUDE_DIRS}"
+        )
+    endif()
+    target_link_libraries(datadog-agent-rtloader PRIVATE Backtrace::Backtrace)
+    target_compile_definitions(datadog-agent-rtloader PRIVATE HAS_BACKTRACE_LIB)
 endif()
-endif()
-
-## Backtrace
-if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
-  find_package(Backtrace REQUIRED)
-  target_link_libraries(datadog-agent-rtloader ${Backtrace_LIBRARIES})
-  add_compile_definitions(HAS_BACKTRACE_LIB)
 endif()
 
 set_target_properties(datadog-agent-rtloader PROPERTIES

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -13,16 +13,6 @@
 // clang-format off
 // handler stuff
 
-#ifndef HAS_BACKTRACE_LIB
-// recommended use of __has_include is with two separate if statements
-// https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html
-#  if defined __has_include
-#    if __has_include (<execinfo.h>)
-#      define HAS_BACKTRACE_LIB
-#    endif
-#  endif
-#endif
-
 #ifdef HAS_BACKTRACE_LIB
 #  include <execinfo.h>
 #else

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -19,14 +19,14 @@
 #  if defined __has_include
 #    if __has_include (<execinfo.h>)
 #      define HAS_BACKTRACE_LIB
-#    else
-#      warning "<execinfo.h> not found, c backtrace will not be available"
 #    endif
 #  endif
 #endif
 
 #ifdef HAS_BACKTRACE_LIB
-#include <execinfo.h>
+#  include <execinfo.h>
+#else
+#  warning "<execinfo.h> not found, C backtrace will not be available"
 #endif
 #include <csignal>
 #include <cstring>

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -12,6 +12,19 @@
 #ifndef _WIN32
 // clang-format off
 // handler stuff
+
+#ifndef HAS_BACKTRACE_LIB
+// recommended use of __has_include is with two separate if statements
+// https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html
+#  if defined __has_include
+#    if __has_include (<execinfo.h>)
+#      define HAS_BACKTRACE_LIB
+#    else
+#      warning "<execinfo.h> not found, c backtrace will not be available"
+#    endif
+#  endif
+#endif
+
 #ifdef HAS_BACKTRACE_LIB
 #include <execinfo.h>
 #endif


### PR DESCRIPTION
### What does this PR do?
Update rtloader's CMake definition to use the [FindBacktrace module](https://cmake.org/cmake/help/v3.13/module/FindPython3.html) to automatically (and properly) find whether the backtrace symbols from `execinfo.h` are available.

`execinfo.h` is actually provided by the glibc so in most cases we don't need to link to any particular library or add include directories https://www.gnu.org/software/gnulib/manual/html_node/execinfo_002eh.html.

[libexecinfo](https://github.com/fam007e/libexecinfo) only exists as a workaround when using non-glibc (eg. musl).

The change also makes `libexecinfo` not a requirement on BSD.

### Motivation
Fix backtrace information not being available with `glibc`. Before this change, backtrace information was only included when `libexecinfo.so` installed.

### Describe how you validated your changes
#### RTLoader build
Checked every impacted system combination: using `glibc`, using `musl` w/o `libexecinfo`, and using `musl` w/ `libexecinfo`. For each, I tried using a version of CMake pre-3.30 and post-3.30 (the `FindBacktrace` module has different behavior).

It correctly detected libc-provided / library-provided backtrace, or disabled backtrace info.

#### C-stacktrace
- install the agent, I used an Ubuntu amd64 VM and installed using the deb artifact
- create a python file for the check in `/etc/datadog-agent/checks.d/mycheck.py`:
```py
from datadog_checks.base import AgentCheck
import ctypes;

class HelloCheck(AgentCheck):
    def check(self, instance):
        # This tries to read a word from nil, leading to segv
        # from: https://bugs.python.org/issue1215#msg143236
        ctypes.string_at(0)
```

- add a check config in `/etc/datadog-agent/conf.d/mycheck.d/conf.yaml`:
```
init_config:

instances:
  - {}
```

- enable c stacktrace collection in the agent config `/etc/datadog-agent/datadog.yaml`:
```
c_stacktrace_collection: true
```

- Restart the agent and observe the crash
```sh
$ sudo systemctl stop datadog-agent
$ sudo -u dd-agent datadog-agent run
```

Result contains something like the following:

```
2025-09-02 12:37:22 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:mycheck | Running check...
HANDLER CAUGHT signal Error: signal 11
C-LAND STACKTRACE:
/opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2(_Z13signalHandleriP9siginfo_tPv+0x24) [0x7ab94707b6f4]
/lib/x86_64-linux-gnu/libc.so.6(+0x42520) [0x7ab946e42520]
/lib/x86_64-linux-gnu/libc.so.6(+0x1b20bc) [0x7ab946fb20bc]
/opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ctypes.cpython-312-x86_64-linux-gnu.so(+0x8dc8) [0x7ab8fc039dc8]
/opt/datadog-agent/embedded/lib/libffi.so.8(+0x9052) [0x7ab8fc02a052]
/opt/datadog-agent/embedded/lib/libffi.so.8(+0x7667) [0x7ab8fc028667]
/opt/datadog-agent/embedded/lib/libffi.so.8(ffi_call+0xce) [0x7ab8fc028dae]
/opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ctypes.cpython-312-x86_64-linux-gnu.so(+0x129ee) [0x7ab8fc0439ee]
/opt/datadog-agent/embedded/lib/python3.12/lib-dynload/_ctypes.cpython-312-x86_64-linux-gnu.so(+0xc6e4) [0x7ab8fc03d6e4]
/opt/datadog-agent/embedded/lib/libpython3.12.so.1.0(_PyObject_MakeTpCall+0x90) [0x7ab8fcd69d40]
/opt/datadog-agent/embedded/lib/libpython3.12.so.1.0(_PyEval_EvalFrameDefault+0x98db) [0x7ab8fcd1a68b]
/opt/datadog-agent/embedded/lib/libpython3.12.so.1.0(+0x16d27b) [0x7ab8fcd6d27b]
/opt/datadog-agent/embedded/lib/libpython3.12.so.1.0(+0x16a8ce) [0x7ab8fcd6a8ce]
/opt/datadog-agent/embedded/lib/libpython3.12.so.1.0(PyObject_CallMethod+0xe9) [0x7ab8fcd6b319]
/opt/datadog-agent/embedded/lib/libdatadog-agent-three.so(_ZN5Three8runCheckEP16RtLoaderPyObject+0x2f) [0x7ab8fd36c55f]
datadog-agent(_cgo_3d006c54b7ca_Cfunc_run_check+0x37) [0x309b445]
datadog-agent() [0x4b5d04]
SIGABRT: abort
PC=0x7ab946fb20bc m=8 sigcode=0
signal arrived during cgo execution
```

### Additional Notes
It seems that CMake provides a module to check if backtrace is supported when building, maybe we could use that, but I don't know if there are other caveats.
https://cmake.org/cmake/help/latest/module/FindBacktrace.html