### PR TITLE
[CSPM] fix badenv tests to actually ensure events are skipped

### DIFF
--- a/pkg/compliance/tests/badenv_test.go
+++ b/pkg/compliance/tests/badenv_test.go
@@ -44,7 +44,7 @@ findings[f] {
 	)
 }
 `).
-		AssertNoEvent()
+		AssertSkippedEvent(nil)
 
 	b.AddRule("NoDockerWithScope").
 		WithScope("docker").
@@ -78,7 +78,7 @@ findings[f] {
 	)
 }
 `).
-		AssertNoEvent()
+		AssertSkippedEvent(nil)
 }
 
 func TestNoKubernetes(t *testing.T) {
@@ -114,7 +114,7 @@ findings[f] {
 	)
 }
 `).
-		AssertNoEvent()
+		AssertSkippedEvent(nil)
 
 	b.AddRule("NoKubernetesCluster").
 		WithScope("kubernetesCluster").
@@ -145,5 +145,5 @@ findings[f] {
 	)
 }
 `).
-		AssertNoEvent()
+		AssertSkippedEvent(nil)
 }

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -195,6 +195,19 @@ func (c *assertedRule) AssertPassedEvent(f func(t *testing.T, evt *compliance.Ch
 	return c
 }
 
+func (c *assertedRule) AssertSkippedEvent(f func(t *testing.T, evt *compliance.CheckEvent)) *assertedRule {
+	c.asserts = append(c.asserts, func(t *testing.T, evt *compliance.CheckEvent) {
+		if assert.Equal(t, compliance.CheckSkipped, evt.Result) {
+			if f != nil {
+				f(t, evt)
+			}
+		} else {
+			t.Logf("received unexpected %q event : %v", evt.Result, evt)
+		}
+	})
+	return c
+}
+
 func (c *assertedRule) AssertFailedEvent(f func(t *testing.T, evt *compliance.CheckEvent)) *assertedRule {
 	c.asserts = append(c.asserts, func(t *testing.T, evt *compliance.CheckEvent) {
 		if assert.Equal(t, compliance.CheckFailed, evt.Result) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the run of
```
go test -v github.com/DataDog/datadog-agent/pkg/compliance/tests
```
by ensuring that when k8s or docker scopes are disabled (because the platform doesn't support it), we emit events as skipped and not no event at all.

### Motivation

### Describe how you validated your changes

### Additional Notes
