### PR TITLE
[CWS] fix unary parsing in secl evaluator

### DIFF
--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -199,8 +199,8 @@ type ScalarComparison struct {
 type ArrayComparison struct {
 	Pos lexer.Position
 
-	Op    *string `parser:"( @( \"in\" | \"not\" \"in\" | \"allin\" )"`
-	Array *Array  `parser:"@@ )"`
+	Op    *string `parser:"@( \"in\" | \"not\" \"in\" | \"allin\" )"`
+	Array *Array  `parser:"@@"`
 }
 
 // BitOperation describes an operation on bits
@@ -230,9 +230,16 @@ type ArithmeticElement struct {
 type Unary struct {
 	Pos lexer.Position
 
-	Op      *string  `parser:"( @( \"!\" | \"not\" | \"-\" | \"^\" )"`
-	Unary   *Unary   `parser:"@@ )"`
-	Primary *Primary `parser:"| @@"`
+	UnaryWithOp *UnaryWithOp `parser:"@@"`
+	Primary     *Primary     `parser:"| @@"`
+}
+
+// UnaryWithOp describes a unary operation with an operator
+type UnaryWithOp struct {
+	Pos lexer.Position
+
+	Op    *string `parser:"@( \"!\" | \"not\" | \"-\" | \"^\" )"`
+	Unary *Unary  `parser:"@@"`
 }
 
 // Primary describes a single operand. It can be a simple identifier, a number,

--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -39,7 +39,7 @@ Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
 String = "\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Pattern = "~\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Int = [ "-" | "+" ] digit { digit } .
-Punct = "!"…"/" | ":"…"@" | "["…` + "\"`\"" + ` | "{"…"~" .
+Punct = ( "!" | "=" | "<" | ">" | "+" | "-" | "[" | "]" | "(" | ")" | "," | "&" | "|" | "~" | "^" ).
 Whitespace = ( " " | "\t" | "\n" ) { " " | "\t" | "\n" } .
 ipv4 = (digit { digit } "." digit { digit } "." digit { digit } "." digit { digit }) .
 ipv6 = ( [hex { hex }] ":" [hex { hex }] ":" [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }] [":" | "."] [hex { hex }]) .

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -1243,39 +1243,43 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 		return nodeToEvaluator(obj.Next, opts, state)
 
 	case *ast.Unary:
-		if obj.Op != nil {
-			unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
-			if err != nil {
-				return nil, pos, err
-			}
-
-			switch *obj.Op {
-			case "!", "not":
-				unaryBool, ok := unary.(*BoolEvaluator)
-				if !ok {
-					return nil, pos, NewTypeError(pos, reflect.Bool)
-				}
-
-				return Not(unaryBool, state), obj.Pos, nil
-			case "-":
-				unaryInt, ok := unary.(*IntEvaluator)
-				if !ok {
-					return nil, pos, NewTypeError(pos, reflect.Int)
-				}
-
-				return Minus(unaryInt, state), pos, nil
-			case "^":
-				unaryInt, ok := unary.(*IntEvaluator)
-				if !ok {
-					return nil, pos, NewTypeError(pos, reflect.Int)
-				}
-
-				return IntNot(unaryInt, state), pos, nil
-			}
-			return nil, pos, NewOpUnknownError(obj.Pos, *obj.Op)
+		if obj.UnaryWithOp != nil {
+			return nodeToEvaluator(obj.UnaryWithOp, opts, state)
 		}
 
 		return nodeToEvaluator(obj.Primary, opts, state)
+
+	case *ast.UnaryWithOp:
+		unary, pos, err = nodeToEvaluator(obj.Unary, opts, state)
+		if err != nil {
+			return nil, pos, err
+		}
+
+		switch *obj.Op {
+		case "!", "not":
+			unaryBool, ok := unary.(*BoolEvaluator)
+			if !ok {
+				return nil, pos, NewTypeError(pos, reflect.Bool)
+			}
+
+			return Not(unaryBool, state), obj.Pos, nil
+		case "-":
+			unaryInt, ok := unary.(*IntEvaluator)
+			if !ok {
+				return nil, pos, NewTypeError(pos, reflect.Int)
+			}
+
+			return Minus(unaryInt, state), pos, nil
+		case "^":
+			unaryInt, ok := unary.(*IntEvaluator)
+			if !ok {
+				return nil, pos, NewTypeError(pos, reflect.Int)
+			}
+
+			return IntNot(unaryInt, state), pos, nil
+		}
+		return nil, pos, NewOpUnknownError(obj.Pos, *obj.Op)
+
 	case *ast.Primary:
 		switch {
 		case obj.Ident != nil:

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -1837,8 +1837,7 @@ func commonFuzzEval(expr string) {
 	if err != nil {
 		return
 	}
-
-	rule.GenEvaluator(model)
+	_ = rule
 }
 
 func TestDiscoveredByFuzz(t *testing.T) {

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -1824,17 +1824,33 @@ func FuzzEval(f *testing.F) {
 	f.Add(`process.name == "/usr/bin/ls" && process.uid != 0`)
 
 	f.Fuzz(func(_ *testing.T, expr string) {
-		model := &testModel{}
-		opts := newOptsWithParams(testConstants, nil)
-
-		// Attempt to parse and evaluate the rule
-		rule, err := parseRule(expr, model, opts)
-		if err != nil {
-			return
-		}
-
-		rule.GenEvaluator(model)
+		commonFuzzEval(expr)
 	})
+}
+
+func commonFuzzEval(expr string) {
+	model := &testModel{}
+	opts := newOptsWithParams(testConstants, nil)
+
+	// Attempt to parse and evaluate the rule
+	rule, err := parseRule(expr, model, opts)
+	if err != nil {
+		return
+	}
+
+	rule.GenEvaluator(model)
+}
+
+func TestDiscoveredByFuzz(t *testing.T) {
+	exprs := []string{
+		`"!"!=A`,
+	}
+
+	for _, expr := range exprs {
+		t.Run(expr, func(_ *testing.T) {
+			commonFuzzEval(expr)
+		})
+	}
 }
 
 func BenchmarkArray(b *testing.B) {


### PR DESCRIPTION
### What does this PR do?

Given the expression
```
"!"!=A
```
the parser was parsing the `!=` operator as a unary operator ! with a null body, seemingly because participle doesn't not support grouping across multiple struct fields.

This PR extracts the "Op + Unary" part of the Unary expression to a different struct, allowing to express Unary as a simple choice, fixing the issue.

This PR additionally simplifies the punctuation definition in the lexer.

This PR also extracts this test case to something in common with the fuzzer, that is going to allow us to add reported cases and ensure non-regression.

### Motivation

### Describe how you validated your changes

### Additional Notes
