### PR TITLE
[CWS] try to rely on inode only

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -22,7 +22,7 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     // check if this event should trigger a syscall drift event
     if (is_anomaly_syscalls_enabled()) {
         // fetch the profile for the current cgroup
-        struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event.cgroup);
+        struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event.cgroup.cgroup_file.ino);
         if (profile) {
             u64 cookie = profile->cookie;
             struct security_profile_syscalls_t *syscalls = bpf_map_lookup_elem(&secprofs_syscalls, &cookie);

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -49,7 +49,7 @@ BPF_HASH_MAP(basename_approvers, struct basename_t, struct event_mask_filter_t, 
 BPF_HASH_MAP(register_netdevice_cache, u64, struct register_netdevice_cache_t, 1024)
 BPF_HASH_MAP(netdevice_lookup_cache, u64, struct device_ifindex_t, 1024)
 BPF_HASH_MAP(fd_link_pid, u8, u32, 1)
-BPF_HASH_MAP(security_profiles, struct path_key_t, struct security_profile_t, 1) // max entries will be overriden at runtime
+BPF_HASH_MAP(security_profiles, u64, struct security_profile_t, 1) // max entries will be overriden at runtime
 BPF_HASH_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // max entries will be overriden at runtime
 BPF_HASH_MAP(auid_approvers, u32, struct event_mask_filter_t, 128)
 BPF_HASH_MAP(auid_range_approvers, u32, struct u32_range_filter_t, EVENT_MAX)

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -296,7 +296,7 @@ func (m *Manager) unloadProfileMap(profile *profile.Profile) {
 
 // linkProfile (thread unsafe) updates the kernel space mapping between a workload and its profile
 func (m *Manager) linkProfileMap(profile *profile.Profile, workload *tags.Workload) {
-	if err := m.securityProfileMap.Put(workload.CGroupFile, profile.GetProfileCookie()); err != nil {
+	if err := m.securityProfileMap.Put(workload.CGroupFile.Inode, profile.GetProfileCookie()); err != nil {
 		seclog.Errorf("couldn't link workload %s (selector: %s, key: %v) with profile %s (check map size limit ?): %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}
@@ -331,7 +331,7 @@ func (m *Manager) unlinkProfileMap(profile *profile.Profile, workload *tags.Work
 		return
 	}
 
-	if err := m.securityProfileMap.Delete(workload.CGroupFile); err != nil {
+	if err := m.securityProfileMap.Delete(workload.CGroupFile.Inode); err != nil {
 		seclog.Errorf("couldn't unlink workload %s (selector: %s, key: %v) with profile %s: %v", workload.ContainerID, workload.Selector.String(), workload.CGroupFile, profile.Metadata.Name, err)
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Try to get rid of error logs `couldn't unlink workload [...] with profile activity-dump-XXXXX: delete: key does not exist` which are due to access of the same cgroup from various mount points/namespaces. Even if the mountid changes, the inode should stay reliable. This PR make use of this assumption to avoid having cache inconsistencies/duplicatas.

### Motivation


### Describe how you validated your changes

### Additional Notes
