### PR TITLE
system-probe: enable configsync component

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
@@ -83,6 +84,8 @@ type cliParams struct {
 	// pidfilePath contains the value of the --pidfile flag.
 	pidfilePath string
 }
+
+const configSyncTimeout = 10 * time.Second
 
 // Commands returns a slice of subcommands for the 'system-probe' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
@@ -152,6 +155,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))
 				}),
 				remotehostnameimpl.Module(),
+				configsyncimpl.Module(configsyncimpl.NewParams(configSyncTimeout, true, configSyncTimeout)),
 			)
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds a dependency on the configsync component for the `run` CLI command of the system-probe, allowing to sync some config options from the core agent.

The component is configured to force a first sync on start (with a 10 seconds timeout) so that we can be sure the sync is done before the config is read during the system-probe boot procedure.

Side note: configsync uses the new-ish agent_ipc mechanism that is disabled by default for now (but enabled internally).

### Motivation

### Describe how you validated your changes

### Additional Notes
