### PR TITLE
collect Argo Rollouts and Karpenter custom resources by default

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -32,6 +32,10 @@ const (
 	defaultExtraSyncTimeout = 60 * time.Second
 	defaultMaximumCRDs      = 100
 	datadogAPIGroup         = "datadoghq.com"
+	ArgoAPIGroup            = "argoproj.io"
+	KarpenterAPIGroup       = "karpenter.sh"
+	KarpenterAWSAPIGroup    = "karpenter.k8s.aws"
+	KarpenterAzureAPIGroup  = "karpenter.azure.com"
 )
 
 var (
@@ -417,8 +421,8 @@ func (cb *CollectorBundle) GetTerminatedResourceBundle() *TerminatedResourceBund
 
 // importBuiltinCollectors imports the builtin collectors into the bundle.
 func (cb *CollectorBundle) importBuiltinCollectors() {
-	// add datadog CR collectors
-	builtinCollectors := cb.getDatadogCustomResourceCollectors()
+	// add builtin CR collectors
+	builtinCollectors := cb.getBuiltinCustomResourceCollectors()
 
 	// add terminated pod collector
 	terminatedPodCollector := cb.getTerminatedPodCollector()
@@ -434,32 +438,75 @@ func (cb *CollectorBundle) importBuiltinCollectors() {
 		}
 
 		cb.activatedCollectors[collector.Metadata().FullName()] = struct{}{}
+		log.Debugf("import builtin collector: %s", collector.Metadata().FullName())
 		cb.collectors = append(cb.collectors, collector)
 	}
 }
 
-// getDatadogCustomResourceCollectors returns a list of collectors for the Datadog custom resources
-func (cb *CollectorBundle) getDatadogCustomResourceCollectors() []collectors.K8sCollector {
-	if !cb.check.orchestratorConfig.CollectDatadogCustomResources {
-		return []collectors.K8sCollector{}
-	}
+// builtinCRDConfig represents the configuration for a built-in custom resource definition.
+type builtinCRDConfig struct {
+	group   string
+	version string
+	kind    string
+	enabled bool
+}
 
+// newBuiltinCRDConfigs returns the configuration for all built-in CRDs.
+func newBuiltinCRDConfigs() []builtinCRDConfig {
+	isDatadogCRDEnabled := pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.datadog.enabled")
+	isThirdPartyCRDEnabled := pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.custom_resources.third_party.enabled")
+
+	return []builtinCRDConfig{
+		{
+			group:   datadogAPIGroup,
+			enabled: isDatadogCRDEnabled,
+		},
+		{
+			group:   ArgoAPIGroup,
+			version: "v1alpha1",
+			kind:    "rollouts",
+			enabled: isThirdPartyCRDEnabled,
+		},
+		{
+			group:   KarpenterAPIGroup,
+			version: "v1",
+			enabled: isThirdPartyCRDEnabled,
+		},
+		{
+			group:   KarpenterAWSAPIGroup,
+			version: "v1",
+			enabled: isThirdPartyCRDEnabled,
+		},
+		{
+			group:   KarpenterAzureAPIGroup,
+			enabled: isThirdPartyCRDEnabled,
+		},
+	}
+}
+
+// getBuiltinCustomResourceCollectors returns the list of builtin custom resource collectors.
+func (cb *CollectorBundle) getBuiltinCustomResourceCollectors() []collectors.K8sCollector {
 	// Check if the CRD collector is present, if not, return an empty list
 	// This is to ensure that we only collect CRs if the CRD collector is present
-	hasCRDCollector := false
-	for _, collector := range cb.collectors {
-		if collector.Metadata().Name == utilTypes.CrdName {
-			hasCRDCollector = true
-			break
-		}
-	}
-	if !hasCRDCollector {
+	if !cb.hasCRDCollector() {
 		return []collectors.K8sCollector{}
 	}
 
-	crs := cb.collectorDiscovery.List(datadogAPIGroup)
+	crCollectors := make([]collectors.K8sCollector, 0, 10)
+	for _, builtinCustomResource := range newBuiltinCRDConfigs() {
+		crCollectors = append(crCollectors, cb.collectorsForBuiltinCRD(builtinCustomResource)...)
+	}
+	return crCollectors
+}
 
-	crCollectors := make([]collectors.K8sCollector, 0, len(crs))
+// collectorsForBuiltinCRD returns the list of collectors for a built-in CRD.
+func (cb *CollectorBundle) collectorsForBuiltinCRD(builtinCustomResource builtinCRDConfig) []collectors.K8sCollector {
+	if !builtinCustomResource.enabled {
+		return nil
+	}
+
+	crCollectors := make([]collectors.K8sCollector, 0, 10)
+	crs := cb.collectorDiscovery.List(builtinCustomResource.group, builtinCustomResource.version, builtinCustomResource.kind)
 	for _, c := range crs {
 		collector, err := cb.collectorDiscovery.VerifyForCRDInventory(c.Name, c.Version)
 		if err != nil {
@@ -470,6 +517,16 @@ func (cb *CollectorBundle) getDatadogCustomResourceCollectors() []collectors.K8s
 		crCollectors = append(crCollectors, collector)
 	}
 	return crCollectors
+}
+
+// hasCRDCollector returns true if the CRD collector is present.
+func (cb *CollectorBundle) hasCRDCollector() bool {
+	for _, collector := range cb.collectors {
+		if collector.Metadata().Name == utilTypes.CrdName {
+			return true
+		}
+	}
+	return false
 }
 
 // getTerminatedPodCollector returns the terminated pod collector if the unassigned pod collector is present and the terminated pod collector is stable.

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -509,9 +509,9 @@ func (cb *CollectorBundle) collectorsForBuiltinCRD(builtinCustomResource builtin
 	crCollectors := make([]collectors.K8sCollector, 0, 10)
 	crs := cb.collectorDiscovery.List(builtinCustomResource.group, builtinCustomResource.version, builtinCustomResource.kind)
 	for _, c := range crs {
-		collector, err := cb.collectorDiscovery.VerifyForCRDInventory(c.Name, c.Version)
+		collector, err := cb.collectorDiscovery.VerifyForCRDInventory(c.Kind, c.GroupVersion)
 		if err != nil {
-			_ = cb.check.Warnf("Unsupported collector: %s/%s: %s", c.Version, c.Name, err)
+			_ = cb.check.Warnf("Unsupported collector: %s/%s: %s", c.GroupVersion, c.Kind, err)
 			continue
 		}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -479,6 +479,7 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		},
 		{
 			group:   KarpenterAzureAPIGroup,
+			version: "v1beta1",
 			enabled: isThirdPartyCRDEnabled,
 		},
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -31,12 +31,12 @@ func TestImportBuiltinCollectors(t *testing.T) {
 	collectorDiscovery.SetCache(
 		discovery.DiscoveryCache{
 			CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-				{Version: "v1", Name: "pods"}:                                      {},
-				{Version: "datadoghq.com/v1alpha1", Name: "datadogmetrics"}:        {},
-				{Version: "datadoghq.com/v1alpha1", Name: "datadogmonitors"}:       {},
-				{Version: "datadoghq.com/v1alpha1", Name: "datadogpodautoscalers"}: {},
-				{Version: "datadoghq.com/v1alpha2", Name: "datadogpodautoscalers"}: {},
-				{Version: "datadoghq.com/v2alpha1", Name: "datadogagents"}:         {},
+				{GroupVersion: "v1", Kind: "pods"}:                                      {},
+				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
+				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+				{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
+				{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
+				{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
 			},
 		})
 
@@ -93,11 +93,11 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 			hasCrdCollectors: true,
 			supportedResources: discovery.DiscoveryCache{
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmetrics"}:        {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmonitors"}:       {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v1alpha2", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v2alpha1", Name: "datadogagents"}:         {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
 				},
 			},
 			expected: []string{
@@ -123,8 +123,8 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 			hasCrdCollectors: true,
 			supportedResources: discovery.DiscoveryCache{
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmetrics"}:  {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmonitors"}: {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:  {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}: {},
 				},
 			},
 			expected: []string{
@@ -138,11 +138,11 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 			hasCrdCollectors: true,
 			supportedResources: discovery.DiscoveryCache{
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmetrics"}:        {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmonitors"}:       {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v1alpha2", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v2alpha1", Name: "datadogagents"}:         {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
 				},
 			},
 			expected: []string{},
@@ -153,11 +153,11 @@ func TestGetDatadogCustomResourceCollectors(t *testing.T) {
 			hasCrdCollectors: false,
 			supportedResources: discovery.DiscoveryCache{
 				CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmetrics"}:        {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogmonitors"}:       {},
-					{Version: "datadoghq.com/v1alpha1", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v1alpha2", Name: "datadogpodautoscalers"}: {},
-					{Version: "datadoghq.com/v2alpha1", Name: "datadogagents"}:         {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmetrics"}:        {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogmonitors"}:       {},
+					{GroupVersion: "datadoghq.com/v1alpha1", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v1alpha2", Kind: "datadogpodautoscalers"}: {},
+					{GroupVersion: "datadoghq.com/v2alpha1", Kind: "datadogagents"}:         {},
 				},
 			},
 			expected: []string{},
@@ -194,7 +194,7 @@ func TestGetTerminatedPodCollector(t *testing.T) {
 	collectorDiscovery.SetCache(
 		discovery.DiscoveryCache{
 			CollectorForVersion: map[discovery.CollectorVersion]struct{}{
-				{Version: "v1", Name: "pods"}: {},
+				{GroupVersion: "v1", Kind: "pods"}: {},
 			},
 		})
 

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -29,10 +29,10 @@ type DiscoveryCache struct {
 	CollectorForVersion map[CollectorVersion]struct{}
 }
 
-// CollectorVersion represents a version of a collector with its name.
+// CollectorVersion represents a group version of a collector with its kind.
 type CollectorVersion struct {
-	Version string
-	Name    string
+	GroupVersion string
+	Kind         string
 }
 
 // DiscoveryCollector stores all the discovered resources and their versions.
@@ -67,8 +67,8 @@ func (d *DiscoveryCollector) fillCache() error {
 		for _, list := range d.cache.Resources {
 			for _, resource := range list.APIResources {
 				cv := CollectorVersion{
-					Version: list.GroupVersion,
-					Name:    resource.Name,
+					GroupVersion: list.GroupVersion,
+					Kind:         resource.Name,
 				}
 				d.cache.CollectorForVersion[cv] = struct{}{}
 			}
@@ -136,8 +136,8 @@ func (d *DiscoveryCollector) DiscoverRegularResource(resource string, groupVersi
 
 func (d *DiscoveryCollector) isSupportCollector(collector collectors.K8sCollector) (collectors.K8sCollector, error) {
 	if _, ok := d.cache.CollectorForVersion[CollectorVersion{
-		Version: collector.Metadata().Version,
-		Name:    collector.Metadata().Name,
+		GroupVersion: collector.Metadata().Version,
+		Kind:         collector.Metadata().Name,
 	}]; ok {
 		return collector, nil
 	}
@@ -185,17 +185,17 @@ func (d *DiscoveryCollector) List(group, version, kind string) []CollectorVersio
 
 	for cv := range d.cache.CollectorForVersion {
 		// Skip "/status" entries
-		if strings.HasSuffix(cv.Name, "/status") {
+		if strings.HasSuffix(cv.Kind, "/status") {
 			continue
 		}
 
 		// Match version prefix
-		if !strings.HasPrefix(cv.Version, groupVersion) {
+		if !strings.HasPrefix(cv.GroupVersion, groupVersion) {
 			continue
 		}
 
 		// If kind is specified, only include matching name
-		if kind != "" && cv.Name != kind {
+		if kind != "" && cv.Kind != kind {
 			continue
 		}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -28,9 +28,9 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "apps/v1", Name: "deployments"}:  {},
-							{Version: "apps/v1", Name: "statefulsets"}: {},
-							{Version: "v1", Name: "pods"}:              {},
+							{GroupVersion: "apps/v1", Kind: "deployments"}:  {},
+							{GroupVersion: "apps/v1", Kind: "statefulsets"}: {},
+							{GroupVersion: "v1", Kind: "pods"}:              {},
 						},
 					},
 				}
@@ -39,7 +39,7 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			version: "v1",
 			kind:    "deployments",
 			expected: []CollectorVersion{
-				{Version: "apps/v1", Name: "deployments"},
+				{GroupVersion: "apps/v1", Kind: "deployments"},
 			},
 		},
 		{
@@ -48,9 +48,9 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "apps/v1", Name: "deployments"}:  {},
-							{Version: "apps/v1", Name: "statefulsets"}: {},
-							{Version: "v1", Name: "pods"}:              {},
+							{GroupVersion: "apps/v1", Kind: "deployments"}:  {},
+							{GroupVersion: "apps/v1", Kind: "statefulsets"}: {},
+							{GroupVersion: "v1", Kind: "pods"}:              {},
 						},
 					},
 				}
@@ -59,8 +59,8 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			version: "v1",
 			kind:    "",
 			expected: []CollectorVersion{
-				{Version: "apps/v1", Name: "deployments"},
-				{Version: "apps/v1", Name: "statefulsets"},
+				{GroupVersion: "apps/v1", Kind: "deployments"},
+				{GroupVersion: "apps/v1", Kind: "statefulsets"},
 			},
 		},
 		{
@@ -69,9 +69,9 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "v1", Name: "pods"}:             {},
-							{Version: "v1", Name: "nodes"}:            {},
-							{Version: "apps/v1", Name: "deployments"}: {},
+							{GroupVersion: "v1", Kind: "pods"}:             {},
+							{GroupVersion: "v1", Kind: "nodes"}:            {},
+							{GroupVersion: "apps/v1", Kind: "deployments"}: {},
 						},
 					},
 				}
@@ -80,8 +80,8 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			version: "v1",
 			kind:    "",
 			expected: []CollectorVersion{
-				{Version: "v1", Name: "pods"},
-				{Version: "v1", Name: "nodes"},
+				{GroupVersion: "v1", Kind: "pods"},
+				{GroupVersion: "v1", Kind: "nodes"},
 			},
 		},
 		{
@@ -90,11 +90,11 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "v1", Name: "pods"}:             {},
-							{Version: "v1", Name: "pods/status"}:      {},
-							{Version: "v1", Name: "nodes"}:            {},
-							{Version: "v1", Name: "nodes/status"}:     {},
-							{Version: "apps/v1", Name: "deployments"}: {},
+							{GroupVersion: "v1", Kind: "pods"}:             {},
+							{GroupVersion: "v1", Kind: "pods/status"}:      {},
+							{GroupVersion: "v1", Kind: "nodes"}:            {},
+							{GroupVersion: "v1", Kind: "nodes/status"}:     {},
+							{GroupVersion: "apps/v1", Kind: "deployments"}: {},
 						},
 					},
 				}
@@ -103,8 +103,8 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			version: "v1",
 			kind:    "",
 			expected: []CollectorVersion{
-				{Version: "v1", Name: "pods"},
-				{Version: "v1", Name: "nodes"},
+				{GroupVersion: "v1", Kind: "pods"},
+				{GroupVersion: "v1", Kind: "nodes"},
 			},
 		},
 		{
@@ -113,10 +113,10 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "apps/v1", Name: "deployments"}:            {},
-							{Version: "apps/v1beta1", Name: "deployments"}:       {},
-							{Version: "extensions/v1beta1", Name: "deployments"}: {},
-							{Version: "v1", Name: "pods"}:                        {},
+							{GroupVersion: "apps/v1", Kind: "deployments"}:            {},
+							{GroupVersion: "apps/v1beta1", Kind: "deployments"}:       {},
+							{GroupVersion: "extensions/v1beta1", Kind: "deployments"}: {},
+							{GroupVersion: "v1", Kind: "pods"}:                        {},
 						},
 					},
 				}
@@ -125,8 +125,8 @@ func TestDiscoveryCollector_List(t *testing.T) {
 			version: "",
 			kind:    "",
 			expected: []CollectorVersion{
-				{Version: "apps/v1", Name: "deployments"},
-				{Version: "apps/v1beta1", Name: "deployments"},
+				{GroupVersion: "apps/v1", Kind: "deployments"},
+				{GroupVersion: "apps/v1beta1", Kind: "deployments"},
 			},
 		},
 		{
@@ -135,7 +135,7 @@ func TestDiscoveryCollector_List(t *testing.T) {
 				return &DiscoveryCollector{
 					cache: DiscoveryCache{
 						CollectorForVersion: map[CollectorVersion]struct{}{
-							{Version: "v1", Name: "pods"}: {},
+							{GroupVersion: "v1", Kind: "pods"}: {},
 						},
 					},
 				}

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd_test.go
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator && test
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoveryCollector_List(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *DiscoveryCollector
+		group    string
+		version  string
+		kind     string
+		expected []CollectorVersion
+	}{
+		{
+			name: "exact match with group, version, and kind",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "apps/v1", Name: "deployments"}:  {},
+							{Version: "apps/v1", Name: "statefulsets"}: {},
+							{Version: "v1", Name: "pods"}:              {},
+						},
+					},
+				}
+			},
+			group:   "apps",
+			version: "v1",
+			kind:    "deployments",
+			expected: []CollectorVersion{
+				{Version: "apps/v1", Name: "deployments"},
+			},
+		},
+		{
+			name: "match by group and version only",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "apps/v1", Name: "deployments"}:  {},
+							{Version: "apps/v1", Name: "statefulsets"}: {},
+							{Version: "v1", Name: "pods"}:              {},
+						},
+					},
+				}
+			},
+			group:   "apps",
+			version: "v1",
+			kind:    "",
+			expected: []CollectorVersion{
+				{Version: "apps/v1", Name: "deployments"},
+				{Version: "apps/v1", Name: "statefulsets"},
+			},
+		},
+		{
+			name: "match by core group (empty string) and version",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "v1", Name: "pods"}:             {},
+							{Version: "v1", Name: "nodes"}:            {},
+							{Version: "apps/v1", Name: "deployments"}: {},
+						},
+					},
+				}
+			},
+			group:   "",
+			version: "v1",
+			kind:    "",
+			expected: []CollectorVersion{
+				{Version: "v1", Name: "pods"},
+				{Version: "v1", Name: "nodes"},
+			},
+		},
+		{
+			name: "exclude status resources",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "v1", Name: "pods"}:             {},
+							{Version: "v1", Name: "pods/status"}:      {},
+							{Version: "v1", Name: "nodes"}:            {},
+							{Version: "v1", Name: "nodes/status"}:     {},
+							{Version: "apps/v1", Name: "deployments"}: {},
+						},
+					},
+				}
+			},
+			group:   "",
+			version: "v1",
+			kind:    "",
+			expected: []CollectorVersion{
+				{Version: "v1", Name: "pods"},
+				{Version: "v1", Name: "nodes"},
+			},
+		},
+		{
+			name: "match by group only",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "apps/v1", Name: "deployments"}:            {},
+							{Version: "apps/v1beta1", Name: "deployments"}:       {},
+							{Version: "extensions/v1beta1", Name: "deployments"}: {},
+							{Version: "v1", Name: "pods"}:                        {},
+						},
+					},
+				}
+			},
+			group:   "apps",
+			version: "",
+			kind:    "",
+			expected: []CollectorVersion{
+				{Version: "apps/v1", Name: "deployments"},
+				{Version: "apps/v1beta1", Name: "deployments"},
+			},
+		},
+		{
+			name: "no matches",
+			setup: func() *DiscoveryCollector {
+				return &DiscoveryCollector{
+					cache: DiscoveryCache{
+						CollectorForVersion: map[CollectorVersion]struct{}{
+							{Version: "v1", Name: "pods"}: {},
+						},
+					},
+				}
+			},
+			group:    "nonexistent",
+			version:  "v1",
+			kind:     "nonexistent",
+			expected: []CollectorVersion{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dc := tt.setup()
+			result := dc.List(tt.group, tt.version, tt.kind)
+			assert.ElementsMatch(t, tt.expected, result, "List() returned unexpected result")
+		})
+	}
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -927,6 +927,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_resources.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.datadog.enabled", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.custom_resources.third_party.enabled", false)
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", true)

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -47,7 +47,6 @@ type OrchestratorConfig struct {
 	IsManifestCollectionEnabled    bool
 	BufferedManifestEnabled        bool
 	ManifestBufferFlushInterval    time.Duration
-	CollectDatadogCustomResources  bool
 }
 
 // NewDefaultOrchestratorConfig returns an NewDefaultOrchestratorConfig using a configuration file. It can be nil
@@ -125,7 +124,6 @@ func (oc *OrchestratorConfig) Load() error {
 	oc.IsManifestCollectionEnabled = pkgconfigsetup.Datadog().GetBool(OrchestratorNSKey("manifest_collection.enabled"))
 	oc.BufferedManifestEnabled = pkgconfigsetup.Datadog().GetBool(OrchestratorNSKey("manifest_collection.buffer_manifest"))
 	oc.ManifestBufferFlushInterval = pkgconfigsetup.Datadog().GetDuration(OrchestratorNSKey("manifest_collection.buffer_flush_interval"))
-	oc.CollectDatadogCustomResources = pkgconfigsetup.Datadog().GetBool(OrchestratorNSKey("custom_resources.datadog.enabled"))
 	return nil
 }
 

--- a/releasenotes-dca/notes/collect-third-party-custom-resources-by-default-dee5675d8c7b1f01.yaml
+++ b/releasenotes-dca/notes/collect-third-party-custom-resources-by-default-dee5675d8c7b1f01.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Collect Argo Rollouts and Karpenter custom resources by default.

--- a/releasenotes-dca/notes/collect-third-party-custom-resources-by-default-dee5675d8c7b1f01.yaml
+++ b/releasenotes-dca/notes/collect-third-party-custom-resources-by-default-dee5675d8c7b1f01.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Collect Argo Rollouts and Karpenter custom resources by default.
+    Add the ability to collect Argo Rollouts and Karpenter custom resources by default.


### PR DESCRIPTION
### What does this PR do?
Added automatic custom resource collection for:
- Argo Rollouts (argoproj.io/v1alpha1/rollouts)
- Karpenter :
   -  karpenter.sh/v1
    - karpenter.k8s.aws/v1
    - karpenter.azure.com/*

This feature is `disabled` by default in this release.

### QA

Add environment var to cluster agent
```
clusterAgent:
  env:
    - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_DATADOG_ENABLED
      value: true
    - name: DD_ORCHESTRATOR_EXPLORER_CUSTOM_RESOURCES_THIRD_PARTY_ENABLED
      value: true
```


Update cluster role to have

```
- apiGroups:
  - datadoghq.com
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.sh
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.k8s.aws
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - karpenter.azure.com
  resources:
  - '*'
  verbs:
  - list
  - watch
- apiGroups:
  - argoproj.io
  resources:
  - '*'
  verbs:
  - list
  - watch

```


Check cluster agent logs, you should be able to see
```
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: argoproj.io/v1alpha1/rollouts
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: karpenter.sh/v1/nodeclaims
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: karpenter.sh/v1/nodepools
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: karpenter.k8s.aws/v1/ec2nodeclasses
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: karpenter.azure.com/v1alpha2/aksnodeclasses
2025-09-01 14:38:55 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:441 in importBuiltinCollectors) | import builtin collector: karpenter.azure.com/v1beta1/aksnodeclasses

.....

2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector argoproj.io/v1alpha1/rollouts run stats: listed=1 processed=0 messages=0 duration=131.166µs
2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector karpenter.sh/v1/nodeclaims run stats: listed=0 processed=0 messages=0 duration=8.417µs
2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector karpenter.sh/v1/nodepools run stats: listed=1 processed=0 messages=0 duration=117.708µs
2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector karpenter.k8s.aws/v1/ec2nodeclasses run stats: listed=1 processed=1 messages=1 duration=585.792µs
2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector karpenter.azure.com/v1alpha2/aksnodeclasses run stats: listed=0 processed=0 messages=0 duration=11.375µs
2025-09-01 15:21:06 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:382 in Run) | Collector karpenter.azure.com/v1beta1/aksnodeclasses run stats: listed=0 processed=0 messages=0 duration=7.083µs

```
