### PR TITLE
[CSPM] add real config option to enable compliance system-probe module

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -24,6 +24,7 @@ const (
 	netNS                        = "network_config"
 	smNS                         = "service_monitoring_config"
 	evNS                         = "event_monitoring_config"
+	compNS                       = "compliance_config"
 	ccmNS                        = "ccm_network_config"
 	diNS                         = "dynamic_instrumentation"
 	wcdNS                        = "windows_crash_detection"
@@ -415,6 +416,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 
 	// process event monitoring data limits for network tracer
 	eventMonitorBindEnv(cfg, join(evNS, "network_process", "max_processes_tracked"))
+
+	cfg.BindEnvAndSetDefault(join(compNS, "enabled"), false)
 
 	// enable/disable use of root net namespace
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_root_netns"), true)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -144,7 +144,9 @@ func load() (*types.Config, error) {
 		diEnabled {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
-	if cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")) {
+	complianceEnabled := cfg.GetBool(compNS("enabled")) ||
+		(cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")))
+	if complianceEnabled {
 		c.EnabledModules[ComplianceModule] = struct{}{}
 	}
 	if cfg.GetBool(spNS("process_config.enabled")) {

--- a/pkg/system-probe/config/ns.go
+++ b/pkg/system-probe/config/ns.go
@@ -47,6 +47,11 @@ func evNS(k ...string) string {
 	return NSkey("event_monitoring_config", k...)
 }
 
+// compNS adds `compliance_config` namespace to configuration key
+func compNS(k ...string) string {
+	return NSkey("compliance_config", k...)
+}
+
 // NSkey returns a full key path in the config file by joining the given namespace and the rest of the path fragments
 func NSkey(ns string, pieces ...string) string {
 	return strings.Join(append([]string{ns}, pieces...), ".")


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `compliance_config.enabled` to enable the compliance system-probe module. This is in replacement to
the currently used `runtime_security_config.compliance_module.enabled` and in preparation to being able to use the compliance module without CWS (runtime security).

This module is only used internally for now, so the transition should be easy, and we will be able to remove the old config flag in 1 or 2 versions.

### Motivation

### Describe how you validated your changes

### Additional Notes
