### PR TITLE
fix(installer): support registry override starting with http(s)://

### DIFF
--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -219,6 +219,7 @@ func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
 		if !strings.HasSuffix(registryOverride, "/") {
 			registryOverride += "/"
 		}
+		registryOverride = formatImageRef(registryOverride)
 		ref = registryOverride + imageWithIdentifier
 	}
 	keychain := getKeychain(env.RegistryAuthOverride, env.RegistryUsername, env.RegistryPassword)
@@ -229,7 +230,7 @@ func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
 		}
 	}
 	return urlWithKeychain{
-		ref:      formatImageRef(ref),
+		ref:      ref,
 		keychain: keychain,
 	}
 }

--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -229,9 +229,14 @@ func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
 		}
 	}
 	return urlWithKeychain{
-		ref:      ref,
+		ref:      formatImageRef(ref),
 		keychain: keychain,
 	}
+}
+
+// formatImageRef formats the image ref by removing the http:// or https:// prefix.
+func formatImageRef(override string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(override, "https://"), "http://")
 }
 
 // downloadRegistry downloads the image from a remote registry.

--- a/pkg/fleet/installer/oci/download_test.go
+++ b/pkg/fleet/installer/oci/download_test.go
@@ -149,6 +149,9 @@ func TestGetRefAndKeychain(t *testing.T) {
 		{url: "install.datad0g.com/agent-package:latest", expectedRef: "install.datad0g.com/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
 		{url: "gcr.io/datadoghq/agent-package@sha256:1234", expectedRef: "gcr.io/datadoghq/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
 		{url: "install.datad0g.com/agent-package:latest", registryOverride: "fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
+		{url: "install.datad0g.com/agent-package:latest", registryOverride: "http://fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
+		{url: "install.datad0g.com/agent-package:latest", registryOverride: "https://fake.io", expectedRef: "fake.io/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
+		{url: "install.datad0g.com/agent-package:latest", registryOverride: "https://fake.io:443", expectedRef: "fake.io:443/agent-package:latest", expectedKeychain: authn.DefaultKeychain},
 		{url: "gcr.io/datadoghq/agent-package@sha256:1234", registryOverride: "fake.io", expectedRef: "fake.io/agent-package@sha256:1234", expectedKeychain: authn.DefaultKeychain},
 		{
 			url:                "install.datad0g.com/agent-package:latest",


### PR DESCRIPTION
### What does this PR do?
Support registry override starting with `http(s)://` & avoids parsing issues

### Motivation

### Describe how you validated your changes

### Additional Notes
