### PR TITLE
[SBOM] fs only `sbomgen`

### DIFF
--- a/cmd/sbomgen/main.go
+++ b/cmd/sbomgen/main.go
@@ -56,14 +56,16 @@ func main() {
 		return nil
 	}
 
+	var removeLayers bool
 	var fsCmd = &cobra.Command{
 		Use:  "fs",
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			path := args[0]
-			return runScanFS(path, analyzers, fast)
+			return runScanFS(path, analyzers, fast, removeLayers)
 		},
 	}
+	fsCmd.Flags().BoolVar(&removeLayers, "remove-layers", false, "remove layers")
 	rootCmd.AddCommand(fsCmd)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/sbomgen/scanners.go
+++ b/cmd/sbomgen/scanners.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && trivy && containerd && docker && crio
+//go:build linux && trivy
 
 package main
 
@@ -12,13 +12,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
-	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
-	"github.com/DataDog/datadog-agent/pkg/util/crio"
-	"github.com/DataDog/datadog-agent/pkg/util/docker"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
-	"github.com/containerd/containerd"
 )
 
 func runScanFS(path string, analyzers []string, fast bool) error {
@@ -29,95 +24,6 @@ func runScanFS(path string, analyzers []string, fast bool) error {
 		Analyzers: analyzers,
 		Fast:      fast,
 	}, false)
-	if err != nil {
-		return err
-	}
-
-	return outputReport(report)
-}
-
-func runScanDocker(imageMeta *workloadmeta.ContainerImageMetadata, analyzers []string, fast bool) error {
-	collector := trivy.NewCollectorForCLI()
-
-	cl, err := docker.GetDockerUtil()
-	if err != nil {
-		return fmt.Errorf("error creating docker client: %w", err)
-	}
-	dockerClient := cl.RawClient()
-
-	ctx := context.Background()
-	report, err := collector.ScanDockerImage(
-		ctx,
-		imageMeta,
-		dockerClient,
-		sbom.ScanOptions{
-			Analyzers: analyzers,
-			Fast:      fast,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	return outputReport(report)
-}
-
-func runScanContainerd(imageMeta *workloadmeta.ContainerImageMetadata, analyzers []string, fast bool, strategy string) error {
-	collector := trivy.NewCollectorForCLI()
-
-	containerdClient, err := containerdutil.NewContainerdUtil()
-	if err != nil {
-		return fmt.Errorf("error creating containerd client: %w", err)
-	}
-
-	image, err := containerdClient.Image(imageMeta.Namespace, imageMeta.Name)
-	if err != nil {
-		return fmt.Errorf("error getting image %s/%s: %w", imageMeta.Namespace, imageMeta.Name, err)
-	}
-
-	var report sbom.Report
-	var scanner func(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, img containerd.Image, client containerdutil.ContainerdItf, scanOptions sbom.ScanOptions) (sbom.Report, error)
-	switch strategy {
-	case "mount":
-		scanner = collector.ScanContainerdImageFromFilesystem
-	case "overlayfs":
-		scanner = collector.ScanContainerdImageFromSnapshotter
-	case "image":
-		scanner = collector.ScanContainerdImage
-	default:
-		return fmt.Errorf("unknown strategy: %s", strategy)
-	}
-
-	ctx := context.Background()
-	report, err = scanner(ctx, imageMeta, image, containerdClient, sbom.ScanOptions{
-		Analyzers: analyzers,
-		Fast:      fast,
-	})
-	if err != nil {
-		return err
-	}
-
-	return outputReport(report)
-}
-
-func runScanCrio(imageMeta *workloadmeta.ContainerImageMetadata, analyzers []string, fast bool) error {
-	collector := trivy.NewCollectorForCLI()
-
-	crioClient, err := crio.NewCRIOClient()
-	if err != nil {
-		return fmt.Errorf("error creating CRI-O client: %w", err)
-	}
-
-	ctx := context.Background()
-	report, err := collector.ScanCRIOImageFromOverlayFS(
-		ctx,
-		imageMeta,
-		crioClient,
-		sbom.ScanOptions{
-			Analyzers: analyzers,
-			Fast:      fast,
-		},
-	)
 	if err != nil {
 		return err
 	}

--- a/cmd/sbomgen/scanners.go
+++ b/cmd/sbomgen/scanners.go
@@ -16,14 +16,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 )
 
-func runScanFS(path string, analyzers []string, fast bool) error {
+func runScanFS(path string, analyzers []string, fast bool, removeLayers bool) error {
 	collector := trivy.NewCollectorForCLI()
 
 	ctx := context.Background()
 	report, err := collector.ScanFilesystem(ctx, path, sbom.ScanOptions{
 		Analyzers: analyzers,
 		Fast:      fast,
-	}, false)
+	}, removeLayers)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR simplifies sbomgen to only support FS scans, enough to support the scanning done by system-probe which is going to allow us to migrate the SBOM scanning done there first.

Note: the sbomgen binary is still built with containers related build tag because of the go deps diff CI job that is failing if I remove them in one go. This will be done in a follow up PR.

### Motivation

### Describe how you validated your changes

### Additional Notes
