### PR TITLE
[FA] Add log integration source

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -102,6 +102,11 @@ type LogsConfig struct {
 	AutoMultiLineSamples           []*AutoMultilineSample   `mapstructure:"auto_multi_line_detection_custom_samples" json:"auto_multi_line_detection_custom_samples" yaml:"auto_multi_line_detection_custom_samples"`
 	FingerprintConfig              *types.FingerprintConfig `mapstructure:"fingerprint_config" json:"fingerprint_config" yaml:"fingerprint_config"`
 	ExperimentalFingerprintEnabled bool                     `mapstructure:"fingerprint_enabled_experimental" json:"fingerprint_enabled_experimental" yaml:"fingerprint_enabled_experimental"`
+
+	// IntegrationSource is the source of the integration file that contains this source.
+	IntegrationSource string `mapstructure:"integration_source" json:"integration_source" yaml:"integration_source"`
+	// IntegrationFileIndex is the index of the integration file that contains this source.
+	IntegrationSourceIndex int `mapstructure:"integration_source_index" json:"integration_source_index" yaml:"integration_source_index"`
 }
 
 // SourceAutoMultiLineOptions defines per-source auto multi-line detection overrides.

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks.go
@@ -255,10 +255,12 @@ func (ic *inventorychecksImpl) getPayload(withConfigs bool) marshaler.JSONMarsha
 						"error":  logSource.Status.GetError(),
 						"status": logSource.Status.String(),
 					},
-					"service":          logSource.Config.Service,
-					"source":           logSource.Config.Source,
-					"integration_name": logSource.Config.IntegrationName,
-					"tags":             tags,
+					"service":                  logSource.Config.Service,
+					"source":                   logSource.Config.Source,
+					"integration_name":         logSource.Config.IntegrationName,
+					"integration_source":       logSource.Config.IntegrationSource,
+					"integration_source_index": logSource.Config.IntegrationSourceIndex,
+					"tags":                     tags,
 				})
 			}
 		}

--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -244,11 +244,14 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 
 	configName := configName(config)
 	var sources []*sourcesPkg.LogSource
-	for _, cfg := range configs {
+	for index, cfg := range configs {
 		// if no service is set fall back to the global one
 		if cfg.Service == "" && globalServiceDefined {
 			cfg.Service = commonGlobalOptions.Service
 		}
+
+		cfg.IntegrationSourceIndex = index
+		cfg.IntegrationSource = config.Source
 
 		if service != nil {
 			// a config defined in a container label or a pod annotation does not always contain a type,


### PR DESCRIPTION
### What does this PR do?

Add log integration source, so we can rebuild the full file in the backend for Fleet Automation

Example in the metadata payload
```
"logs_metadata": {
        "redisdb": [
            {
                "config": "{\"type\":\"file\",\"path\":\"/var/log/redis.log\",\"service\":\"mycache\",\"source\":\"redis\"}",
                "integration_name": "redisdb",
                "integration_source": "file:/etc/datadog-agent/conf.d/redisdb.d/conf.yaml",
                "integration_source_index": 0,
                "service": "mycache",
                "source": "redis",
                "state": {
                    "error": "",
                    "status": "success"
                },
                "tags": []
            },
            {
                "config": "{\"type\":\"file\",\"path\":\"/var/log/redis2.log\",\"source\":\"redis\"}",
                "integration_name": "redisdb",
                "integration_source": "file:/etc/datadog-agent/conf.d/redisdb.d/conf.yaml",
                "integration_source_index": 1,
                "service": "",
                "source": "redis",
                "state": {
                    "error": "",
                    "status": "success"
                },
                "tags": []
            }
        ]
    },
```

### Motivation

### Describe how you validated your changes

### Additional Notes
