### PR TITLE
tasks: add debugger-go team to list of system-probe codeowners

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -415,6 +415,7 @@ def is_system_probe(owners, files):
         ("TEAM", "@DataDog/ebpf-platform"),
         ("TEAM", "@DataDog/agent-security"),
         ("TEAM", "@DataDog/cloud-network-monitoring"),
+        ("TEAM", "@DataDog/debugger-go"),
     }
     for f in files:
         match_teams = set(owners.of(f)) & target


### PR DESCRIPTION
### What does this PR do?

This PR adds the dynamic instrumentation team to the list of teams that contributes to system-probe code

### Motivation

Improve visibility on system-probe deployments

### Describe how you validated your changes


### Additional Notes
