### PR TITLE
Report successful first RC update

### DIFF
--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -39,6 +39,9 @@ const (
 	recoveryInterval      = 2
 
 	maxMessageSize = 1024 * 1024 * 110 // 110MB, current backend limit
+
+	// number of update failed update attempts before reporting an error log
+	consecutiveFailuresThreshold = 5
 )
 
 // ConfigFetcher defines the interface that an agent client uses to get config updates
@@ -398,7 +401,7 @@ func (c *Client) pollLoop() {
 					// as an Info log as the race is expected. If the error persists, we log with error logs
 					if logLimit.ShouldLog() {
 						message := "retrying the first update of remote-config state (%v), consecutive failures: %d"
-						if consecutiveFailures >= 5 {
+						if consecutiveFailures >= consecutiveFailuresThreshold {
 							log.Errorf(message, err, consecutiveFailures)
 						} else {
 							log.Infof(message, err, consecutiveFailures)

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -436,6 +436,10 @@ func (c *Client) pollLoop() {
 					log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
 				}
 			} else {
+				if !successfulFirstRun {
+					log.Infof("first update successful")
+				}
+				log.Debugf("update successful: successful_first_run:%s", successfulFirstRun)
 				if c.lastUpdateError != nil {
 					c.m.Lock()
 					for _, productListeners := range c.listeners {

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -436,9 +436,6 @@ func (c *Client) pollLoop() {
 					log.Errorf("could not update remote-config state: %v", c.lastUpdateError)
 				}
 			} else {
-				if !successfulFirstRun {
-					log.Infof("first update successful")
-				}
 				log.Debugf("update successful: successful_first_run:%t", successfulFirstRun)
 				if c.lastUpdateError != nil {
 					c.m.Lock()
@@ -450,8 +447,13 @@ func (c *Client) pollLoop() {
 					c.m.Unlock()
 				}
 
-				c.lastUpdateError = nil
+				// record and report that the first update was successful
+				if !successfulFirstRun {
+					log.Infof("first update successful")
+				}
 				successfulFirstRun = true
+
+				c.lastUpdateError = nil
 				c.backoffErrorCount = c.backoffPolicy.DecError(c.backoffErrorCount)
 			}
 		}

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -439,7 +439,7 @@ func (c *Client) pollLoop() {
 				if !successfulFirstRun {
 					log.Infof("first update successful")
 				}
-				log.Debugf("update successful: successful_first_run:%s", successfulFirstRun)
+				log.Debugf("update successful: successful_first_run:%t", successfulFirstRun)
 				if c.lastUpdateError != nil {
 					c.m.Lock()
 					for _, productListeners := range c.listeners {


### PR DESCRIPTION
- Reworked the Remote Configuration poll loop
- The Remote Configuration Client doesn't log when it does a first update successfully but only if it fails which makes it harder to understand when it's in working state.
This can happen as the trace-agent can start faster then the core-agent.


The modified/added logs look like this

```
2025-09-03 10:09:38 CEST | TRACE | INFO | (pkg/config/remote/client/client.go:404 in pollLoop) | retrying the first update of remote-config state (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:5001: connect: connection refused"), consecutive failures: 1
2025-09-03 10:09:39 CEST | TRACE | INFO | (pkg/config/remote/client/client.go:404 in pollLoop) | retrying the first update of remote-config state (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:5001: connect: connection refused"), consecutive failures: 2
2025-09-03 10:09:40 CEST | TRACE | INFO | (pkg/config/remote/client/client.go:404 in pollLoop) | retrying the first update of remote-config state (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:5001: connect: connection refused"), consecutive failures: 3
2025-09-03 10:09:41 CEST | TRACE | INFO | (pkg/config/remote/client/client.go:404 in pollLoop) | retrying the first update of remote-config state (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:5001: connect: connection refused"), consecutive failures: 4
2025-09-03 10:09:42 CEST | TRACE | ERROR | (pkg/config/remote/client/client.go:402 in pollLoop) | retrying the first update of remote-config state (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:5001: connect: connection refused"), consecutive failures: 5
2025-09-03 10:09:46 CEST | TRACE | DEBUG | (pkg/config/remote/client/client.go:421 in pollLoop) | update successful: successful_first_run:false, consecutive failures:8
2025-09-03 10:09:46 CEST | TRACE | INFO | (pkg/config/remote/client/client.go:434 in pollLoop) | first update successful after 8 attempts
```