### PR TITLE
[ACIX-982] Ensure generated tokens are valid

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -792,7 +792,14 @@ def generate_local_github_token(ctx):
     try:
         token = ctx.run('ddtool auth github token', hide=True).stdout.strip()
 
+        assert (
+            token.startswith('gh') and ' ' not in token
+        ), "`ddtool auth github token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
+
         return token
+    except AssertionError:
+        # No retry on asserts
+        raise
     except Exception:
         # Try to login and then get a token
         ctx.run('ddtool auth github login')

--- a/tasks/libs/common/auth.py
+++ b/tasks/libs/common/auth.py
@@ -15,4 +15,13 @@ def datadog_infra_token(ctx, audience, datacenter="us1.ddbuild.io"):
         .removeprefix('Authorization: ')
     )
 
+    assert (
+        token.startswith('Bearer ') and token.count(' ') == 1
+    ), (
+        "`authanywhere` returned an invalid token."
+        if running_in_ci()
+        else
+        "`ddtool auth token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
+    )
+
     return token

--- a/tasks/libs/common/auth.py
+++ b/tasks/libs/common/auth.py
@@ -15,13 +15,10 @@ def datadog_infra_token(ctx, audience, datacenter="us1.ddbuild.io"):
         .removeprefix('Authorization: ')
     )
 
-    assert (
-        token.startswith('Bearer ') and token.count(' ') == 1
-    ), (
+    assert token.startswith('Bearer ') and token.count(' ') == 1, (
         "`authanywhere` returned an invalid token."
         if running_in_ci()
-        else
-        "`ddtool auth token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
+        else "`ddtool auth token` returned an invalid token, it might be due to ddtool outdated. Please run `brew update && brew upgrade ddtool`."
     )
 
     return token


### PR DESCRIPTION
### What does this PR do?

I noticed that:
```sh
ddtool auth <invalid-command>
```
doesn't exit with an error code. If `ddtool` is out of date, we don't catch errors.

Added checks to verify that generated tokens are valid.

### Motivation

### Describe how you validated your changes

### Additional Notes
