### PR TITLE
Deprecate python flag in integration subcommand

### DIFF
--- a/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
+++ b/cmd/agent/subcommands/integrations/integrations_nix_helpers.go
@@ -23,8 +23,8 @@ var (
 	pythonMinorVersion string
 )
 
-func getRelPyPath(pythonMajorVersion string) string {
-	return filepath.Join("embedded", "bin", fmt.Sprintf("%s%s", pythonBin, pythonMajorVersion))
+func getRelPyPath() string {
+	return filepath.Join("embedded", "bin", fmt.Sprintf("%s3", pythonBin))
 }
 
 func getRelChecksPath(cliParams *cliParams) (string, error) {
@@ -33,13 +33,13 @@ func getRelChecksPath(cliParams *cliParams) (string, error) {
 		return "", err
 	}
 
-	pythonDir := fmt.Sprintf("%s%s.%s", pythonBin, cliParams.pythonMajorVersion, pythonMinorVersion)
+	pythonDir := fmt.Sprintf("%s3.%s", pythonBin, pythonMinorVersion)
 	return filepath.Join("embedded", "lib", pythonDir, "site-packages", "datadog_checks"), nil
 }
 
 func detectPythonMinorVersion(cliParams *cliParams) error {
 	if pythonMinorVersion == "" {
-		pythonPath, err := getCommandPython(cliParams.pythonMajorVersion, cliParams.useSysPython)
+		pythonPath, err := getCommandPython(cliParams.useSysPython)
 		if err != nil {
 			return err
 		}

--- a/cmd/agent/subcommands/integrations/integrations_windows.go
+++ b/cmd/agent/subcommands/integrations/integrations_windows.go
@@ -9,7 +9,6 @@ package integrations
 
 import (
 	"errors"
-	"fmt"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
@@ -19,12 +18,12 @@ const (
 	pythonBin = "python.exe"
 )
 
-func getRelPyPath(pythonMajorVersion string) string {
-	return filepath.Join(fmt.Sprintf("embedded%s", pythonMajorVersion), pythonBin)
+func getRelPyPath() string {
+	return filepath.Join("embedded3", pythonBin)
 }
 
-func getRelChecksPath(cliParams *cliParams) (string, error) {
-	return filepath.Join(fmt.Sprintf("embedded%s", cliParams.pythonMajorVersion), "Lib", "site-packages", "datadog_checks"), nil
+func getRelChecksPath(_ *cliParams) (string, error) {
+	return filepath.Join("embedded3", "Lib", "site-packages", "datadog_checks"), nil
 }
 
 func validateUser(_ bool) error {

--- a/releasenotes/notes/remove-python-major-arg-subcommand-177e74357054cfdc.yaml
+++ b/releasenotes/notes/remove-python-major-arg-subcommand-177e74357054cfdc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    The ``--python`` argument is no longer used in the ``integrations`` subcommand.


### PR DESCRIPTION
### What does this PR do?
Deprecate the `python` flag of the `agent integration` command.

### Motivation
Simplify the code.
We don't support Python2 anymore.

### Describe how you validated your changes
CI

### Additional Notes
The flag still exists (so the command doesn't crash when used), but it won't show in the help message and a deprecation warning will be shown when used.