### PR TITLE
process: service: make service heartbeats do partial updates

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -310,14 +310,13 @@ func (c *collector) detectLanguages(processes []*procutil.Process) []*languagemo
 	return nil
 }
 
-// filterPidsToRequest filters PIDs to only request services for new or stale processes.
-// It returns a slice of pids to request (to be used as a request parameters), and
-// a map of pids to *model.Service to be filled up with the response received from
-// system-probe. This map is useful to know for which pids we have not received
-// service info and that needs to be handled by the retry mechanism.
-func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]int32, map[int32]*model.Service) {
+// filterPidsToRequest filters PIDs to categorize them as new or needing heartbeat refresh.
+// It returns separate slices for new PIDs and heartbeat PIDs, along with a map of pids to *model.Service
+// to be filled up with the response received from system-probe.
+func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]int32, []int32, map[int32]*model.Service) {
 	now := c.clock.Now().UTC()
-	pidsToRequest := make([]int32, 0, len(alivePids))
+	newPids := make([]int32, 0, len(alivePids))
+	heartbeatPids := make([]int32, 0, len(alivePids))
 	pidsToService := make(map[int32]*model.Service, len(alivePids))
 
 	for pid := range alivePids {
@@ -335,25 +334,29 @@ func (c *collector) filterPidsToRequest(alivePids core.PidSet, procs map[int32]*
 
 		// Check if service data is stale or never collected
 		lastHeartbeat, exists := c.pidHeartbeats[pid]
-		if !exists || now.Sub(lastHeartbeat) > core.HeartbeatTime {
-			// Service data is stale or never collected, need to refresh it
-			pidsToRequest = append(pidsToRequest, pid)
+		if !exists {
+			// Never seen this process before, need full service info
+			newPids = append(newPids, pid)
+			pidsToService[pid] = nil
+		} else if now.Sub(lastHeartbeat) > core.HeartbeatTime {
+			// Service data is stale, need heartbeat refresh
+			// Since we have a pidHeartbeats entry, we know service data exists
+			heartbeatPids = append(heartbeatPids, pid)
 			pidsToService[pid] = nil
 		}
 	}
 
-	return pidsToRequest, pidsToService
+	return newPids, heartbeatPids, pidsToService
 }
 
 // getDiscoveryServices calls the system-probe /discovery/services endpoint
-func (c *collector) getDiscoveryServices(pids []int32) (*model.ServicesEndpointResponse, error) {
+func (c *collector) getDiscoveryServices(newPids []int32, heartbeatPids []int32) (*model.ServicesEndpointResponse, error) {
 	var responseData model.ServicesEndpointResponse
 
-	// Create params with PIDs and convert to JSON
+	// Create params with categorized PIDs and convert to JSON
 	params := core.DefaultParams()
-	for _, pid := range pids {
-		params.Pids = append(params.Pids, int(pid))
-	}
+	params.NewPids = newPids
+	params.HeartbeatPids = heartbeatPids
 
 	jsonBody, err := params.ToJSON()
 	if err != nil {
@@ -404,11 +407,12 @@ func (c *collector) handleServiceRetries(pid int32) {
 }
 
 // getProcessEntitiesFromServices creates Process entities with service discovery data
-func (c *collector) getProcessEntitiesFromServices(pids []int32, pidsToService map[int32]*model.Service) []*workloadmeta.Process {
-	entities := make([]*workloadmeta.Process, 0, len(pids))
+func (c *collector) getProcessEntitiesFromServices(newPids []int32, heartbeatPids []int32, pidsToService map[int32]*model.Service) []*workloadmeta.Process {
+	entities := make([]*workloadmeta.Process, 0, len(pidsToService))
 	now := c.clock.Now().UTC()
 
-	for _, pid := range pids {
+	// Process new PIDs - create complete entities
+	for _, pid := range newPids {
 		service := pidsToService[pid]
 		if service == nil {
 			c.handleServiceRetries(pid)
@@ -432,17 +436,59 @@ func (c *collector) getProcessEntitiesFromServices(pids []int32, pidsToService m
 		entities = append(entities, entity)
 	}
 
+	// Process heartbeat PIDs - only update entities that have existing Service data
+	for _, pid := range heartbeatPids {
+		service := pidsToService[pid]
+		if service == nil {
+			c.handleServiceRetries(pid)
+			continue
+		}
+
+		// Verify existing entity has Service data (should always be true for heartbeat PIDs)
+		existingProcess, err := c.store.GetProcess(pid)
+		if err != nil || existingProcess == nil || existingProcess.Service == nil {
+			log.Debugf("Heartbeat for pid %d but no existing service found, skipping", pid)
+			continue
+		}
+
+		c.pidHeartbeats[int32(service.PID)] = now
+
+		// For heartbeat updates, preserve static fields from existing service
+		// Since workloadmeta replaces entities from the same source instead of merging,
+		// we need to preserve static fields here
+		newService := convertModelServiceToService(service)
+
+		// Copy existing service and update only dynamic fields
+		preservedService := *existingProcess.Service
+		preservedService.TCPPorts = newService.TCPPorts
+		preservedService.UDPPorts = newService.UDPPorts
+		preservedService.LogFiles = newService.LogFiles
+
+		entity := &workloadmeta.Process{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindProcess,
+				ID:   strconv.Itoa(service.PID),
+			},
+			Pid:     int32(service.PID),
+			Service: &preservedService,
+			// Preserve language from existing process
+			Language: existingProcess.Language,
+		}
+
+		entities = append(entities, entity)
+	}
+
 	return entities
 }
 
 // updateServices retrieves service discovery data for alive processes and returns workloadmeta entities
 func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procutil.Process) ([]*workloadmeta.Process, map[int32]*model.Service) {
-	pidsToRequest, pidsToService := c.filterPidsToRequest(alivePids, procs)
-	if len(pidsToRequest) == 0 {
+	newPids, heartbeatPids, pidsToService := c.filterPidsToRequest(alivePids, procs)
+	if len(newPids) == 0 && len(heartbeatPids) == 0 {
 		return nil, nil
 	}
 
-	resp, err := c.getDiscoveryServices(pidsToRequest)
+	resp, err := c.getDiscoveryServices(newPids, heartbeatPids)
 	if err != nil {
 		if time.Since(c.startTime) < c.startupTimeout {
 			log.Warnf("service collector: system-probe not started yet: %v", err)
@@ -456,7 +502,7 @@ func (c *collector) updateServices(alivePids core.PidSet, procs map[int32]*procu
 		pidsToService[int32(service.PID)] = &resp.Services[i]
 	}
 
-	return c.getProcessEntitiesFromServices(pidsToRequest, pidsToService), pidsToService
+	return c.getProcessEntitiesFromServices(newPids, heartbeatPids, pidsToService), pidsToService
 }
 
 func (c *collector) updateServicesNoCache(alivePids core.PidSet, procs map[int32]*procutil.Process) []*workloadmeta.Process {

--- a/pkg/collector/corechecks/servicediscovery/core/params.go
+++ b/pkg/collector/corechecks/servicediscovery/core/params.go
@@ -22,7 +22,8 @@ const (
 // Params represents the parameters for service discovery requests.
 type Params struct {
 	HeartbeatTime time.Duration `json:"heartbeat_time"`
-	Pids          []int         `json:"pids,omitzero"`
+	NewPids       []int32       `json:"new_pids,omitempty"`       // PIDs never seen before, require full service info
+	HeartbeatPids []int32       `json:"heartbeat_pids,omitempty"` // PIDs needing heartbeat refresh, minimal updates
 }
 
 // DefaultParams returns a new Params instance with default values.

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -534,6 +534,39 @@ func (s *discovery) getServiceInfo(pid int32) (*core.ServiceInfo, error) {
 	}, nil
 }
 
+// getHeartbeatServiceInfo gets minimal service information for heartbeat processes.
+// This only collects dynamic fields (ports and log files) and skips expensive operations
+// like language detection, service name generation, and APM instrumentation detection.
+func (s *discovery) getHeartbeatServiceInfo(context parsingContext, pid int32) *model.Service {
+	if s.shouldIgnoreComm(pid) {
+		return nil
+	}
+
+	openFileInfo, err := getOpenFilesInfo(pid, context.readlinkBuffer)
+	if err != nil {
+		return nil
+	}
+	tcpPorts, udpPorts, err := s.getPorts(context, pid, openFileInfo.sockets)
+	if err != nil {
+		return nil
+	}
+
+	totalPorts := len(tcpPorts) + len(udpPorts)
+	if totalPorts == 0 {
+		return nil
+	}
+
+	logFiles := getLogFiles(pid, openFileInfo.logs)
+
+	// Return minimal service info with only dynamic fields
+	return &model.Service{
+		PID:      int(pid),
+		TCPPorts: tcpPorts,
+		UDPPorts: udpPorts,
+		LogFiles: logFiles,
+	}
+}
+
 // maxNumberOfPorts is the maximum number of listening ports which we report per
 // service.
 const maxNumberOfPorts = 50
@@ -703,10 +736,10 @@ func (s *discovery) getCheckServices(params core.Params) (*model.ServicesRespons
 	})
 }
 
-// getServices processes a list of PIDs and returns service information for each.
+// getServices processes categorized PID lists and returns service information for each.
 // This is used by the /services endpoint which accepts explicit PID lists and bypasses
 // the port retry logic used by the /check endpoint. The caller (the Core-Agent
-// process collector) will handle the retry..
+// process collector) will handle the retry.
 func (s *discovery) getServices(params core.Params) (*model.ServicesEndpointResponse, error) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
@@ -716,8 +749,18 @@ func (s *discovery) getServices(params core.Params) (*model.ServicesEndpointResp
 
 	context := newParsingContext()
 
-	for _, pid := range params.Pids {
-		service := s.getServiceWithoutRetry(context, int32(pid))
+	// Process new PIDs with full service info collection
+	for _, pid := range params.NewPids {
+		service := s.getServiceWithoutRetry(context, pid)
+		if service == nil {
+			continue
+		}
+		response.Services = append(response.Services, *service)
+	}
+
+	// Process heartbeat PIDs with minimal updates (only ports and log files)
+	for _, pid := range params.HeartbeatPids {
+		service := s.getHeartbeatServiceInfo(context, pid)
 		if service == nil {
 			continue
 		}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -170,16 +170,10 @@ func makeRequest[T any](t require.TestingT, url string, params *core.Params) *T 
 
 // getRunningPids wraps the process.Pids function, returning a slice of ints
 // that can be used as the pids query param.
-func getRunningPids(t require.TestingT) []int {
+func getRunningPids(t require.TestingT) []int32 {
 	pids, err := process.Pids()
 	require.NoError(t, err)
-
-	pidsInt := make([]int, len(pids))
-	for i, v := range pids {
-		pidsInt[i] = int(v)
-	}
-
-	return pidsInt
+	return pids
 }
 
 // getCheckWithParams call the /discovery/check endpoint with the given params.

--- a/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_services_test.go
@@ -48,7 +48,7 @@ import (
 func getServices(t require.TestingT, url string) *model.ServicesEndpointResponse {
 	location := url + "/" + string(config.DiscoveryModule) + pathServices
 	params := &core.Params{
-		Pids: getRunningPids(t),
+		NewPids: getRunningPids(t),
 	}
 
 	return makeRequest[model.ServicesEndpointResponse](t, location, params)


### PR DESCRIPTION

### What does this PR do?

This PR make the process collector, when service collection is enabled, able to request partial Service updates from system-probe on heartbeats. This is done by separating the `pids` parameter of the requests made to SP between new pids and "heartbeat pids". The SP `/discovery/services` path will now perform full collection of service info on the new pids, as before, and collect only the ports and log files on pids that need a heartbeat.

### Motivation

DSCVR-188
In short, with the removal of service info caching in system-probe, the existing code was re-computing every fields on heartbeats, including service names, language, etc... which are expensive operations and unneeded.

This PR prevents the expensive updates and should reduce the number of allocations made by service updates.

### Describe how you validated your changes

Change covered by unit tests.

### Additional Notes

