### PR TITLE
Ignore connections metrics in Linux network e2e test

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/checks/network/network_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/checks/network/network_nix_test.go
@@ -35,6 +35,12 @@ func TestLinuxNetworkSuite(t *testing.T) {
 				"system.net.tcp.send_q.avg",
 				"system.net.tcp.send_q.median",
 				"system.net.tcp.send_q.max",
+				"system.net.tcp.connections",
+				"system.net.tcp.current_established",
+				"system.net.tcp4.connections",
+				"system.net.tcp4.current_established",
+				"system.net.tcp6.connections",
+				"system.net.tcp6.current_established",
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Ignore connections metrics in Linux network e2e test.

### Motivation
I've had a few failures on branches for those metrics, comparing them to a previous run is flaky by definition (they are not constant), so we should just ignore them.

### Describe how you validated your changes

### Additional Notes
