### PR TITLE
chore(fleet): Temporarily pin Ansible collection version

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -57,6 +57,7 @@ var (
 )
 
 const latestPython2AnsibleVersion = "5.10.0"
+const latestAnsibleVersionWithInstallerPackage = "6.1.1"
 
 func shouldSkipFlavor(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool {
 	for _, f := range flavors {
@@ -249,7 +250,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 				(s.os.Flavor == e2eos.CentOS && s.os.Version == e2eos.CentOS7.Version) {
 				_, err = s.Env().RemoteHost.Execute(fmt.Sprintf("%sansible-galaxy collection install -vvv datadog.dd:==%s", ansiblePrefix, latestPython2AnsibleVersion))
 			} else {
-				_, err = s.Env().RemoteHost.Execute(fmt.Sprintf("%sansible-galaxy collection install -vvv datadog.dd", ansiblePrefix))
+				_, err = s.Env().RemoteHost.Execute(fmt.Sprintf("%sansible-galaxy collection install -vvv datadog.dd:==%s", ansiblePrefix, latestAnsibleVersionWithInstallerPackage))
 			}
 			if err == nil {
 				break


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/ansible-datadog/pull/665 brings some changes breaking our E2E tests, so to ensure a smooth transition without CI incidents this PR temporarily pins the Ansible collection used in the Fleet Automation E2E tests; giving us control over when to use the breaking Ansible version

### Motivation
No broken CI

### Describe how you validated your changes
CI only is enough

### Additional Notes
