### PR TITLE
config: process: make wlm-based process collector the default

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector_test.go
@@ -93,6 +93,7 @@ func TestProcessCollector(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": true,
 		"process_config.run_in_core_agent.enabled":  true,
+		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)
@@ -257,6 +258,7 @@ func TestProcessCollectorWithoutProcessCheck(t *testing.T) {
 		"language_detection.enabled":                true,
 		"process_config.process_collection.enabled": false,
 		"process_config.run_in_core_agent.enabled":  true,
+		"process_config.process_collection.use_wlm": false,
 	}
 
 	c := setUpCollectorTest(t, configOverrides)

--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -167,6 +167,7 @@ func cmpEvents(a, b *event) bool {
 func Test_linuxImpl(t *testing.T) {
 	host := "test-host"
 	t.Setenv("DD_DISCOVERY_ENABLED", "true")
+	t.Setenv("DD_PROCESS_CONFIG_PROCESS_COLLECTION_USE_WLM", "false")
 
 	type checkRun struct {
 		servicesResp *model.ServicesResponse

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -115,7 +115,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnv(config, "process_config.enabled")
 	procBindEnvAndSetDefault(config, "process_config.container_collection.enabled", true)
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
-	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", false)
+	procBindEnvAndSetDefault(config, "process_config.process_collection.use_wlm", true)
 
 	// This allows for the process check to run in the core agent but is for linux only
 	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -141,7 +141,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		// TODO: process_config.process_collection.use_wlm is a temporary configuration for refactoring purposes
 		{
 			key:          "process_config.process_collection.use_wlm",
-			defaultValue: false,
+			defaultValue: true,
 		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {

--- a/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_config.yaml
@@ -1,1 +1,4 @@
 log_level: DEBUG
+process_config:
+  process_collection:
+    use_wlm: false

--- a/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/agent_process_config.yaml
@@ -4,7 +4,6 @@ language_detection:
 process_config:
   process_collection:
     enabled: true
-    use_wlm: true
   run_in_core_agent:
     enabled: true
 

--- a/test/new-e2e/tests/language-detection/etc/process_config.yaml
+++ b/test/new-e2e/tests/language-detection/etc/process_config.yaml
@@ -3,6 +3,7 @@ process_config:
     enabled: false
   process_collection:
     enabled: true
+    use_wlm: false
   intervals:
     process: 1
 language_detection:


### PR DESCRIPTION
### What does this PR do?

This PR makes the WLM process collector the default for use by process collection and service discovery.

### Motivation

Phase out the old discovery check and process collector in favor of the newer pipeline.

### Describe how you validated your changes

Updated unit tests.

### Additional Notes
