### PR TITLE
[Dynamic Instrumentation] Reverting a line that activated Go DI on arbitrary Go processes

### DIFF
--- a/pkg/dyninst/procmon/analyze.go
+++ b/pkg/dyninst/procmon/analyze.go
@@ -131,7 +131,7 @@ func analyzeProcess(
 			"failed to analyze environ", err,
 		)
 	}
-	if ddEnv.serviceName == "" && !ddEnv.diEnabled {
+	if ddEnv.serviceName == "" || !ddEnv.diEnabled {
 		log.Tracef(
 			"process %d is not interesting: service name is %q, %s=%t",
 			pid, ddEnv.serviceName, ddDynInstEnabledEnvVar, ddEnv.diEnabled,


### PR DESCRIPTION
### What does this PR do?
In #39642, we made a [small mistake](https://github.com/DataDog/datadog-agent/pull/39642/files#diff-a55b3b343403838f51e5ca48a198451bd185d7751ebe93c21ee5185fe1eaad15L134) that led to DI accidentally analyzing all Go processes that simply have `DD_SERVICE` **or** `DD_DYNAMIC_INSTRUMENTATION_ENABLED` instead of **both** . It was a fortunate mistake since analyzing all Go processes's symbols revealed a flaw we have in memory management regarding `pclntab` section that is used to build up a mapping between pc <-> line. It caused OOM on staging.

### Motivation
Enable Go DI only if a service has `DD_SERVICE` _and_ `DD_DYNAMIC_INSTRUMENTATION_ENABLED`.

### Incident
incident-42623.