### PR TITLE
[ACIX-1030] Added timeouts to agent ci API and stack cleaner

### DIFF
--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -64,7 +64,7 @@ def run(
         jq: One of 'no', 'auto' or 'yes'. Will pipe the json result to jq for pretty printing if jq present.
         query: jq query for the output.
         timeout: Once this timeout is reached, the task will stop with an error.
-        ignore_timeout: If True, won't throw an error if the request times out.
+        ignore_timeout_error: If True, won't throw an error if the request times out.
 
     Examples:
         $ dda inv -- api hello --env staging

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -138,7 +138,7 @@ def run(
             if jq_result.returncode != 0:
                 print(result.text)
     except requests.Timeout as e:
-        if ignore_timeout:
+        if ignore_timeout_error:
             print(
                 f'{color_message("Warning", Color.ORANGE)}: Agent CI API request {url} timed out after {timeout} seconds, ignoring error...',
                 file=sys.stderr,

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -144,7 +144,7 @@ def run(
                 file=sys.stderr,
             )
         else:
-            raise RuntimeError(f'Agent CI API request {url} timed out after {timeout} seconds') from e
+            raise TimeoutError(f'Agent CI API request {url} timed out after {timeout} seconds') from e
 
 
 @task

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -48,7 +48,7 @@ def run(
     jq='auto',
     query='.errors // .data',
     timeout: float = 600.0,
-    ignore_timeout: bool = False,
+    ignore_timeout_error: bool = False,
 ):
     """Triggers the agent-ci-api service.
 

--- a/tasks/agent_ci_api.py
+++ b/tasks/agent_ci_api.py
@@ -3,11 +3,13 @@
 import os
 import shutil
 import subprocess
+import sys
 
 import requests
 from invoke import task
 
 from tasks.libs.common.auth import datadog_infra_token
+from tasks.libs.common.color import Color, color_message
 
 
 def get_datacenter(env):
@@ -45,6 +47,8 @@ def run(
     prefix='internal/agent-ci-api/',
     jq='auto',
     query='.errors // .data',
+    timeout: float = 600.0,
+    ignore_timeout: bool = False,
 ):
     """Triggers the agent-ci-api service.
 
@@ -59,6 +63,8 @@ def run(
         prefix: The prefix to use for the endpoint.
         jq: One of 'no', 'auto' or 'yes'. Will pipe the json result to jq for pretty printing if jq present.
         query: jq query for the output.
+        timeout: Once this timeout is reached, the task will stop with an error.
+        ignore_timeout: If True, won't throw an error if the request times out.
 
     Examples:
         $ dda inv -- api hello --env staging
@@ -111,24 +117,34 @@ def run(
         if is_local
         else f"https://agent-ci-api.{dc}/{prefix}{endpoint}"
     )
-    result = requests.request(
-        method.upper(),
-        url,
-        json=payload,
-        headers={
-            'Authorization': token,
-            'X-DdOrigin': origin_header,
-            'Content-Type': 'application/json',
-        },
-    )
-    if not result.ok:
-        raise RuntimeError(f'Request failed with code {result.status_code}:\n{result.text}')
-    elif use_jq:
-        jq_result = subprocess.run(['jq', '-C', query], input=result.text, text=True)
+    try:
+        result = requests.request(
+            method.upper(),
+            url,
+            json=payload,
+            headers={
+                'Authorization': token,
+                'X-DdOrigin': origin_header,
+                'Content-Type': 'application/json',
+            },
+            timeout=timeout,
+        )
+        if not result.ok:
+            raise RuntimeError(f'Request failed with code {result.status_code}:\n{result.text}')
+        elif use_jq:
+            jq_result = subprocess.run(['jq', '-C', query], input=result.text, text=True)
 
-        # Jq parsing failed, ignore (otherwise everything is already printed)
-        if jq_result.returncode != 0:
-            print(result.text)
+            # Jq parsing failed, ignore (otherwise everything is already printed)
+            if jq_result.returncode != 0:
+                print(result.text)
+    except requests.Timeout as e:
+        if ignore_timeout:
+            print(
+                f'{color_message("Warning", Color.ORANGE)}: Agent CI API request {url} timed out after {timeout} seconds, ignoring error...',
+                file=sys.stderr,
+            )
+        else:
+            raise RuntimeError(f'Agent CI API request {url} timed out after {timeout} seconds') from e
 
 
 @task

--- a/tasks/tools/e2e_stacks.py
+++ b/tasks/tools/e2e_stacks.py
@@ -25,6 +25,8 @@ def destroy_remote_stack_api(stack: str, ctx: Context | None = None):
             env="prod",
             ty="stackcleaner_workflow_request",
             attrs=f"stack_name={stack},job_name={os.environ['CI_JOB_NAME']},job_id={os.environ['CI_JOB_ID']},pipeline_id={os.environ['CI_PIPELINE_ID']},ref={os.environ['CI_COMMIT_REF_NAME']},ignore_lock=bool:true,ignore_not_found=bool:true",
+            timeout=10,
+            ignore_timeout=True,
         )
     except Exception as e:
         exit_code = 1

--- a/tasks/tools/e2e_stacks.py
+++ b/tasks/tools/e2e_stacks.py
@@ -26,7 +26,7 @@ def destroy_remote_stack_api(stack: str, ctx: Context | None = None):
             ty="stackcleaner_workflow_request",
             attrs=f"stack_name={stack},job_name={os.environ['CI_JOB_NAME']},job_id={os.environ['CI_JOB_ID']},pipeline_id={os.environ['CI_PIPELINE_ID']},ref={os.environ['CI_COMMIT_REF_NAME']},ignore_lock=bool:true,ignore_not_found=bool:true",
             timeout=10,
-            ignore_timeout=True,
+            ignore_timeout_error=True,
         )
     except Exception as e:
         exit_code = 1

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -733,7 +733,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 
 			// If we are within CI, we let the stack be destroyed by the stackcleaner-worker service
 			// After 10s, the API will time out without an error, this can happen on high workload but the stack will still be created from the agent-ci-api
-			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout")
+			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout-error")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				bs.T().Errorf("Unable to destroy stack %s: %s", stackName, out)

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -732,7 +732,8 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 			bs.T().Logf("Remote stack cleaning enabled for stack %s", fullStackName)
 
 			// If we are within CI, we let the stack be destroyed by the stackcleaner-worker service
-			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")))
+			// After 10s, the API will time out without an error, this can happen on high workload but the stack will still be created from the agent-ci-api
+			cmd := exec.Command("dda", "inv", "agent-ci-api", "stackcleaner/stack", "--env", "prod", "--ty", "stackcleaner_workflow_request", "--attrs", fmt.Sprintf("stack_name=%s,job_name=%s,job_id=%s,pipeline_id=%s,ref=%s,ignore_lock=bool:true,ignore_not_found=bool:false", fullStackName, os.Getenv("CI_JOB_NAME"), os.Getenv("CI_JOB_ID"), os.Getenv("CI_PIPELINE_ID"), os.Getenv("CI_COMMIT_REF_NAME")), "--timeout", "10", "--ignore-timeout")
 			out, err := cmd.CombinedOutput()
 			if err != nil {
 				bs.T().Errorf("Unable to destroy stack %s: %s", stackName, out)


### PR DESCRIPTION
### What does this PR do?

Added timeouts to only create the request and not always wait that the agent-ci-api service creates the stack (takes time on high workload / errors).
These timeouts only show a warning since the stackcleaner request is created and will process.

### Motivation

### Describe how you validated your changes

### Additional Notes
