### PR TITLE
[CWS] use cookie helper to resolver flow pid

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
+++ b/pkg/security/ebpf/c/include/helpers/network/pid_resolver.h
@@ -43,13 +43,25 @@ __attribute__((always_inline)) void resolve_pid_from_flow_pid(struct packet_t *p
     pkt->pid = get_flow_pid(&pid_route);
 }
 
-__attribute__((always_inline)) void resolve_pid(struct packet_t *pkt) {
+__attribute__((always_inline)) void resolve_pid(struct __sk_buff *skb, struct packet_t *pkt) {
+    // direct pid from sched_cls
     u64 sched_cls_has_current_pid_tgid_helper = 0;
     LOAD_CONSTANT("sched_cls_has_current_pid_tgid_helper", sched_cls_has_current_pid_tgid_helper);
     if (sched_cls_has_current_pid_tgid_helper) {
         u64 pid_tgid = bpf_get_current_pid_tgid();
         pkt->pid = pid_tgid >> 32;
     }
+
+    // pid from socket cookie
+    if (pkt->pid == 0) {
+        u64 cookie = bpf_get_socket_cookie(skb);
+        u32 *pid = bpf_map_lookup_elem(&sock_cookie_pid, &cookie);
+        if (pid) {
+            pkt->pid = *pid;
+        }
+    }
+
+    // pid from flow pid
     if (pkt->pid == 0) {
         resolve_pid_from_flow_pid(pkt);
     }

--- a/pkg/security/ebpf/c/include/hooks/all.h
+++ b/pkg/security/ebpf/c/include/hooks/all.h
@@ -43,6 +43,7 @@
 #include "network/accept.h"
 #include "network/bind.h"
 #include "network/connect.h"
+#include "network/socket.h"
 
 #ifndef DO_NOT_USE_TC
 #include "network/dns.h"

--- a/pkg/security/ebpf/c/include/hooks/network/socket.h
+++ b/pkg/security/ebpf/c/include/hooks/network/socket.h
@@ -1,0 +1,34 @@
+#ifndef _HOOKS_SOCKET_H_
+#define _HOOKS_SOCKET_H_
+
+SEC("cgroup/sock_create")
+int hook_sock_create(struct bpf_sock *ctx) {
+    if (ctx->family != AF_INET && ctx->family != AF_INET6) {
+        return 1;
+    }
+
+    u64 cookie = bpf_get_socket_cookie(ctx);
+    if (cookie == 0) {
+        return 1;
+    }
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    if (pid_tgid == 0) {
+        return 1;
+    }
+    u32 tgid = pid_tgid >> 32;
+
+    bpf_map_update_elem(&sock_cookie_pid, &cookie, &tgid, BPF_ANY);
+
+    return 1;
+}
+
+SEC("cgroup/sock_release")
+int hook_sock_release(struct bpf_sock *ctx)
+{
+    u64 cookie = bpf_get_socket_cookie(ctx);
+    bpf_map_delete_elem(&sock_cookie_pid, &cookie);
+    return 1;
+}
+
+#endif

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -12,7 +12,7 @@ int classifier_ingress(struct __sk_buff *skb) {
     if (!pkt) {
         return TC_ACT_UNSPEC;
     }
-    resolve_pid(pkt);
+    resolve_pid(skb, pkt);
 
     return route_pkt(skb, pkt, INGRESS);
 };
@@ -23,7 +23,7 @@ int classifier_egress(struct __sk_buff *skb) {
     if (!pkt) {
         return TC_ACT_UNSPEC;
     }
-    resolve_pid(pkt);
+    resolve_pid(skb, pkt);
 
     return route_pkt(skb, pkt, EGRESS);
 };
@@ -73,7 +73,7 @@ int classifier_raw_packet_ingress(struct __sk_buff *skb) {
     if (!pkt) {
         return TC_ACT_UNSPEC;
     }
-    resolve_pid(pkt);
+    resolve_pid(skb, pkt);
 
     if (!is_raw_packet_allowed(pkt)) {
         return TC_ACT_UNSPEC;
@@ -98,7 +98,7 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
     if (!pkt) {
         return TC_ACT_UNSPEC;
     }
-    resolve_pid(pkt);
+    resolve_pid(skb, pkt);
 
     u64 sched_cls_has_current_cgroup_id_helper = 0;
     LOAD_CONSTANT("sched_cls_has_current_cgroup_id_helper", sched_cls_has_current_cgroup_id_helper);

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -89,6 +89,7 @@ BPF_LRU_MAP(ns_flow_to_network_stats, struct namespaced_flow_t, struct network_s
 BPF_LRU_MAP(sock_meta, void *, struct sock_meta_t, 4096);
 BPF_LRU_MAP(dns_responses_sent_to_userspace, u16, struct dns_responses_sent_to_userspace_lru_entry_t, 1024)
 BPF_LRU_MAP(capabilities_usage, struct capabilities_usage_key_t, struct capabilities_usage_entry_t, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(sock_cookie_pid, u64, u32, 40960); // TODO adapt the size dynamically
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -89,7 +89,7 @@ BPF_LRU_MAP(ns_flow_to_network_stats, struct namespaced_flow_t, struct network_s
 BPF_LRU_MAP(sock_meta, void *, struct sock_meta_t, 4096);
 BPF_LRU_MAP(dns_responses_sent_to_userspace, u16, struct dns_responses_sent_to_userspace_lru_entry_t, 1024)
 BPF_LRU_MAP(capabilities_usage, struct capabilities_usage_key_t, struct capabilities_usage_entry_t, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(sock_cookie_pid, u64, u32, 40960); // TODO adapt the size dynamically
+BPF_LRU_MAP(sock_cookie_pid, u64, u32, 1); // max entries will be overridden at runtime
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -182,3 +182,9 @@ func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentCgroupId) == nil
 }
+
+// HasBpfGetSocketCookieForCgroupSocket returns if the kernel supports bpf_get_socket_cookie for Cgroup Socket program type
+// https://github.com/torvalds/linux/commit/c5dbb89fc2ac013afe67b9e4fcb3743c02b567cd
+func (k *Version) HasBpfGetSocketCookieForCgroupSocket() bool {
+	return features.HaveProgramHelper(ebpf.CGroupSock, asm.FnGetSocketCookie) == nil
+}

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -85,3 +85,9 @@ func (k *Version) HasBpfGetCurrentPidTgidForSchedCLS() bool {
 func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return false
 }
+
+// HasBpfGetSocketCookieForCgroupSocket returns if the kernel supports bpf_get_socket_cookie for Cgroup Socket program type
+// https://github.com/torvalds/linux/commit/c5dbb89fc2ac013afe67b9e4fcb3743c02b567cd
+func (k *Version) HasBpfGetSocketCookieForCgroupSocket() bool {
+	return false
+}

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -204,6 +204,7 @@ type MapSpecEditorOpts struct {
 	NetworkSkStorageEnabled       bool
 	SpanTrackMaxCount             int
 	CapabilitiesMonitoringEnabled bool
+	CgroupSocketEnabled           bool
 }
 
 // AllMapSpecEditors returns the list of map editors
@@ -328,6 +329,13 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			MaxEntries: opts.RingBufferSize,
 			Type:       ebpf.RingBuf,
 			EditorFlag: manager.EditMaxEntries | manager.EditType | manager.EditKeyValue,
+		}
+	}
+
+	if opts.CgroupSocketEnabled {
+		editors["sock_cookie_pid"] = manager.MapSpecEditor{
+			MaxEntries: 40960,
+			EditorFlag: manager.EditMaxEntries,
 		}
 	}
 

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -117,6 +117,7 @@ func AllProbes(fentry bool, cgroup2MountPoint string) []*manager.Probe {
 	allProbes = append(allProbes, getSetrlimitProbes(fentry)...)
 	allProbes = append(allProbes, getCapabilitiesMonitoringProbes()...)
 	allProbes = append(allProbes, getPrCtlProbes(fentry)...)
+	allProbes = append(allProbes, getSocketProbes(cgroup2MountPoint)...)
 
 	allProbes = append(allProbes,
 		&manager.Probe{

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -334,7 +334,7 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 
 	if opts.CgroupSocketEnabled {
 		editors["sock_cookie_pid"] = manager.MapSpecEditor{
-			MaxEntries: 40960,
+			MaxEntries: 40000,
 			EditorFlag: manager.EditMaxEntries,
 		}
 	}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -74,6 +74,12 @@ func NetworkSelectors() []manager.ProbesSelector {
 			hookFunc("rethook_dev_new_index"),
 			hookFunc("hook___dev_get_by_index"),
 		}},
+
+		// socket probes
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			hookFunc("hook_sock_create"),
+			hookFunc("hook_sock_release"),
+		}},
 	}
 }
 

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -37,7 +37,7 @@ func NetworkVethSelectors() []manager.ProbesSelector {
 }
 
 // NetworkSelectors is the list of probes that should be activated when the network is enabled
-func NetworkSelectors(hasBpfGetSocketCookieForCgroupSocket bool) []manager.ProbesSelector {
+func NetworkSelectors(hasCgroupSocket bool) []manager.ProbesSelector {
 	ps := []manager.ProbesSelector{
 		// flow classification probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
@@ -76,7 +76,7 @@ func NetworkSelectors(hasBpfGetSocketCookieForCgroupSocket bool) []manager.Probe
 		}},
 	}
 
-	if hasBpfGetSocketCookieForCgroupSocket {
+	if hasCgroupSocket {
 		ps = append(ps, &manager.BestEffort{Selectors: []manager.ProbesSelector{
 			hookFunc("hook_sock_create"),
 			hookFunc("hook_sock_release"),
@@ -132,7 +132,7 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 }
 
 // GetSelectorsPerEventType returns the list of probes that should be activated for each event
-func GetSelectorsPerEventType(hasFentry bool, hasBpfGetSocketCookieForCgroupSocket bool) map[eval.EventType][]manager.ProbesSelector {
+func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.EventType][]manager.ProbesSelector {
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -586,7 +586,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasBpfGetSocketCookieForCgroupSock
 			}},
 		},
 		"prctl": {
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "prctl", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "prctl", hasFentry, EntryAndExit)},
 		},
 	}
 
@@ -599,7 +599,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasBpfGetSocketCookieForCgroupSock
 	for _, networkEventType := range networkEventTypes {
 		selectorsPerEventTypeStore[networkEventType] = []manager.ProbesSelector{
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.AllOf{Selectors: NetworkSelectors(hasBpfGetSocketCookieForCgroupSocket)},
+				&manager.AllOf{Selectors: NetworkSelectors(hasCgroupSocket)},
 				&manager.AllOf{Selectors: NetworkVethSelectors()},
 			}},
 		}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -37,8 +37,8 @@ func NetworkVethSelectors() []manager.ProbesSelector {
 }
 
 // NetworkSelectors is the list of probes that should be activated when the network is enabled
-func NetworkSelectors() []manager.ProbesSelector {
-	return []manager.ProbesSelector{
+func NetworkSelectors(hasBpfGetSocketCookieForCgroupSocket bool) []manager.ProbesSelector {
+	ps := []manager.ProbesSelector{
 		// flow classification probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			hookFunc("hook_accept"),
@@ -74,13 +74,16 @@ func NetworkSelectors() []manager.ProbesSelector {
 			hookFunc("rethook_dev_new_index"),
 			hookFunc("hook___dev_get_by_index"),
 		}},
+	}
 
-		// socket probes
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
+	if hasBpfGetSocketCookieForCgroupSocket {
+		ps = append(ps, &manager.BestEffort{Selectors: []manager.ProbesSelector{
 			hookFunc("hook_sock_create"),
 			hookFunc("hook_sock_release"),
-		}},
+		}})
 	}
+
+	return ps
 }
 
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
@@ -129,7 +132,7 @@ func GetCapabilitiesMonitoringSelectors() []manager.ProbesSelector {
 }
 
 // GetSelectorsPerEventType returns the list of probes that should be activated for each event
-func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSelector {
+func GetSelectorsPerEventType(hasFentry bool, hasBpfGetSocketCookieForCgroupSocket bool) map[eval.EventType][]manager.ProbesSelector {
 	selectorsPerEventTypeStore := map[eval.EventType][]manager.ProbesSelector{
 		// The following probes will always be activated, regardless of the loaded rules
 		"*": {
@@ -176,25 +179,25 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_cgroup_tasks_write"),
 				hookFunc("hook_cgroup1_tasks_write"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execve", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execveat", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid16", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "capset", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execve", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "execveat", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setuid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setgid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsuid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setfsgid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setreuid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setregid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresuid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setresgid16", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "capset", hasFentry, EntryAndExit)},
 
 			// File Attributes
 			hookFunc("hook_security_inode_setattr"),
@@ -206,13 +209,13 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_vfs_truncate"),
 				hookFunc("hook_do_truncate"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open", fentry, EntryAndExit, true)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "creat", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "truncate", fentry, EntryAndExit, true)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ftruncate", fentry, EntryAndExit, true)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat2", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_by_handle_at", fentry, EntryAndExit, true)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open", hasFentry, EntryAndExit, true)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "creat", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "truncate", hasFentry, EntryAndExit, true)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ftruncate", hasFentry, EntryAndExit, true)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "openat2", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_by_handle_at", hasFentry, EntryAndExit, true)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_io_openat"),
 				hookFunc("hook_io_openat2"),
@@ -246,11 +249,11 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("rethook_alloc_vfsmnt"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mount", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsmount", fentry, EntryAndExit, false)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_tree", fentry, EntryAndExit, false)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "umount", fentry, Exit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unshare", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mount", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsmount", hasFentry, EntryAndExit, false)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "open_tree", hasFentry, EntryAndExit, false)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "umount", hasFentry, Exit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unshare", hasFentry, EntryAndExit)},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_attach_mnt"),
 				hookFunc("hook___attach_mnt"),
@@ -262,20 +265,20 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_vfs_rename"),
 				hookFunc("hook_mnt_want_write"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rename", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rename", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "renameat", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: append(
 				[]manager.ProbesSelector{
 					hookFunc("hook_do_renameat2"),
 					hookFunc("rethook_do_renameat2"),
 				},
-				ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", fentry, EntryAndExit)...)},
+				ExpandSyscallProbesSelector(SecurityAgentUID, "renameat2", hasFentry, EntryAndExit)...)},
 
 			// unlink rmdir probes
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_mnt_want_write"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlinkat", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_do_unlinkat"),
 				hookFunc("rethook_do_unlinkat"),
@@ -285,7 +288,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_inode_rmdir"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rmdir", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "rmdir", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_do_rmdir"),
 				hookFunc("rethook_do_rmdir"),
@@ -295,7 +298,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_vfs_unlink"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlink", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "unlink", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_do_linkat"),
 				hookFunc("rethook_do_linkat"),
@@ -316,8 +319,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					hookFunc("rethook___lookup_hash"),
 				}},
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "link", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "linkat", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "link", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "linkat", hasFentry, EntryAndExit)},
 
 			// selinux
 			// This needs to be best effort, as sel_write_disable is in the process of being removed
@@ -333,10 +336,10 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_mnt_want_write"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat2", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chmod", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmod", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchmodat2", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture chown events
@@ -348,13 +351,13 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_mnt_want_write_file"),
 				hookFunc("hook_mnt_want_write_file_path"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown16", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchownat", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown16", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chown16", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchown16", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchownat", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lchown16", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture mkdir events
@@ -366,8 +369,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					hookFunc("hook_security_path_mkdir"),
 				}},
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdirat", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdir", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mkdirat", hasFentry, EntryAndExit)},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_do_mkdirat"),
 				hookFunc("rethook_do_mkdirat"),
@@ -383,9 +386,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_mnt_want_write_file"),
 				hookFunc("hook_mnt_want_write_file_path"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "removexattr", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fremovexattr", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lremovexattr", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "removexattr", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fremovexattr", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lremovexattr", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture setxattr events
@@ -404,9 +407,9 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_mnt_want_write_file"),
 				hookFunc("hook_mnt_want_write_file_path"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setxattr", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsetxattr", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lsetxattr", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setxattr", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fsetxattr", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "lsetxattr", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture utimes events
@@ -414,14 +417,14 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_mnt_want_write"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", fentry, EntryAndExit|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", fentry, EntryAndExit|ExpandTime32)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit, true)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", fentry, EntryAndExit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utime32", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimes", hasFentry, EntryAndExit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "utimensat", hasFentry, EntryAndExit|ExpandTime32)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", hasFentry, EntryAndExit, true)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "futimesat", hasFentry, EntryAndExit|ExpandTime32)},
 		},
 
 		// List of probes required to capture bpf events
@@ -431,12 +434,12 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_security_bpf_prog"),
 				hookFunc("hook_check_helper_call"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bpf", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bpf", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture ptrace events
 		"ptrace": {
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "ptrace", hasFentry, EntryAndExit)},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_ptrace_check_attach"),
 				hookFunc("hook_arch_ptrace"),
@@ -460,7 +463,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_file_mprotect"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mprotect", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "mprotect", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture kernel load_module events
@@ -475,13 +478,13 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					hookFunc("hook_module_param_sysfs_setup"),
 				}},
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "init_module", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "finit_module", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture kernel unload_module events
 		"unload_module": {
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "delete_module", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "delete_module", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture signal events
@@ -490,12 +493,12 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("rethook_check_kill_permission"),
 				hookFunc("hook_check_kill_permission"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", fentry, Entry)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "kill", hasFentry, Entry)},
 		},
 
 		// List of probes required to capture setsockopt events
 		"setsockopt": {
-			&manager.AllOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setsockopt", fentry, EntryAndExit)},
+			&manager.AllOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setsockopt", hasFentry, EntryAndExit)},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_socket_setsockopt"),
 				hookFunc("hook_sk_attach_filter"),
@@ -506,7 +509,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 
 		// List of probes required to capture splice events
 		"splice": {
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "splice", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "splice", hasFentry, EntryAndExit)},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_get_pipe_info"),
 				hookFunc("rethook_get_pipe_info"),
@@ -527,7 +530,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_io_bind"),
 				hookFunc("rethook_io_bind"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bind", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "bind", hasFentry, EntryAndExit)},
 		},
 		// List of probes required to capture connect events
 		"connect": {
@@ -538,7 +541,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 				hookFunc("hook_io_connect"),
 				hookFunc("rethook_io_connect"),
 			}},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "connect", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "connect", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture chdir events
@@ -546,8 +549,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_set_fs_pwd"),
 			}},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chdir", fentry, EntryAndExit)},
-			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchdir", fentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "chdir", hasFentry, EntryAndExit)},
+			&manager.OneOf{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "fchdir", hasFentry, EntryAndExit)},
 		},
 
 		// List of probes required to capture network_flow_monitor events
@@ -576,8 +579,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 			}},
 		},
 		"setrlimit": {
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setrlimit", fentry, EntryAndExit)},
-			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "prlimit64", fentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "setrlimit", hasFentry, EntryAndExit)},
+			&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(SecurityAgentUID, "prlimit64", hasFentry, EntryAndExit)},
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_security_task_setrlimit"),
 			}},
@@ -596,7 +599,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 	for _, networkEventType := range networkEventTypes {
 		selectorsPerEventTypeStore[networkEventType] = []manager.ProbesSelector{
 			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				&manager.AllOf{Selectors: NetworkSelectors()},
+				&manager.AllOf{Selectors: NetworkSelectors(hasBpfGetSocketCookieForCgroupSocket)},
 				&manager.AllOf{Selectors: NetworkVethSelectors()},
 			}},
 		}

--- a/pkg/security/ebpf/probes/socket.go
+++ b/pkg/security/ebpf/probes/socket.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package probes holds probes related files
+package probes
+
+import manager "github.com/DataDog/ebpf-manager"
+
+func getSocketProbes(cgroup2MountPoint string) []*manager.Probe {
+	return []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_sock_create",
+			},
+			CGroupPath: cgroup2MountPoint,
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_sock_release",
+			},
+			CGroupPath: cgroup2MountPoint,
+		},
+	}
+}

--- a/pkg/security/ebpf/probes/socket.go
+++ b/pkg/security/ebpf/probes/socket.go
@@ -8,7 +8,13 @@
 // Package probes holds probes related files
 package probes
 
-import manager "github.com/DataDog/ebpf-manager"
+import (
+	"fmt"
+
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
 
 func getSocketProbes(cgroup2MountPoint string) []*manager.Probe {
 	return []*manager.Probe{
@@ -27,4 +33,48 @@ func getSocketProbes(cgroup2MountPoint string) []*manager.Probe {
 			CGroupPath: cgroup2MountPoint,
 		},
 	}
+}
+
+// CheckCgroupSocketReturnCode checks if the return code is 1(accept)
+//
+//nolint:unused,deadcode
+func CheckCgroupSocketReturnCode(progSpecs map[string]*ebpf.ProgramSpec) error {
+	for _, progSpec := range progSpecs {
+		if progSpec.Type == ebpf.CGroupSock {
+			if IsProgAllowedToTCActShot(progSpec.Name) {
+				continue
+			}
+
+			r0 := int32(255)
+
+			for _, inst := range progSpec.Instructions {
+				fmt.Printf(">> %v\n", inst)
+
+				class := inst.OpCode.Class()
+				if class.IsJump() {
+					if inst.OpCode.JumpOp() == asm.Exit {
+						fmt.Printf("code: %d\n", r0)
+
+						if r0 != 1 {
+							return fmt.Errorf("cgroup sock program %s is not using 1 as return code, %d, %v", progSpec.Name, r0, progSpec.Instructions)
+						}
+					}
+				} else {
+					op := inst.OpCode
+					switch op {
+					case asm.Mov.Op(asm.ImmSource),
+						asm.LoadImmOp(asm.DWord),
+						asm.LoadImmOp(asm.Word),
+						asm.LoadImmOp(asm.Half),
+						asm.LoadImmOp(asm.Byte):
+						if inst.Dst == asm.R0 {
+							r0 = int32(inst.Constant)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/security/ebpf/probes/socket.go
+++ b/pkg/security/ebpf/probes/socket.go
@@ -56,8 +56,6 @@ func CheckCgroupSocketReturnCode(progSpecs map[string]*ebpf.ProgramSpec) error {
 			r0 := int32(255)
 
 			for _, inst := range progSpec.Instructions {
-				fmt.Printf(">> %v\n", inst)
-
 				class := inst.OpCode.Class()
 				if class.IsJump() {
 					if inst.OpCode.JumpOp() == asm.Exit {

--- a/pkg/security/ebpf/probes/socket.go
+++ b/pkg/security/ebpf/probes/socket.go
@@ -35,6 +35,14 @@ func getSocketProbes(cgroup2MountPoint string) []*manager.Probe {
 	}
 }
 
+// GetAllSocketProgramFunctions returns the list of socket functions
+func GetAllSocketProgramFunctions() []string {
+	return []string{
+		"hook_sock_create",
+		"hook_sock_release",
+	}
+}
+
 // CheckCgroupSocketReturnCode checks if the return code is 1(accept)
 //
 //nolint:unused,deadcode

--- a/pkg/security/ebpf/tests/socket_test.go
+++ b/pkg/security/ebpf/tests/socket_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata && cgo
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+func TestCgroupSocketReturnCode(t *testing.T) {
+	t.Run("static", func(t *testing.T) {
+		err := probes.CheckCgroupSocketReturnCode(loadColSpec(t).Programs)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("ko", func(t *testing.T) {
+		insts := asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		}
+		progSpecs := make(map[string]*ebpf.ProgramSpec)
+		progSpecs["test"] = &ebpf.ProgramSpec{
+			Name:         "test",
+			Type:         ebpf.CGroupSock,
+			Instructions: insts,
+		}
+
+		err := probes.CheckCgroupSocketReturnCode(progSpecs)
+		if err == nil {
+			t.Error("expected error")
+		}
+	})
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1881,7 +1881,7 @@ func (p *EBPFProbe) updateProbes(ruleSetEventTypes []eval.EventType, needRawSysc
 	}
 
 	// extract probe to activate per the event types
-	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry) {
+	for eventType, selectors := range probes.GetSelectorsPerEventType(p.useFentry, p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket()) {
 		if (eventType == "*" || slices.Contains(requestedEventTypes, eventType) || p.isNeededForActivityDump(eventType) || p.isNeededForSecurityProfile(eventType) || p.config.Probe.EnableAllProbes) && p.validEventTypeForConfig(eventType) {
 			activatedProbes = append(activatedProbes, selectors...)
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2638,6 +2638,7 @@ func (p *EBPFProbe) initManagerOptionsMapSpecEditors() {
 		NetworkSkStorageEnabled:       p.isSKStorageSupported(),
 		SpanTrackMaxCount:             1,
 		CapabilitiesMonitoringEnabled: p.config.Probe.CapabilitiesMonitoringEnabled,
+		CgroupSocketEnabled:           p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket(),
 	}
 
 	if p.config.Probe.SpanTrackingEnabled {
@@ -2667,8 +2668,13 @@ func (p *EBPFProbe) initManagerOptionsExcludedFunctions() error {
 	// prevent some TC classifiers from loading
 	if !p.config.Probe.NetworkEnabled {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllTCProgramFunctions()...)
+		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllSocketProgramFunctions()...)
 	} else if !p.config.Probe.NetworkRawPacketEnabled {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetRawPacketTCProgramFunctions()...)
+	}
+
+	if !p.kernelVersion.HasBpfGetSocketCookieForCgroupSocket() {
+		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.GetAllSocketProgramFunctions()...)
 	}
 
 	// prevent some tal calls from loading

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -89,6 +89,7 @@ var bpfMapNames = []string{
 	"selinux_write_b",
 	"setsockopt_even",
 	"sk_storage_meta",
+	"sock_cookie_pid",
 	"sock_meta",
 	"span_tls",
 	"splice_entry_fl",

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -556,15 +556,6 @@ func (tm *testModule) WaitSignal(tb testing.TB, action func() error, cb onRuleHa
 	})
 }
 
-func (tm *testModule) WaitSignalWithoutProcessContext(tb testing.TB, action func() error, cb onRuleHandler) {
-	tb.Helper()
-
-	tm.waitSignal(tb, action, func(event *model.Event, rule *rules.Rule) error {
-		cb(event, rule)
-		return nil
-	})
-}
-
 //nolint:deadcode,unused
 func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
 	b, err := serializers.MarshalEvent(ev, nil)

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -556,6 +556,15 @@ func (tm *testModule) WaitSignal(tb testing.TB, action func() error, cb onRuleHa
 	})
 }
 
+func (tm *testModule) WaitSignalWithoutProcessContext(tb testing.TB, action func() error, cb onRuleHandler) {
+	tb.Helper()
+
+	tm.waitSignal(tb, action, func(event *model.Event, rule *rules.Rule) error {
+		cb(event, rule)
+		return nil
+	})
+}
+
 //nolint:deadcode,unused
 func (tm *testModule) marshalEvent(ev *model.Event) (string, error) {
 	b, err := serializers.MarshalEvent(ev, nil)

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -171,14 +171,15 @@ func TestRawPacket(t *testing.T) {
 			return
 		}
 
+		waitSignal := test.WaitSignalWithoutProcessContext
+
 		kv, err := kernel.NewKernelVersion()
 		if err != nil {
 			t.Errorf("failed to get kernel version: %s", err)
 			return
 		}
 
-		waitSignal := test.WaitSignal
-		if !kv.HasBpfGetSocketCookieForCgroupSocket() {
+		if !kv.HasBpfGetSocketCookieForCgroupSocket() || kv.Code < kernel.Kernel5_15 {
 			waitSignal = test.WaitSignalWithoutProcessContext
 		}
 

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -172,7 +172,7 @@ func TestRawPacket(t *testing.T) {
 		}
 
 		wrapper.Run(t, "ping", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-			test.WaitSignalWithoutProcessContext(t, func() error {
+			test.WaitSignal(t, func() error {
 				cmd := cmdFunc("/bin/ping", []string{"-c", "1", "8.8.8.8"}, nil)
 				if out, err := cmd.CombinedOutput(); err != nil {
 					return fmt.Errorf("%s: %w", out, err)


### PR DESCRIPTION
### What does this PR do?

Use the socket cookie helpers to improve the pid context resolution in flow related detection.

### Motivation

### Describe how you validated your changes

### Additional Notes
