### PR TITLE
[CWS] reduce kernel memory usage of `pid_rate_limiters` and `inet_bind_args`

### DIFF
--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -261,7 +261,7 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"inet_bind_args": {
-			MaxEntries: procPidCacheMaxEntries,
+			MaxEntries: superReducedProcPidCacheSize,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"activity_dumps_config": {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -206,11 +206,11 @@ type MapSpecEditorOpts struct {
 
 // AllMapSpecEditors returns the list of map editors
 func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) map[string]manager.MapSpecEditor {
-	var procPidCacheMaxEntries uint32
+	procPidCacheMaxEntries := getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+	reducedProcPidCacheSize := getMaxEntries(numCPU, minProcEntries/2, maxProcEntries/2)
+	superReducedProcPidCacheSize := getMaxEntries(numCPU, minProcEntries/4, maxProcEntries/4)
 	if opts.ReducedProcPidCacheSize {
-		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries/2)
-	} else {
-		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+		procPidCacheMaxEntries = reducedProcPidCacheSize
 	}
 
 	var activeFlowsMaxEntries, nsFlowToNetworkStats uint32
@@ -245,7 +245,7 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts, kv *kernel.Version) m
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"pid_rate_limiters": {
-			MaxEntries: procPidCacheMaxEntries,
+			MaxEntries: superReducedProcPidCacheSize,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"active_flows": {


### PR DESCRIPTION
### What does this PR do?

Those 2 maps have very low utilization, this PR reduces drastically the max entries to limit the waste in kernel memory.

`pid_rate_limiters`: is only used to rate limit the ptrace and setrlimit events, on production we store on average 2 values in this map that is currently limited to ~131k entries.

`inet_bind_args`: is only used to store args between `inet_bind` entry and exit, on production we store on average 4 values in this map that is currently limited to ~131k entries.

This PR divides by 4 the max entries used by those 2 maps.

### Motivation

### Describe how you validated your changes

### Additional Notes
