### PR TITLE
fakeintake client parse host-tags payloads

### DIFF
--- a/test/fakeintake/aggregator/hostAggregator.go
+++ b/test/fakeintake/aggregator/hostAggregator.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package aggregator
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/api"
+)
+
+// Host struct contains agents host-tags payload and attributes to fit Aggregator implementation
+//
+// Use a pointer to assign `HostTags` inner struct.
+// When we ParseHostPayload we receive variaous payload types.
+// We only want to keep those with host-tags
+// Using a pointer allows us to check if the pointer has been allocated
+// and therefore found the right payload
+type Host struct {
+	HostTags *struct {
+		System []string `json:"system"`
+	} `json:"host-tags"`
+
+	InternalHostname string `json:"internalHostname"`
+	collectedTime    time.Time
+}
+
+// GetCollectedTime return the time the payload was collected
+func (host *Host) GetCollectedTime() time.Time {
+	return host.collectedTime
+}
+
+// GetTags returns the tags collected by the payload
+// currently none
+func (host *Host) GetTags() []string {
+	return nil
+}
+
+// name return the payload name
+func (host *Host) name() string {
+	return host.InternalHostname
+}
+
+// ParseHostPayload parses the generic payload and returns a typed struct with hostImpl data
+func ParseHostPayload(payload api.Payload) ([]*Host, error) {
+	if len(payload.Data) == 0 {
+		return nil, nil
+	}
+
+	inflated, err := inflate(payload.Data, payload.Encoding)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inflate host Payload: %w", err)
+	}
+
+	var data = &Host{}
+
+	if err := json.Unmarshal(inflated, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshall payload: %w", err)
+	}
+
+	// the current route returns different payload types,
+	// we only want to keep the matching payloads with host information
+	// return an empty list with no error to skip this non-matching payload
+	if data.HostTags == nil {
+		return []*Host{}, nil
+	}
+
+	// set hostname and collected time
+	data.collectedTime = payload.Timestamp
+
+	return []*Host{data}, nil
+}
+
+// HostAggregator structure
+type HostAggregator struct {
+	Aggregator[*Host]
+}
+
+// NewHostAggregator returns a new Host aggregator
+func NewHostAggregator() HostAggregator {
+	return HostAggregator{
+		Aggregator: newAggregator(ParseHostPayload),
+	}
+}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -145,6 +145,7 @@ type Client struct {
 	ndmflowAggregator              aggregator.NDMFlowAggregator
 	netpathAggregator              aggregator.NetpathAggregator
 	serviceDiscoveryAggregator     aggregator.ServiceDiscoveryAggregator
+	hostAggregator                 aggregator.HostAggregator
 }
 
 // NewClient creates a new fake intake client
@@ -176,6 +177,7 @@ func NewClient(fakeIntakeURL string, opts ...Option) *Client {
 		ndmflowAggregator:              aggregator.NewNDMFlowAggregator(),
 		netpathAggregator:              aggregator.NewNetpathAggregator(),
 		serviceDiscoveryAggregator:     aggregator.NewServiceDiscoveryAggregator(),
+		hostAggregator:                 aggregator.NewHostAggregator(),
 	}
 	for _, opt := range opts {
 		opt(client)
@@ -332,6 +334,15 @@ func (c *Client) getNetpathEvents() error {
 		return err
 	}
 	return c.netpathAggregator.UnmarshallPayloads(payloads)
+}
+
+func (c *Client) getHostInfos() error {
+	payloads, err := c.getFakePayloads(intakeEndpoint)
+	if err != nil {
+		return err
+	}
+
+	return c.hostAggregator.UnmarshallPayloads(payloads)
 }
 
 // FilterMetrics fetches fakeintake on `/api/v2/series` endpoint and returns
@@ -1063,6 +1074,26 @@ func (c *Client) GetLatestNetpathEvents() ([]*aggregator.Netpath, error) {
 		}
 	}
 	return netpaths, nil
+}
+
+// GetLatestHostInfos returns the latest host information received by the fake intake
+func (c *Client) GetLatestHostInfos() ([]*aggregator.Host, error) {
+	err := c.getHostInfos()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var hostInfos []*aggregator.Host
+	for _, name := range c.hostAggregator.GetNames() {
+		payloads := c.hostAggregator.GetPayloadsByName(name)
+
+		if len(payloads) > 0 {
+			hostInfos = append(hostInfos, payloads...)
+		}
+	}
+
+	return hostInfos, nil
 }
 
 // filterPayload returns payloads matching any [MatchOpt](#MatchOpt) options

--- a/test/fakeintake/cmd/client/cmd/get.go
+++ b/test/fakeintake/cmd/client/cmd/get.go
@@ -33,6 +33,7 @@ func NewGetCommand(cl **client.Client) (cmd *cobra.Command) {
 		NewGetProcessesCommand(cl),
 		NewGetSBOMCommand(cl),
 		NewGetTracesCommand(cl),
+		NewGetHostInfosCommand(cl),
 	)
 
 	return cmd

--- a/test/fakeintake/cmd/client/cmd/gethostinfos.go
+++ b/test/fakeintake/cmd/client/cmd/gethostinfos.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/client"
+)
+
+// NewGetHostInfosCommand adds a new command to get host infos
+func NewGetHostInfosCommand(cl **client.Client) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:   "host-infos",
+		Short: "Get Host infos",
+		RunE: func(*cobra.Command, []string) error {
+			hostInfos, err := (*cl).GetLatestHostInfos()
+			if err != nil {
+				return err
+			}
+
+			output, err := json.MarshalIndent(hostInfos, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(output))
+
+			return nil
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
### What does this PR do?

Add necessary code in the `fakeintake` library to parse and deserialize the host-impl tags.

This requires some filtering, the route to read the tags contains other payloads that could match while calling `Unmarshall`.

The field `meta` is located in the payload we try to extract, but it's also located in some other struct that we don't want.

Use an inner filed allocated with a pointer to check for its presence and therefore validate if we are looking at the right payload.

Add necessary code to query the host-implementation tags from the command line.

Once we have a match return all payloads.

### Motivation

This allows us later to add some end2end tests for host-tags

### Describe how you validated your changes

1. deploy a test stack using `pulumi`
2. use the `fakeintakectl` to query the host tags
3. see the host-tags in the output

command:
```
./test/fakeintake/build/fakeintakectl --url "http://w.x.y.z:80" get host-infos
```

output:
```
[
  {
    "host-tags": {
      "system": [
        "arch:amd64",
        "cluster_name:gcp-gcp-alexandre-lavigne-gke-deb76db",
        "kube_cluster_name:gcp-gcp-alexandre-lavigne-gke-deb76db",
        "kube_node:gke-gcp-gcp-alexandre-la-default-pool-7a56dc29-8ggv",
        "orch_cluster_id:f340972a-1311-47b3-a6af-c6f83a7ece1c",
        "os:linux"
      ]
    },
    "internalHostname": "gke-gcp-gcp-alexandre-la-default-pool-7a56dc29-8ggv.c.datadog-agent-sandbox.internal"
  }
]
```

### Additional Notes
