### PR TITLE
Remove all linter TODOs and fix all linter issues in ALP owned files

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -304,7 +304,7 @@ Package orchestratorinterface defines the interface for the orchestrator forward
 
 *Datadog Team*: agent-log-pipelines
 
-
+Package logs provides the logs component bundle
 
 ### [comp/logs/adscheduler](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/adscheduler)
 

--- a/comp/logs/agent/config/channel_message.go
+++ b/comp/logs/agent/config/channel_message.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package config provides log configuration structures and utilities
 package config
 
 import "time"

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -51,8 +51,7 @@ type LogsConfig struct {
 	ExcludePaths StringSliceField `mapstructure:"exclude_paths" json:"exclude_paths" yaml:"exclude_paths"`    // File
 	TailingMode  string           `mapstructure:"start_position" json:"start_position" yaml:"start_position"` // File
 
-	//nolint:revive // TODO(AML) Fix revive linter
-	ConfigId           string           `mapstructure:"config_id" json:"config_id" yaml:"config_id"`                            // Journald
+	ConfigID           string           `mapstructure:"config_id" json:"config_id" yaml:"config_id"`                            // Journald
 	IncludeSystemUnits StringSliceField `mapstructure:"include_units" json:"include_units" yaml:"include_units"`                // Journald
 	ExcludeSystemUnits StringSliceField `mapstructure:"exclude_units" json:"exclude_units" yaml:"exclude_units"`                // Journald
 	IncludeUserUnits   StringSliceField `mapstructure:"include_user_units" json:"include_user_units" yaml:"include_user_units"` // Journald

--- a/comp/logs/agent/config/parser_test.go
+++ b/comp/logs/agent/config/parser_test.go
@@ -374,7 +374,7 @@ logs:
 				assert.Equal(t, "utf-8", config.Encoding)
 				require.Equal(t, len(config.ExcludePaths), 2)
 				assert.Equal(t, "beginning", config.TailingMode)
-				assert.Equal(t, "test_config_id", config.ConfigId)
+				assert.Equal(t, "test_config_id", config.ConfigID)
 				require.Equal(t, len(config.IncludeSystemUnits), 1)
 				require.Equal(t, len(config.ExcludeSystemUnits), 3)
 				require.Equal(t, len(config.IncludeUserUnits), 1)

--- a/comp/logs/agent/flare/flare_controller.go
+++ b/comp/logs/agent/flare/flare_controller.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive
+// Package flare provides log flare collection functionality for diagnostics
 package flare
 
 import (
@@ -17,6 +17,8 @@ import (
 
 // FlareController is a type that contains information needed to insert into a
 // flare from the logs agent.
+//
+//nolint:revive // exported: ignore package name struct conflict
 type FlareController struct {
 	mu           sync.Mutex
 	allFiles     []string
@@ -77,7 +79,7 @@ func (fc *FlareController) SetAllFiles(files []string) {
 	fc.allFiles = files
 }
 
-// SetAllJournalFiles assigns the journalFiles parameter of FlareController
+// AddToJournalFiles assigns the journalFiles parameter of FlareController
 func (fc *FlareController) AddToJournalFiles(files []string) {
 	fc.mu.Lock()
 	defer fc.mu.Unlock()

--- a/comp/logs/bundle.go
+++ b/comp/logs/bundle.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package logs //nolint:revive // TODO(AML) Fix revive linter
+// Package logs provides the logs component bundle
+package logs
 
 import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"

--- a/comp/logs/bundle_mock.go
+++ b/comp/logs/bundle_mock.go
@@ -5,7 +5,8 @@
 
 //go:build test
 
-package logs //nolint:revive // TODO(AML) Fix revive linter
+// Package logs provides the logs component bundle with mock implementations
+package logs
 
 import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"

--- a/pkg/logs/client/destination.go
+++ b/pkg/logs/client/destination.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package client provides log destination client functionality
 package client
 
 import (

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
 package http
 
 import (
@@ -58,10 +57,8 @@ var (
 	expVarInUseMsMapKey = "inUseMs"
 )
 
-// emptyJsonPayload is an empty payload used to check HTTP connectivity without sending logs.
-//
-//nolint:revive // TODO(AML) Fix revive linter
-var emptyJsonPayload = message.Payload{MessageMetas: []*message.MessageMetadata{}, Encoded: []byte("{}")}
+// emptyJSONPayload is an empty payload used to check HTTP connectivity without sending logs.
+var emptyJSONPayload = message.Payload{MessageMetas: []*message.MessageMetadata{}, Encoded: []byte("{}")}
 
 type destinationResult struct {
 	latency time.Duration
@@ -185,11 +182,11 @@ func newDestination(endpoint config.Endpoint,
 func errorToTag(err error) string {
 	if err == nil {
 		return "none"
-	} else if _, ok := err.(*client.RetryableError); ok {
-		return "retryable"
-	} else {
-		return "non-retryable"
 	}
+	if _, ok := err.(*client.RetryableError); ok {
+		return "retryable"
+	}
+	return "non-retryable"
 }
 
 // IsMRF indicates that this destination is a Multi-Region Failover destination.
@@ -378,8 +375,8 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	log.Tracef("Log payload sent to %s. Response resolved with protocol %s in %d ms", d.url, resp.Proto, latency)
 
-	metrics.DestinationHttpRespByStatusAndUrl.Add(strconv.Itoa(resp.StatusCode), 1)
-	metrics.TlmDestinationHttpRespByStatusAndUrl.Inc(strconv.Itoa(resp.StatusCode), d.url)
+	metrics.DestinationHTTPRespByStatusAndURL.Add(strconv.Itoa(resp.StatusCode), 1)
+	metrics.TlmDestinationHTTPRespByStatusAndURL.Inc(strconv.Itoa(resp.StatusCode), d.url)
 
 	if resp.StatusCode >= http.StatusBadRequest {
 		log.Warnf("failed to post http payload. code=%d, url=%s, EvP track type=%s, content type=%s, EvP category=%s, origin=%s, response=%s", resp.StatusCode, d.url, d.endpoint.TrackType, d.contentType, d.destMeta.EvpCategory(), d.origin, string(response))
@@ -396,10 +393,9 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		// the server could not serve the request, most likely because of an
 		// internal error. We should retry these requests.
 		return client.NewRetryableError(errServer)
-	} else {
-		d.pipelineMonitor.ReportComponentEgress(payload, d.destMeta.MonitorTag(), d.instanceID)
-		return nil
 	}
+	d.pipelineMonitor.ReportComponentEgress(payload, d.destMeta.MonitorTag(), d.instanceID)
+	return nil
 }
 
 func (d *Destination) updateRetryState(err error, isRetrying chan bool) bool {
@@ -414,15 +410,14 @@ func (d *Destination) updateRetryState(err error, isRetrying chan bool) bool {
 		d.lastRetryError = err
 
 		return true
-	} else { //nolint:revive // TODO(AML) Fix revive linter
-		d.nbErrors = d.backoff.DecError(d.nbErrors)
-		if isRetrying != nil && d.lastRetryError != nil {
-			isRetrying <- false
-		}
-		d.lastRetryError = nil
-
-		return false
 	}
+	d.nbErrors = d.backoff.DecError(d.nbErrors)
+	if isRetrying != nil && d.lastRetryError != nil {
+		isRetrying <- false
+	}
+	d.lastRetryError = nil
+
+	return false
 }
 
 func httpClientFactory(cfg pkgconfigmodel.Reader, timeoutOverride time.Duration) func() *http.Client {
@@ -505,7 +500,7 @@ func prepareCheckConnectivity(endpoint config.Endpoint, cfg pkgconfigmodel.Reade
 func completeCheckConnectivity(ctx *client.DestinationsContext, destination *Destination) error {
 	ctx.Start()
 	defer ctx.Stop()
-	return destination.unconditionalSend(&emptyJsonPayload)
+	return destination.unconditionalSend(&emptyJSONPayload)
 }
 
 // CheckConnectivity check if sending logs through HTTP works
@@ -522,7 +517,7 @@ func CheckConnectivity(endpoint config.Endpoint, cfg pkgconfigmodel.Reader) conf
 	return err == nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// CheckConnectivityDiagnose checks HTTP connectivity to an endpoint and returns the URL and any errors for diagnostic purposes
 func CheckConnectivityDiagnose(endpoint config.Endpoint, cfg pkgconfigmodel.Reader) (url string, err error) {
 	ctx, destination := prepareCheckConnectivity(endpoint, cfg)
 	return destination.url, completeCheckConnectivity(ctx, destination)

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -77,7 +77,6 @@ func TestBuildURLPathPrefixV1(t *testing.T) {
 	assert.Equal(t, "https://foo:8080/prefix/url/v1/input", url)
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestDestinationSend200(t *testing.T) {
 	cfg := configmock.New(t)
 	server := NewTestServer(200, cfg)
@@ -105,7 +104,6 @@ func TestNoRetries(t *testing.T) {
 	testNoRetry(t, 413)
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func testNoRetry(t *testing.T, statusCode int) {
 	cfg := configmock.New(t)
 	server := NewTestServer(statusCode, cfg)

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
 package http
 
 import (

--- a/pkg/logs/client/mock/mock.go
+++ b/pkg/logs/client/mock/mock.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package mock provides mock utilities for testing log clients
 package mock
 
 import (

--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tcp provides TCP connection management for log clients
 package tcp
 
 import (

--- a/pkg/logs/diagnostic/format.go
+++ b/pkg/logs/diagnostic/format.go
@@ -25,7 +25,6 @@ type logFormatter struct {
 	hostname hostnameinterface.Component
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (l *logFormatter) Format(m *message.Message, _ string, redactedMsg []byte) string {
 	hname, err := l.hostname.Get(context.TODO())
 	if err != nil {

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package decoder provides log line decoding and parsing functionality
 package decoder
 
 import (

--- a/pkg/logs/internal/decoder/decoder.go
+++ b/pkg/logs/internal/decoder/decoder.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
-	//nolint:revive // TODO(AML) Fix revive linter
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/framer"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"

--- a/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/legacy_auto_multiline_handler.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
 package decoder
 
 import (

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
 const contentLenLimit = 256000
@@ -39,10 +40,9 @@ func chunk(input []byte, size int) [][]byte {
 		if size <= len(iter) {
 			rv = append(rv, iter)
 			break
-		} else { //nolint:revive // TODO(AML) Fix revive linter
-			rv = append(rv, iter[:size])
-			iter = iter[size:]
 		}
+		rv = append(rv, iter[:size])
+		iter = iter[size:]
 	}
 	return rv
 }

--- a/pkg/logs/internal/framer/no_framing.go
+++ b/pkg/logs/internal/framer/no_framing.go
@@ -9,8 +9,6 @@ package framer
 type noFramingMatcher struct{}
 
 // FindFrame considers the given bytes buffer as one full frame.
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *noFramingMatcher) FindFrame(buf []byte, _ int) ([]byte, int) {
 	return buf, len(buf)
 }

--- a/pkg/logs/internal/parsers/kubernetes/kubernetes.go
+++ b/pkg/logs/internal/parsers/kubernetes/kubernetes.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package kubernetes provides Kubernetes log format parsing
 package kubernetes
 
 import (

--- a/pkg/logs/internal/tag/local_provider.go
+++ b/pkg/logs/internal/tag/local_provider.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tag provides tags for log sources
 package tag
 
 import (

--- a/pkg/logs/internal/util/adlistener/ad.go
+++ b/pkg/logs/internal/util/adlistener/ad.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package adlistener provides autodiscovery event listener utilities
 package adlistener
 
 import (

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestListenersGetScheduleCalls(t *testing.T) {
 	adsched := scheduler.NewControllerAndStart()
 	ac := fxutil.Test[autodiscovery.Mock](t,

--- a/pkg/logs/internal/util/containersorpods/containers_or_pods.go
+++ b/pkg/logs/internal/util/containersorpods/containers_or_pods.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package containersorpods provides logic to choose between logging containers or pods
 package containersorpods
 
 import (

--- a/pkg/logs/internal/util/moving_sum.go
+++ b/pkg/logs/internal/util/moving_sum.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package util provides internal utility functions for logs
 package util
 
 import (

--- a/pkg/logs/launchers/channel/launcher.go
+++ b/pkg/logs/launchers/channel/launcher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package channel provides channel-based log launchers
 package channel
 
 import (

--- a/pkg/logs/launchers/container/launcher.go
+++ b/pkg/logs/launchers/container/launcher.go
@@ -5,7 +5,7 @@
 
 //go:build kubelet || docker
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package container provides container-based log launchers
 package container
 
 import (
@@ -17,9 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/container/tailerfactory"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
-	"github.com/DataDog/datadog-agent/pkg/logs/sources"
-
-	//nolint:revive // TODO(AML) Fix revive linter
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -77,9 +74,7 @@ func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmet
 }
 
 // Start starts the Launcher
-//
-//nolint:revive // TODO(AML) Fix revive linter
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, _ *tailers.TailerTracker) {
 	// only start this launcher once it's determined that we should be logging containers, and not pods.
 	ctx, cancel := context.WithCancel(context.Background())
 	l.cancel = cancel
@@ -186,5 +181,5 @@ func (l *Launcher) stop() {
 	stopper.Stop()
 	log.Info("Stopping container launcher")
 
-	l.tailers = make(map[*sources.LogSource]tailerfactory.Tailer)
+	l.tailers = make(map[*sourcesPkg.LogSource]tailerfactory.Tailer)
 }

--- a/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
+++ b/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
@@ -5,7 +5,7 @@
 
 //go:build !kubelet && !docker
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package container provides container-based log launchers
 package container
 
 import (

--- a/pkg/logs/launchers/container/launcher_test.go
+++ b/pkg/logs/launchers/container/launcher_test.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package container provides container-based log launchers
 package container
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/api.go
+++ b/pkg/logs/launchers/container/tailerfactory/api.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 // This file handles creating API tailers which access logs by querying the Kubelet's API

--- a/pkg/logs/launchers/container/tailerfactory/api_nokubelet.go
+++ b/pkg/logs/launchers/container/tailerfactory/api_nokubelet.go
@@ -5,10 +5,13 @@
 
 //go:build !kubelet && docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (
 	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 

--- a/pkg/logs/launchers/container/tailerfactory/api_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/api_test.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/defaults.go
+++ b/pkg/logs/launchers/container/tailerfactory/defaults.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/defaults_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/defaults_test.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/factory_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/factory_test.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 // This file handles creating docker tailers which access the container runtime

--- a/pkg/logs/launchers/container/tailerfactory/file_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/file_test.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/socket.go
+++ b/pkg/logs/launchers/container/tailerfactory/socket.go
@@ -5,6 +5,8 @@
 
 //go:build docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 // This file handles creating docker tailers which access the container runtime
@@ -13,9 +15,10 @@ package tailerfactory
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers/container"
 	dockerutilPkg "github.com/DataDog/datadog-agent/pkg/util/docker"
-	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/container/tailerfactory/tailers"

--- a/pkg/logs/launchers/container/tailerfactory/socket_nodocker.go
+++ b/pkg/logs/launchers/container/tailerfactory/socket_nodocker.go
@@ -5,10 +5,13 @@
 
 //go:build kubelet && !docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (
 	"errors"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers/container"
 )

--- a/pkg/logs/launchers/container/tailerfactory/socket_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/socket_test.go
@@ -5,6 +5,8 @@
 
 //go:build docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/tailers/api.go
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/api.go
@@ -5,7 +5,7 @@
 
 //go:build kubelet
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tailers provides tailers for API logs
 package tailers
 
 import (
@@ -23,6 +23,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 )
 
+// APITailer is a tailer for kubelet API logs
 type APITailer struct {
 	kubeUtil      kubelet.KubeUtilInterface
 	ContainerName string

--- a/pkg/logs/launchers/container/tailerfactory/tailers/shared.go
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/shared.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package tailers provides tailers for API logs
 package tailers
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/tailers/socket.go
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/socket.go
@@ -5,7 +5,7 @@
 
 //go:build docker
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tailers provides tailers for API logs
 package tailers
 
 import (
@@ -26,6 +26,7 @@ import (
 // modified to suit the Tailer interface directly and to handle connection
 // failures on its own, and this wrapper will no longer be necessary.
 
+// DockerSocketTailer is a tailer for docker socket logs
 type DockerSocketTailer struct {
 	dockerutil containerTailerPkg.DockerContainerLogInterface
 	base

--- a/pkg/logs/launchers/container/tailerfactory/tailers/source.go
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/source.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package tailers provides tailers for API logs
 package tailers
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/tailers/tailer.go
+++ b/pkg/logs/launchers/container/tailerfactory/tailers/tailer.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package tailers provides tailers for API logs
 package tailers
 
 import (
@@ -122,8 +123,9 @@ func (t *base) run(
 				// is unbuffered, any pending writes to this channel could cause a deadlock as the tailers stop
 				// condition is managed in the same goroutine in containerTailerPkg.
 				go func() {
-					//nolint:revive // TODO(AML) Fix revive linter
-					for range erroredContainerID {
+					for id := range erroredContainerID {
+						// Consume messages from channel until closed
+						_ = id
 					}
 				}()
 				stopTailer(inner)

--- a/pkg/logs/launchers/container/tailerfactory/testing.go
+++ b/pkg/logs/launchers/container/tailerfactory/testing.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import "errors"

--- a/pkg/logs/launchers/container/tailerfactory/types.go
+++ b/pkg/logs/launchers/container/tailerfactory/types.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 // Tailer abstracts types which can tail logs.

--- a/pkg/logs/launchers/container/tailerfactory/whichtailer.go
+++ b/pkg/logs/launchers/container/tailerfactory/whichtailer.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/container/tailerfactory/whichtailer_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/whichtailer_test.go
@@ -5,6 +5,8 @@
 
 //go:build kubelet || docker
 
+// Package tailerfactory implements the logic required to determine which kind
+// of tailer to use for a container-related LogSource, and to create that tailer.
 package tailerfactory
 
 import (

--- a/pkg/logs/launchers/file/launcher.go
+++ b/pkg/logs/launchers/file/launcher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package file provides file-based log launchers
 package file
 
 import (
@@ -233,7 +233,7 @@ func (s *Launcher) scan() {
 
 	for _, tailer := range s.tailers.All() {
 		// stop all tailers which have not been selected
-		_, shouldTail := filesTailed[tailer.GetId()]
+		_, shouldTail := filesTailed[tailer.GetID()]
 		if !shouldTail {
 			s.stopTailer(tailer)
 		}
@@ -556,7 +556,7 @@ func (s *Launcher) createRotatedTailer(t *tailer.Tailer, file *tailer.File, patt
 	return t.NewRotatedTailer(file, channel, monitor, decoder.NewDecoderFromSourceWithPattern(file.Source, pattern, tailerInfo), tailerInfo, s.tagger, fingerprint, s.registry)
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// CheckProcessTelemetry checks process file statistics and logs warnings about file handle usage
 func CheckProcessTelemetry(stats *procfilestats.ProcessFileStats) {
 	ratio := float64(stats.AgentOpenFiles) / float64(stats.OsFileLimit)
 	if ratio > 0.9 {

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package fileprovider provides file source provisioning for log launchers
 package fileprovider
 
 import (
@@ -183,17 +183,16 @@ func (p *FileProvider) FilesToTail(validatePodContainerID bool, inputSources []*
 			if isWildcardSource {
 				wildcardSources = append(wildcardSources, source)
 				continue
-			} else { //nolint:revive // TODO(AML) Fix revive linter
-				files, err := p.CollectFiles(source)
-				if err != nil {
-					source.Status.Error(err)
-					if shouldLogErrors {
-						log.Warnf("Could not collect files: %v", err)
-					}
-					continue
-				}
-				filesToTail = p.addFilesToTailList(validatePodContainerID, files, filesToTail, &wildcardFileCounter, registry)
 			}
+			files, err := p.CollectFiles(source)
+			if err != nil {
+				source.Status.Error(err)
+				if shouldLogErrors {
+					log.Warnf("Could not collect files: %v", err)
+				}
+				continue
+			}
+			filesToTail = p.addFilesToTailList(validatePodContainerID, files, filesToTail, &wildcardFileCounter, registry)
 		}
 
 		// Second pass, resolve all wildcards and add them to one big list

--- a/pkg/logs/launchers/journald/launcher.go
+++ b/pkg/logs/launchers/journald/launcher.go
@@ -5,7 +5,7 @@
 
 //go:build systemd
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package journald provides journald-based log launchers (no-op for non-systemd builds)
 package journald
 
 import (
@@ -29,12 +29,12 @@ import (
 // SDJournalFactory is a JournalFactory implementation that produces sdjournal instances
 type SDJournalFactory struct{}
 
-//nolint:revive // TODO(AML) Fix revive linter
+// NewJournal creates a new sdjournal instance
 func (s *SDJournalFactory) NewJournal() (tailer.Journal, error) {
 	return sdjournal.NewJournal()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// NewJournalFromPath creates a new sdjournal instance from the supplied path
 func (s *SDJournalFactory) NewJournalFromPath(path string) (tailer.Journal, error) {
 	return sdjournal.NewJournalFromDir(path)
 }
@@ -68,9 +68,7 @@ func NewLauncherWithFactory(journalFactory tailer.JournalFactory, fc *flareContr
 }
 
 // Start starts the launcher.
-//
-//nolint:revive // TODO(AML) Fix revive linter
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, _ *tailers.TailerTracker) {
 	l.sources = sourceProvider.GetAddedForType(config.JournaldType)
 	l.pipelineProvider = pipelineProvider
 	l.registry = registry

--- a/pkg/logs/launchers/journald/launcher_nosystemd.go
+++ b/pkg/logs/launchers/journald/launcher_nosystemd.go
@@ -5,7 +5,7 @@
 
 //go:build !systemd
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package journald provides journald-based log launchers (no-op for non-systemd builds)
 package journald
 
 import (
@@ -26,8 +26,6 @@ func NewLauncher(*flareController.FlareController, tagger.Component) *Launcher {
 }
 
 // Start does nothing
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (l *Launcher) Start(_ launchers.SourceProvider, _ pipeline.Provider, _ auditor.Registry, _ *tailers.TailerTracker) {
 }
 

--- a/pkg/logs/launchers/journald/launcher_test.go
+++ b/pkg/logs/launchers/journald/launcher_test.go
@@ -5,6 +5,7 @@
 
 //go:build systemd
 
+// Package journald provides journald-based log launchers (no-op for non-systemd builds)
 package journald
 
 import (
@@ -27,20 +28,13 @@ import (
 
 type MockJournal struct{}
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) AddMatch(match string) error { return nil }
-func (m *MockJournal) AddDisjunction() error       { return nil }
-func (m *MockJournal) SeekTail() error             { return nil }
-func (m *MockJournal) SeekHead() error             { return nil }
-
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) Wait(timeout time.Duration) int { return 0 }
-
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) SeekCursor(cursor string) error { return nil }
-
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) NextSkip(skip uint64) (uint64, error)       { return 0, nil }
+func (m *MockJournal) AddMatch(_ string) error                    { return nil }
+func (m *MockJournal) AddDisjunction() error                      { return nil }
+func (m *MockJournal) SeekTail() error                            { return nil }
+func (m *MockJournal) SeekHead() error                            { return nil }
+func (m *MockJournal) Wait(_ time.Duration) int                   { return 0 }
+func (m *MockJournal) SeekCursor(_ string) error                  { return nil }
+func (m *MockJournal) NextSkip(_ uint64) (uint64, error)          { return 0, nil }
 func (m *MockJournal) Close() error                               { return nil }
 func (m *MockJournal) Next() (uint64, error)                      { return 0, nil }
 func (m *MockJournal) Previous() (uint64, error)                  { return 0, nil }
@@ -54,8 +48,7 @@ func (s *MockJournalFactory) NewJournal() (tailer.Journal, error) {
 	return &MockJournal{}, nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (s *MockJournalFactory) NewJournalFromPath(path string) (tailer.Journal, error) {
+func (s *MockJournalFactory) NewJournalFromPath(_ string) (tailer.Journal, error) {
 	return &MockJournal{}, nil
 }
 
@@ -115,8 +108,8 @@ func TestMultipleTailersOnSamePath(t *testing.T) {
 func TestMultipleTailersSamePathWithId(t *testing.T) {
 	launcher := newTestLauncher(t)
 
-	launcher.sources <- sources.NewLogSource("testSource", &config.LogsConfig{Path: "/foo/bar", ConfigId: "foo"})
-	launcher.sources <- sources.NewLogSource("testSource2", &config.LogsConfig{Path: "/foo/bar", ConfigId: "bar"})
+	launcher.sources <- sources.NewLogSource("testSource", &config.LogsConfig{Path: "/foo/bar", ConfigID: "foo"})
+	launcher.sources <- sources.NewLogSource("testSource2", &config.LogsConfig{Path: "/foo/bar", ConfigID: "bar"})
 
 	launcher.stop <- struct{}{}
 
@@ -126,8 +119,8 @@ func TestMultipleTailersSamePathWithId(t *testing.T) {
 func TestMultipleTailersWithId(t *testing.T) {
 	launcher := newTestLauncher(t)
 
-	launcher.sources <- sources.NewLogSource("testSource", &config.LogsConfig{ConfigId: "foo"})
-	launcher.sources <- sources.NewLogSource("testSource2", &config.LogsConfig{ConfigId: "bar"})
+	launcher.sources <- sources.NewLogSource("testSource", &config.LogsConfig{ConfigID: "foo"})
+	launcher.sources <- sources.NewLogSource("testSource2", &config.LogsConfig{ConfigID: "bar"})
 
 	launcher.stop <- struct{}{}
 

--- a/pkg/logs/launchers/launchers.go
+++ b/pkg/logs/launchers/launchers.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package launchers provides log tailer launcher functionality
 package launchers
 
 import (

--- a/pkg/logs/launchers/listener/errors.go
+++ b/pkg/logs/launchers/listener/errors.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package listener provides error handling for log listeners
 package listener
 
 import (

--- a/pkg/logs/launchers/listener/launcher.go
+++ b/pkg/logs/launchers/listener/launcher.go
@@ -34,8 +34,6 @@ func NewLauncher(frameSize int) *Launcher {
 }
 
 // Start starts the listener.
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, _ auditor.Registry, _ *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.tcpSources = sourceProvider.GetAddedForType(config.TCPType)

--- a/pkg/logs/launchers/listener/udp_test.go
+++ b/pkg/logs/launchers/listener/udp_test.go
@@ -39,7 +39,6 @@ func TestUDPShouldReceiveMessage(t *testing.T) {
 	listener.Stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestUDPShouldStopWhenNotStarted(_ *testing.T) {
 	pp := mock.NewMockProvider()
 	listener := NewUDPListener(pp, sources.NewLogSource("", &config.LogsConfig{Port: udpTestPort}), 9000)

--- a/pkg/logs/launchers/mock_source_provider.go
+++ b/pkg/logs/launchers/mock_source_provider.go
@@ -31,15 +31,11 @@ func (sp *MockSourceProvider) SubscribeAll() (chan *sources.LogSource, chan *sou
 }
 
 // SubscribeForType implements SourceProvider#SubscribeForType.
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (sp *MockSourceProvider) SubscribeForType(_ string) (chan *sources.LogSource, chan *sources.LogSource) {
 	return sp.SourceChan, sp.SourceChan
 }
 
 // GetAddedForType implements SourceProvider#GetAddedForType.
-//
-//nolint:revive // TODO(AML) Fix revive linter
 func (sp *MockSourceProvider) GetAddedForType(_ string) chan *sources.LogSource {
 	return sp.SourceChan
 }

--- a/pkg/logs/launchers/windowsevent/launcher.go
+++ b/pkg/logs/launchers/windowsevent/launcher.go
@@ -44,10 +44,8 @@ func NewLauncher() *Launcher {
 	}
 }
 
-// Start starts the launcher.
-//
-//nolint:revive // TODO(WINA) Fix revive linter
-func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, tracker *tailers.TailerTracker) {
+// Start starts the launcher by setting up Windows event log sources and beginning to tail them.
+func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvider pipeline.Provider, registry auditor.Registry, _ *tailers.TailerTracker) {
 	l.pipelineProvider = pipelineProvider
 	l.sources = sourceProvider.GetAddedForType(config.WindowsEventType)
 	l.registry = registry

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package message provides log message data structures and utilities
 package message
 
 import (
@@ -40,6 +40,7 @@ type Payload struct {
 	UnencodedSize int
 }
 
+// NewPayload creates a new payload with the given message metadata, encoded content, encoding type and unencoded size
 func NewPayload(messageMetas []*MessageMetadata, encoded []byte, encoding string, unencodedSize int) *Payload {
 	return &Payload{
 		MessageMetas:  messageMetas,
@@ -56,7 +57,7 @@ func (m *Payload) Count() int64 {
 
 // Size returns the size of the message.
 func (m *Payload) Size() int64 {
-	var size int64 = 0
+	var size int64
 	for _, m := range m.MessageMetas {
 		size += m.Size()
 	}
@@ -69,6 +70,9 @@ type Message struct {
 	MessageMetadata
 }
 
+// MessageMetadata contains metadata information about a log message
+//
+//nolint:revive // exported: ignore package name struct conflict
 type MessageMetadata struct {
 	Hostname           string
 	Origin             *Origin
@@ -382,12 +386,12 @@ func (m *MessageMetadata) GetLatency() int64 {
 	return time.Now().UnixNano() - m.IngestionTimestamp
 }
 
-// Message returns all tags that this message is attached with.
+// Tags returns all tags that this message is attached with.
 func (m *MessageMetadata) Tags() []string {
 	return m.Origin.Tags(m.ProcessingTags)
 }
 
-// Message returns all tags that this message is attached with, as a string.
+// TagsToString returns all tags that this message is attached with, as a string.
 func (m *MessageMetadata) TagsToString() string {
 	return m.Origin.TagsToString(m.ProcessingTags)
 }

--- a/pkg/logs/metrics/capacity_monitor.go
+++ b/pkg/logs/metrics/capacity_monitor.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package metrics provides telemetry metrics for the logs agent
 package metrics
 
 import (

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package metrics provides telemetry metrics for the logs agent
 package metrics
 
 import (
@@ -48,9 +48,9 @@ var (
 		[]string{"source"}, "Total number of bytes sent before encoding if any")
 	// RetryCount is the total number of times we have retried payloads that failed to send
 	RetryCount = expvar.Int{}
-	// TlmRetryCountis the total number of times we have retried payloads that failed to send
+	// TlmRetryCount is the total number of times we have retried payloads that failed to send
 	TlmRetryCount = telemetry.NewCounter("logs", "retry_count",
-		nil, "Total number of retried paylaods")
+		nil, "Total number of retried payloads")
 	// RetryTimeSpent is the total time spent retrying payloads that failed to send
 	RetryTimeSpent = expvar.Int{}
 	// EncodedBytesSent is the total number of sent bytes after encoding if any
@@ -70,11 +70,10 @@ var (
 		nil, "Histogram of http sender latency in ms", []float64{10, 25, 50, 75, 100, 250, 500, 1000, 10000})
 	// DestinationExpVars a map of sender utilization metrics for each http destination
 	DestinationExpVars = expvar.Map{}
-	// TODO: Add LogsCollected for the total number of collected logs.
-	//nolint:revive // TODO(AML) Fix revive linter
-	DestinationHttpRespByStatusAndUrl = expvar.Map{}
-	//nolint:revive // TODO(AML) Fix revive linter
-	TlmDestinationHttpRespByStatusAndUrl = telemetry.NewCounter("logs", "destination_http_resp", []string{"status_code", "url"}, "Count of http responses by status code and destination url")
+	// DestinationHTTPRespByStatusAndURL tracks HTTP responses by status code and destination URL
+	DestinationHTTPRespByStatusAndURL = expvar.Map{}
+	// TlmDestinationHTTPRespByStatusAndURL tracks HTTP responses by status code and destination URL
+	TlmDestinationHTTPRespByStatusAndURL = telemetry.NewCounter("logs", "destination_http_resp", []string{"status_code", "url"}, "Count of http responses by status code and destination url")
 
 	// TlmAutoMultilineAggregatorFlush Count of each line flushed from the auto multiline aggregator.
 	TlmAutoMultilineAggregatorFlush = telemetry.NewCounter("logs", "auto_multi_line_aggregator_flush", []string{"truncated", "line_type"}, "Count of each line flushed from the auto multiline aggregator")

--- a/pkg/logs/pipeline/mock/mock.go
+++ b/pkg/logs/pipeline/mock/mock.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package mock provides mock pipeline components for testing
 package mock
 
 import (
@@ -38,7 +38,7 @@ func (p *mockProvider) GetOutputChan() chan *message.Message {
 
 // Flush does nothing
 //
-//nolint:revive // TODO(AML) Fix revive linter
+
 func (p *mockProvider) Flush(_ context.Context) {}
 
 // NextPipelineChan returns the next pipeline

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package pipeline provides log processing pipeline functionality
 package pipeline
 
 import (
@@ -39,7 +39,7 @@ func NewPipeline(
 	diagnosticMessageReceiver diagnostic.MessageReceiver,
 	serverlessMeta sender.ServerlessMeta,
 	hostname hostnameinterface.Component,
-	cfg pkgconfigmodel.Reader,
+	_ pkgconfigmodel.Reader,
 	compression logscompression.Component,
 	instanceID string,
 ) *Pipeline {
@@ -90,7 +90,6 @@ func (p *Pipeline) Flush(ctx context.Context) {
 	p.processor.Flush(ctx) // flush messages in the processor into the sender
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func getStrategy(
 	inputChan chan *message.Message,
 	outputChan chan *message.Payload,

--- a/pkg/logs/processor/encoder.go
+++ b/pkg/logs/processor/encoder.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package processor provides log message processing functionality
 package processor
 
 import (

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package ad provides autodiscovery-based log scheduling
 package ad
 
 import (
@@ -189,7 +189,7 @@ func configName(config integration.Config) string {
 	return config.Provider
 }
 
-// createsSources creates new sources from an integration config,
+// CreateSources creates new sources from an integration config,
 // returns an error if the parsing failed.
 func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 	var configs []*logsConfig.LogsConfig

--- a/pkg/logs/schedulers/base_test.go
+++ b/pkg/logs/schedulers/base_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package schedulers provides log source scheduling functionality
 package schedulers
 
 import (
@@ -20,7 +20,6 @@ type testSched struct {
 	stopped bool
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (t *testSched) Start(_ SourceManager) {
 	t.started = true
 }

--- a/pkg/logs/schedulers/channel/scheduler.go
+++ b/pkg/logs/schedulers/channel/scheduler.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package channel provides a channel-based log scheduler
 package channel
 
 import (

--- a/pkg/logs/sds/reconfigure.go
+++ b/pkg/logs/sds/reconfigure.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive
+// Package sds provides sensitive data scanning functionality for logs
 package sds
 
 import (
@@ -12,6 +12,7 @@ import (
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
+// ReconfigureOrderType is a type of reconfiguration order
 type ReconfigureOrderType string
 
 const waitForConfigField = "logs_config.sds.wait_for_configuration"

--- a/pkg/logs/sds/rules.go
+++ b/pkg/logs/sds/rules.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive
+// Package sds provides sensitive data scanning functionality for logs
 package sds
 
 // RulesConfig as sent by the Remote Configuration.

--- a/pkg/logs/sds/rules_test.go
+++ b/pkg/logs/sds/rules_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive
+// Package sds provides sensitive data scanning functionality for logs
 package sds
 
 import (

--- a/pkg/logs/sds/scanner.go
+++ b/pkg/logs/sds/scanner.go
@@ -5,7 +5,7 @@
 
 //go:build sds
 
-//nolint:revive
+// Package sds provides sensitive data scanning functionality for logs
 package sds
 
 import (

--- a/pkg/logs/sds/scanner_nosds.go
+++ b/pkg/logs/sds/scanner_nosds.go
@@ -5,6 +5,8 @@
 
 //go:build !sds
 
+// Package sds provides sensitive data scanning functionality for logs
+//
 //nolint:revive
 package sds
 

--- a/pkg/logs/sds/scanner_test.go
+++ b/pkg/logs/sds/scanner_test.go
@@ -5,7 +5,7 @@
 
 //go:build sds
 
-//nolint:revive
+// Package sds provides sensitive data scanning functionality for logs
 package sds
 
 import (

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package sender provides log message sending functionality
 package sender
 
 import (

--- a/pkg/logs/sender/stream_strategy_test.go
+++ b/pkg/logs/sender/stream_strategy_test.go
@@ -42,7 +42,6 @@ func TestStreamStrategy(t *testing.T) {
 	s.Stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestStreamStrategyShouldNotBlockWhenForceStopping(_ *testing.T) {
 	input := make(chan *message.Message)
 	output := make(chan *message.Payload)

--- a/pkg/logs/sender/worker.go
+++ b/pkg/logs/sender/worker.go
@@ -193,8 +193,9 @@ func noopDestinationsSink(bufferSize int) chan *message.Payload {
 	sink := make(chan *message.Payload, bufferSize)
 	go func() {
 		// drain channel, stop when channel is closed
-		//nolint:revive // TODO(AML) Fix revive linter
-		for range sink {
+		for msg := range sink {
+			// Consume messages from channel until closed
+			_ = msg
 		}
 	}()
 	return sink

--- a/pkg/logs/sender/worker_test.go
+++ b/pkg/logs/sender/worker_test.go
@@ -80,7 +80,6 @@ func TestSender(t *testing.T) {
 	destinationsCtx.Stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestSenderSingleDestination(t *testing.T) {
 	cfg := configmock.New(t)
 	input := make(chan *message.Payload, 1)
@@ -112,7 +111,6 @@ func TestSenderSingleDestination(t *testing.T) {
 	worker.stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestSenderDualReliableDestination(t *testing.T) {
 	cfg := configmock.New(t)
 	input := make(chan *message.Payload, 1)
@@ -151,7 +149,6 @@ func TestSenderDualReliableDestination(t *testing.T) {
 	worker.stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestSenderUnreliableAdditionalDestination(t *testing.T) {
 	cfg := configmock.New(t)
 	input := make(chan *message.Payload, 1)
@@ -240,7 +237,6 @@ func TestSenderUnreliableStopsWhenMainFails(t *testing.T) {
 	worker.stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestSenderReliableContinuseWhenOneFails(t *testing.T) {
 	cfg := configmock.New(t)
 	input := make(chan *message.Payload, 1)
@@ -290,7 +286,6 @@ func TestSenderReliableContinuseWhenOneFails(t *testing.T) {
 	worker.stop()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func TestSenderReliableWhenOneFailsAndRecovers(t *testing.T) {
 	cfg := configmock.New(t)
 	input := make(chan *message.Payload, 1)

--- a/pkg/logs/service/service.go
+++ b/pkg/logs/service/service.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package service provides log service abstraction
 package service
 
 // Service represents a process to tail logs for.

--- a/pkg/logs/sources/config_source.go
+++ b/pkg/logs/sources/config_source.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package sources provides log source configuration and management
 package sources
 
 // ConfigSources receives file paths to log configs and creates sources. The sources are added to a channel and read by the launcher.

--- a/pkg/logs/sources/replaceable_source.go
+++ b/pkg/logs/sources/replaceable_source.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
 package sources
 
 import (

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package status provides log agent status information
 package status
 
 import (
@@ -123,7 +123,7 @@ func (b *Builder) getTailers() []Tailer {
 		info := tailer.GetInfo().Rendered()
 
 		tailerStatus = append(tailerStatus, Tailer{
-			Id:   tailer.GetId(),
+			ID:   tailer.GetID(),
 			Type: tailer.GetType(),
 			Info: info,
 		})

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -58,10 +58,9 @@ type Source struct {
 	Info          map[string][]string    `json:"info"`
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Tailer provides status information about a log tailer
 type Tailer struct {
-	//nolint:revive // TODO(AML) Fix revive linter
-	Id   string              `json:"id"`
+	ID   string              `json:"id"`
 	Type string              `json:"type"`
 	Info map[string][]string `json:"info"`
 }

--- a/pkg/logs/status/utils/info.go
+++ b/pkg/logs/status/utils/info.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package utils provides status information utilities
 package utils
 
 import (

--- a/pkg/logs/tailers/channel/tailer.go
+++ b/pkg/logs/tailers/channel/tailer.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package channel provides a channel-based log tailer implementation
 package channel
 
 import (

--- a/pkg/logs/tailers/container/reader.go
+++ b/pkg/logs/tailers/container/reader.go
@@ -5,7 +5,7 @@
 
 //go:build kubelet || docker
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package container provides container-related log tailers
 package container
 
 import (

--- a/pkg/logs/tailers/container/reader_test.go
+++ b/pkg/logs/tailers/container/reader_test.go
@@ -5,6 +5,7 @@
 
 //go:build docker
 
+// Package container provides container-related log tailers
 package container
 
 import (
@@ -39,8 +40,7 @@ type ReadErrorMock struct {
 	io.Reader
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (r *ReadErrorMock) Read(p []byte) (int, error) {
+func (r *ReadErrorMock) Read(_ []byte) (int, error) {
 	return 0, errFoo
 }
 

--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package container provides container-related log tailers
 package container
 
 import (

--- a/pkg/logs/tailers/container/tailer_test.go
+++ b/pkg/logs/tailers/container/tailer_test.go
@@ -5,6 +5,7 @@
 
 //go:build kubelet || docker
 
+// Package container provides container-related log tailers
 package container
 
 import (

--- a/pkg/logs/tailers/file/file.go
+++ b/pkg/logs/tailers/file/file.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
 package file
 
 import (
@@ -46,6 +45,7 @@ func (t *File) GetScanKey() string {
 	return t.Path
 }
 
-func (f *File) Identifier() string {
-	return fmt.Sprintf("file:%s", f.Path)
+// Identifier returns a unique identifier for this file
+func (t *File) Identifier() string {
+	return fmt.Sprintf("file:%s", t.Path)
 }

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -435,17 +435,17 @@ func (t *Tailer) Source() *sources.LogSource {
 	return t.file.Source.UnderlyingSource()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (t *Tailer) GetId() string {
+// GetID returns the tailer's unique identifier
+func (t *Tailer) GetID() string {
 	return t.file.GetScanKey()
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// GetType returns the tailer type
 func (t *Tailer) GetType() string {
 	return "file"
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
+// GetInfo returns the tailer's status info registry
 func (t *Tailer) GetInfo() *status.InfoRegistry {
 	return t.info
 }

--- a/pkg/logs/tailers/journald/docker.go
+++ b/pkg/logs/tailers/journald/docker.go
@@ -5,7 +5,7 @@
 
 //go:build systemd
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package journald provides journald-based log launchers (no-op for non-systemd builds)
 package journald
 
 import (

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -493,8 +493,8 @@ func (t *Tailer) Identifier() string {
 // Identifier returns the unique identifier of the current journald config
 func Identifier(config *config.LogsConfig) string {
 	id := "default"
-	if config.ConfigId != "" {
-		id = config.ConfigId
+	if config.ConfigID != "" {
+		id = config.ConfigID
 	} else if config.Path != "" {
 		id = config.Path
 	}

--- a/pkg/logs/tailers/journald/tailer_test.go
+++ b/pkg/logs/tailers/journald/tailer_test.go
@@ -35,51 +35,42 @@ type MockJournal struct {
 	entries  []*sdjournal.JournalEntry
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) AddMatch(match string) error {
+func (m *MockJournal) AddMatch(_ string) error {
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) AddDisjunction() error {
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) SeekTail() error {
 	m.seekTail++
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) SeekHead() error {
 	m.seekHead++
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) Wait(timeout time.Duration) int {
+func (m *MockJournal) Wait(_ time.Duration) int {
 	time.Sleep(time.Millisecond)
 	return 0
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) SeekCursor(cursor string) error {
 	m.cursor = cursor
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (m *MockJournal) NextSkip(skip uint64) (uint64, error) {
+func (m *MockJournal) NextSkip(_ uint64) (uint64, error) {
 	return 0, nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) Close() error {
 	return nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) Next() (uint64, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -87,7 +78,6 @@ func (m *MockJournal) Next() (uint64, error) {
 	return uint64(len(m.entries)), nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) Previous() (uint64, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -95,7 +85,6 @@ func (m *MockJournal) Previous() (uint64, error) {
 	return uint64(len(m.entries)), nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) GetEntry() (*sdjournal.JournalEntry, error) {
 	m.m.Lock()
 	defer m.m.Unlock()
@@ -110,7 +99,6 @@ func (m *MockJournal) GetEntry() (*sdjournal.JournalEntry, error) {
 	return m.entries[0], nil
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (m *MockJournal) GetCursor() (string, error) {
 	return "", nil
 }

--- a/pkg/logs/tailers/socket/tailer.go
+++ b/pkg/logs/tailers/socket/tailer.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package socket provides socket-based log tailers
 package socket
 
 import (

--- a/pkg/logs/tailers/tailer.go
+++ b/pkg/logs/tailers/tailer.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-present Datadog, Inc.
 
-//nolint:revive // TODO(AML) Fix revive linter
+// Package tailers provides the base interface and tracking for log tailers
 package tailers
 
 import (
@@ -12,7 +12,7 @@ import (
 
 // Tailer is the base interface for a tailer.
 type Tailer interface {
-	GetId() string
+	GetID() string
 	GetType() string
 	GetInfo() *status.InfoRegistry
 }

--- a/pkg/logs/tailers/tailer_tracker.go
+++ b/pkg/logs/tailers/tailer_tracker.go
@@ -75,14 +75,14 @@ func (t *TailerContainer[T]) Contains(id string) bool {
 func (t *TailerContainer[T]) Add(tailer T) {
 	t.Lock()
 	defer t.Unlock()
-	t.tailers[tailer.GetId()] = tailer
+	t.tailers[tailer.GetID()] = tailer
 }
 
 // Remove removes a tailer from the container.
 func (t *TailerContainer[T]) Remove(tailer T) {
 	t.Lock()
 	defer t.Unlock()
-	delete(t.tailers, tailer.GetId())
+	delete(t.tailers, tailer.GetID())
 }
 
 // All returns a slice of all tailers in the container.

--- a/pkg/logs/tailers/tailer_tracker_test.go
+++ b/pkg/logs/tailers/tailer_tracker_test.go
@@ -8,8 +8,9 @@ package tailers
 import (
 	"testing"
 
-	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 	assert "github.com/stretchr/testify/require"
+
+	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 )
 
 type TestTailer1 struct {
@@ -24,8 +25,7 @@ func NewTestTailer1(id string) *TestTailer1 {
 	}
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (t *TestTailer1) GetId() string {
+func (t *TestTailer1) GetID() string {
 	return t.id
 }
 func (t *TestTailer1) GetType() string {
@@ -47,17 +47,14 @@ func NewTestTailer2(id string) *TestTailer2 {
 	}
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
-func (t *TestTailer2) GetId() string {
+func (t *TestTailer2) GetID() string {
 	return t.id
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (t *TestTailer2) GetType() string {
 	return "test"
 }
 
-//nolint:revive // TODO(AML) Fix revive linter
 func (t *TestTailer2) GetInfo() *status.InfoRegistry {
 	return t.info
 }
@@ -82,7 +79,7 @@ func TestCollectAllTailers(t *testing.T) {
 
 	results := make(map[string]bool)
 	for _, t := range tailers {
-		results[t.GetId()] = true
+		results[t.GetID()] = true
 	}
 
 	for _, k := range []string{"1a", "1b", "2a", "2b"} {
@@ -93,7 +90,7 @@ func TestCollectAllTailers(t *testing.T) {
 
 	results = make(map[string]bool)
 	for _, t := range tailers {
-		results[t.GetId()] = true
+		results[t.GetID()] = true
 	}
 
 	for _, k := range []string{"1a", "2a", "2b"} {

--- a/pkg/logs/tailers/windowsevent/tailer.go
+++ b/pkg/logs/tailers/windowsevent/tailer.go
@@ -5,7 +5,7 @@
 
 //go:build windows
 
-//nolint:revive // TODO(WINA) Fix revive linter
+// Package windowsevent provides Windows event log tailers
 package windowsevent
 
 import (

--- a/pkg/logs/util/testutils/test_utils.go
+++ b/pkg/logs/util/testutils/test_utils.go
@@ -13,8 +13,9 @@ import "github.com/DataDog/datadog-agent/pkg/logs/sources"
 func consumeSources(sources *sources.LogSources) {
 	go func() {
 		sources := sources.GetAddedForType("foo")
-		//nolint:revive // TODO(AML) Fix revive linter
-		for range sources {
+		for source := range sources {
+			// Consume from channel to prevent blocking
+			_ = source
 		}
 	}()
 }


### PR DESCRIPTION
### What does this PR do?
Before this change:
```
grep -r '//nolint:revive // TODO' --include="*.go" | grep 'pkg/logs\|comp/logs' | wc -l
112
```

After this change:
```
grep -r '//nolint:revive // TODO' --include="*.go" | grep 'pkg/logs\|comp/logs' | wc -l
0
```

All lingering TODOs for enabling revive have been removed and addressed. 

### Motivation

Address long standing disabled linter. 

### Describe how you validated your changes

This is a non functional change. If tests pass we should be good. 
