### PR TITLE
fix(notifications): Use the correct channel and add debugger-go to mapping

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -21,7 +21,7 @@ from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.datadog_api import create_gauge, send_event, send_metrics
 from tasks.libs.owners.linter import codeowner_has_orphans, directory_has_packages_without_owner
 from tasks.libs.owners.parsing import read_owners
-from tasks.libs.pipeline.notifications import GITHUB_SLACK_MAP
+from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_MAP
 from tasks.libs.releasing.version import current_version
 from tasks.libs.types.types import PermissionCheck
 
@@ -601,7 +601,9 @@ query {
 
 
 @task
-def check_permissions(_, name: str, check: PermissionCheck = PermissionCheck.REPO, channel: str = "agent-devx-ops"):
+def check_permissions(
+    _, name: str, check: PermissionCheck = PermissionCheck.REPO, channel: str = DEFAULT_SLACK_CHANNEL
+):
     """
     Check the permissions on a given repository or team.
       - list contributing teams on the repository or subteams

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -8,7 +8,12 @@ from tasks.libs.ciproviders.github_api import GithubAPI, ask_review_actor
 from tasks.libs.issue.assign import assign_with_model, assign_with_rules
 from tasks.libs.issue.model.actions import fetch_data_and_train_model
 from tasks.libs.owners.parsing import search_owners
-from tasks.libs.pipeline.notifications import GITHUB_SLACK_MAP, GITHUB_SLACK_REVIEW_MAP, HELP_SLACK_CHANNEL
+from tasks.libs.pipeline.notifications import (
+    DEFAULT_SLACK_CHANNEL,
+    GITHUB_SLACK_MAP,
+    GITHUB_SLACK_REVIEW_MAP,
+    HELP_SLACK_CHANNEL,
+)
 
 
 @task
@@ -64,19 +69,19 @@ def ask_reviews(_, pr_id):
         for reviewer in reviewers:
             channel = next(
                 (chan for team, chan in GITHUB_SLACK_REVIEW_MAP.items() if team.casefold() == reviewer.casefold()),
-                HELP_SLACK_CHANNEL,
+                DEFAULT_SLACK_CHANNEL,
             )
             stop_updating = ""
             if pr.user.login == "renovate[bot]" and pr.title.startswith("chore(deps): update integrations-core"):
                 stop_updating = "Add the `stop-updating` label before trying to merge this PR, to prevent it from being updated by Renovate.\n"
             message = f'Hello :{random.choice(waves)}:!\n*{actor}* is asking review for PR <{pr.html_url}/s|{pr.title}>.\nCould you please have a look?\n{stop_updating}Thanks in advance!\n'
-            if channel == HELP_SLACK_CHANNEL:
+            if channel == DEFAULT_SLACK_CHANNEL:
                 message = f'Hello :{random.choice(waves)}:!\nA review channel is missing for {reviewer}, can you please ask them to update `github_slack_review_map.yaml` and transfer them this review <{pr.html_url}/s|{pr.title}>?\n Thanks in advance!'
             try:
                 client.chat_postMessage(channel=channel, text=message)
             except Exception as e:
                 message = f"An error occurred while sending a review message from {actor} for PR <{pr.html_url}/s|{pr.title}> to channel {channel}. Error: {e}"
-                client.chat_postMessage(channel='#agent-devx-ops', text=message)
+                client.chat_postMessage(channel=DEFAULT_SLACK_CHANNEL, text=message)
 
 
 @task

--- a/tasks/libs/dynamic_test/evaluator.py
+++ b/tasks/libs/dynamic_test/evaluator.py
@@ -429,8 +429,9 @@ class DatadogDynTestEvaluator(DynTestEvaluator):
             - Sets unreliable_status=True for tests marked as flaky by Datadog
             - Queries up to 3 days of historical data
         """
+        escaped_job_name = job_name.replace('"', '\\"')
         events = get_ci_test_events(
-            f'@ci.pipeline.name:DataDog/datadog-agent @ci.pipeline.id:{self.pipeline_id} @ci.job.name:"{job_name.replace('"', '\\"')}"',
+            f'@ci.pipeline.name:DataDog/datadog-agent @ci.pipeline.id:{self.pipeline_id} @ci.job.name:"{escaped_job_name}"',
             3,
         )
 

--- a/tasks/libs/notify/alerts.py
+++ b/tasks/libs/notify/alerts.py
@@ -12,14 +12,11 @@ from tasks.libs.ciproviders.gitlab_api import BASE_URL, get_pipeline
 from tasks.libs.common.datadog_api import create_count, send_metrics
 from tasks.libs.notify.utils import (
     AWS_S3_CP_CMD,
-    CHANNEL_BROADCAST,
     PROJECT_NAME,
     get_ci_visibility_job_url,
 )
 from tasks.libs.pipeline.data import get_failed_jobs
-from tasks.libs.pipeline.notifications import (
-    get_pr_from_commit,
-)
+from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL, get_pr_from_commit
 from tasks.owners import channel_owners, make_partition
 
 """
@@ -258,7 +255,7 @@ def send_notification(ctx: Context, alert_jobs, jobowners=".gitlab/JOBOWNERS"):
     partition = make_partition(all_alerts, jobowners, get_channels=True)
 
     for channel in partition:
-        if channel == CHANNEL_BROADCAST:
+        if channel == DEFAULT_SLACK_CHANNEL:
             # All alerts are sent to the broadcast channel. Continue here to prevent duplicates.
             continue
         consecutive = ConsecutiveJobAlert(
@@ -269,10 +266,10 @@ def send_notification(ctx: Context, alert_jobs, jobowners=".gitlab/JOBOWNERS"):
         )
         metrics.extend(send_alert(channel, consecutive, cumulative))
 
-    # Send all alerts to CHANNEL_BROADCAST
+    # Send all alerts to DEFAULT_SLACK_CHANNEL
     consecutive = ConsecutiveJobAlert(alert_jobs["consecutive"])
     cumulative = CumulativeJobAlert(alert_jobs["cumulative"])
-    metrics.extend(send_alert(CHANNEL_BROADCAST, consecutive, cumulative))
+    metrics.extend(send_alert(DEFAULT_SLACK_CHANNEL, consecutive, cumulative))
 
     if metrics:
         send_metrics(metrics)

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -10,7 +10,6 @@ from tasks.libs.pipeline.notifications import HELP_SLACK_CHANNEL
 PROJECT_NAME = "DataDog/datadog-agent"
 CI_VISIBILITY_JOB_URL = 'https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A{name}{extra_flags}&agg_m=count{extra_args}'
 NOTIFICATION_DISCLAIMER = f"If there is something wrong with the notification please contact {HELP_SLACK_CHANNEL}"
-CHANNEL_BROADCAST = '#agent-devx-ops'
 PIPELINES_CHANNEL = '#datadog-agent-pipelines'
 AWS_S3_CP_CMD = "aws s3 cp --only-show-errors --region us-east-1 --sse AES256"
 AWS_S3_LS_CMD = "aws s3api list-objects-v2 --bucket '{bucket}' --prefix '{prefix}/' --delimiter /"

--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -33,7 +33,7 @@
 '@datadog/container-platform': '#container-platform'
 '@datadog/data-jobs-monitoring': '#data-jobs-monitoring'
 '@datadog/database-monitoring': '#database-monitoring'
-'@datadog/debugger': '#debugger'
+'@datadog/debugger-go': '#debugger-go'
 '@datadog/documentation': '#documentation'
 '@datadog/ebpf-platform': '#ebpf-platform'
 '@datadog/fleet': '#fleet-automation-monitoring'

--- a/tasks/unit_tests/github_tasks_tests.py
+++ b/tasks/unit_tests/github_tasks_tests.py
@@ -15,6 +15,7 @@ from tasks.github_tasks import (
     extract_test_qa_description,
     pr_merge_dd_event_sender,
 )
+from tasks.libs.pipeline.notifications import DEFAULT_SLACK_CHANNEL
 from tasks.libs.types.types import PermissionCheck
 
 
@@ -508,7 +509,7 @@ class TestCheckPermissions(unittest.TestCase):
             {'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'Admins:\n - <http://zorro|zorro>\n'}},
         ]
         client_mock.chat_postMessage.assert_called_once_with(
-            channel="agent-devx-ops",
+            channel=DEFAULT_SLACK_CHANNEL,
             blocks=blocks,
             text=''.join(b['text']['text'] for b in blocks),
         )
@@ -550,7 +551,7 @@ class TestCheckPermissions(unittest.TestCase):
             },
         ]
         client_mock.chat_postMessage.assert_called_once_with(
-            channel="agent-devx-ops",
+            channel=DEFAULT_SLACK_CHANNEL,
             blocks=blocks,
             text=''.join(b['text']['text'] for b in blocks),
         )
@@ -608,7 +609,7 @@ class TestCheckPermissions(unittest.TestCase):
             },
         ]
         client_mock.chat_postMessage.assert_called_once_with(
-            channel="agent-devx-ops",
+            channel=DEFAULT_SLACK_CHANNEL,
             blocks=blocks,
             text=''.join(b['text']['text'] for b in blocks),
         )
@@ -662,7 +663,7 @@ class TestCheckPermissions(unittest.TestCase):
             },
         ]
         client_mock.chat_postMessage.assert_called_once_with(
-            channel="agent-devx-ops",
+            channel=DEFAULT_SLACK_CHANNEL,
             blocks=blocks,
             text=''.join(b['text']['text'] for b in blocks),
         )

--- a/tasks/unit_tests/libs/notify/alerts_tests.py
+++ b/tasks/unit_tests/libs/notify/alerts_tests.py
@@ -233,7 +233,7 @@ class TestAlertsSendNotification(unittest.TestCase):
     @patch.object(alerts.ConsecutiveJobAlert, 'message', lambda self, _: '\n'.join(self.failures) + '\n')
     @patch.object(alerts.CumulativeJobAlert, 'message', lambda self: '\n'.join(self.failures))
     @patch('tasks.owners.GITHUB_SLACK_MAP', get_github_slack_map())
-    @patch('tasks.libs.notify.alerts.CHANNEL_BROADCAST', '#channel-broadcast')
+    @patch('tasks.libs.notify.alerts.DEFAULT_SLACK_CHANNEL', '#channel-broadcast')
     def test_jobowners(self, mock_slack: MagicMock, mock_metrics: MagicMock):
         client_mock = MagicMock()
         mock_slack.return_value = client_mock
@@ -297,7 +297,7 @@ class TestAlertsSendNotification(unittest.TestCase):
     @patch.object(alerts.ConsecutiveJobAlert, 'message', lambda self, _: '\n'.join(self.failures) + '\n')
     @patch.object(alerts.CumulativeJobAlert, 'message', lambda self: '\n'.join(self.failures))
     @patch('tasks.owners.GITHUB_SLACK_MAP', get_github_slack_map())
-    @patch('tasks.libs.notify.alerts.CHANNEL_BROADCAST', '#channel-a')
+    @patch('tasks.libs.notify.alerts.DEFAULT_SLACK_CHANNEL', '#channel-a')
     def test_prevent_duplication(self, mock_slack: MagicMock, mock_metrics: MagicMock):
         client_mock = MagicMock()
         mock_slack.return_value = client_mock


### PR DESCRIPTION
### What does this PR do?
- Use `agent-devx-ops` instead of `agent-devx-help` on failure notifications
- Remove redundant definition of static for `agent-devx-ops`
- Add a slack review channel for the debugger-go team
- Change something completely unrelated to silence a mypy warning

### Motivation
Tech debt

### Describe how you validated your changes
Unit tests are still ok

### Additional Notes
