### PR TITLE
Add more discovery paths to E2E test trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -765,8 +765,11 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
+        - cmd/agent/dist/conf.d/discovery.d/*
         - cmd/agent/dist/conf.d/service_discovery.d/*
+        - comp/core/autodiscovery/providers/process_log.go
         - test/new-e2e/tests/discovery/**/*
+        - pkg/collector/corechecks/discovery/**/*
         - pkg/collector/corechecks/servicediscovery/**/*
         - pkg/discovery/**/*
       compare_to: $COMPARE_TO_BRANCH


### PR DESCRIPTION
Add some paths used for logs discovery to the CI trigger for the E2E
discovery test which tests the feature.

https://datadoghq.atlassian.net/browse/DSCVR-187
