### PR TITLE
[USMON-1478] Increase expected_tags_duration for System Probe from 5 to 30 minutes

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -315,7 +315,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnv(join(netNS, "http_max_request_fragment"))
 	cfg.BindEnv(join(smNS, "http_max_request_fragment"))
 
-	cfg.BindEnvAndSetDefault(join(spNS, "expected_tags_duration"), 5*time.Minute, "DD_SYSTEM_PROBE_EXPECTED_TAGS_DURATION")
+	cfg.BindEnvAndSetDefault(join(spNS, "expected_tags_duration"), 30*time.Minute, "DD_SYSTEM_PROBE_EXPECTED_TAGS_DURATION")
 
 	// list of DNS query types to be recorded
 	cfg.BindEnvAndSetDefault(join(netNS, "dns_recorded_query_types"), []string{})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -1799,7 +1799,7 @@ func TestExpectedTagsDuration(t *testing.T) {
 		mock.NewSystemProbe(t)
 		cfg := New()
 
-		assert.Equal(t, 5*time.Minute, cfg.ExpectedTagsDuration)
+		assert.Equal(t, 30*time.Minute, cfg.ExpectedTagsDuration)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Increase the default expected_tags_duration from 5 minutes to 30 minutes to better handle backend tag resolution race conditions and reduce intermittent missing tags in USM/CNM metrics.

### Motivation

Making USM and CNM more reliable

### Describe how you validated your changes

### Additional Notes
