### PR TITLE
[CWS] add support for activity dumps in direct sender

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -421,8 +421,8 @@ type RuntimeSecurityConfig struct {
 	// IMDSIPv4 is used to provide a custom IP address for the IMDS endpoint
 	IMDSIPv4 uint32
 
-	// SendEventFromSystemProbe defines when the event are sent directly from system-probe
-	SendEventFromSystemProbe bool
+	// SendPayloadsFromSystemProbe defines when the event and activity dumps are sent directly from system-probe
+	SendPayloadsFromSystemProbe bool
 
 	// FileMetadataResolverEnabled defines if the file metadata is enabled
 	FileMetadataResolverEnabled bool
@@ -632,7 +632,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		IMDSIPv4: parseIMDSIPv4(),
 
 		// direct sender
-		SendEventFromSystemProbe: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe"),
+		SendPayloadsFromSystemProbe: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe"),
 
 		// FileMetadataResolverEnabled
 		FileMetadataResolverEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.file_metadata_resolver.enabled"),

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -330,15 +330,7 @@ func (c *CWSConsumer) APIServer() *APIServer {
 
 // HandleActivityDump sends an activity dump to the backend
 func (c *CWSConsumer) HandleActivityDump(imageName string, imageTag string, header []byte, data []byte) error {
-	msg := &api.ActivityDumpStreamMessage{
-		Selector: &api.WorkloadSelectorMessage{
-			Name: imageName,
-			Tag:  imageTag,
-		},
-		Header: header,
-		Data:   data,
-	}
-	c.apiServer.SendActivityDump(msg)
+	c.apiServer.SendActivityDump(imageName, imageTag, header, data)
 	return nil
 }
 

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -224,7 +224,7 @@ func (c *CWSConsumer) Start() error {
 	}
 
 	// do not wait external api connection, send directly running metrics
-	if c.config.SendEventFromSystemProbe {
+	if c.config.SendPayloadsFromSystemProbe {
 		c.startRunningMetrics()
 	}
 

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -22,17 +22,23 @@ import (
 )
 
 // MsgSender defines a message sender
-type MsgSender interface {
-	Send(msg *api.SecurityEventMessage, expireFnc func(*api.SecurityEventMessage))
+type MsgSender[T any] interface {
+	Send(msg *T, expireFnc func(*T))
 }
 
+// EventMsgSender defines a message sender for security events
+type EventMsgSender = MsgSender[api.SecurityEventMessage]
+
+// ActivityDumpMsgSender defines a message sender for activity dump messages
+type ActivityDumpMsgSender = MsgSender[api.ActivityDumpStreamMessage]
+
 // ChanMsgSender defines a chan message sender
-type ChanMsgSender struct {
-	msgs chan *api.SecurityEventMessage
+type ChanMsgSender[T any] struct {
+	msgs chan *T
 }
 
 // Send the message
-func (cs *ChanMsgSender) Send(msg *api.SecurityEventMessage, expireFnc func(*api.SecurityEventMessage)) {
+func (cs *ChanMsgSender[T]) Send(msg *T, expireFnc func(*T)) {
 	select {
 	case cs.msgs <- msg:
 		break
@@ -59,8 +65,8 @@ func (cs *ChanMsgSender) Send(msg *api.SecurityEventMessage, expireFnc func(*api
 }
 
 // NewChanMsgSender returns a new chan sender
-func NewChanMsgSender(msgs chan *api.SecurityEventMessage) *ChanMsgSender {
-	return &ChanMsgSender{
+func NewChanMsgSender[T any](msgs chan *T) *ChanMsgSender[T] {
+	return &ChanMsgSender[T]{
 		msgs: msgs,
 	}
 }

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -71,18 +71,18 @@ func NewChanMsgSender[T any](msgs chan *T) *ChanMsgSender[T] {
 	}
 }
 
-// DirectMsgSender defines a direct sender
-type DirectMsgSender struct {
+// DirectEventMsgSender defines a direct sender
+type DirectEventMsgSender struct {
 	reporter common.RawReporter
 }
 
 // Send the message
-func (ds *DirectMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.SecurityEventMessage)) {
+func (ds *DirectEventMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.SecurityEventMessage)) {
 	ds.reporter.ReportRaw(msg.Data, msg.Service, msg.Timestamp.AsTime(), msg.Tags...)
 }
 
-// NewDirectMsgSender returns a new direct sender
-func NewDirectMsgSender(stopper startstop.Stopper, compression compression.Component, ipc ipc.Component) (*DirectMsgSender, error) {
+// NewDirectEventMsgSender returns a new direct sender
+func NewDirectEventMsgSender(stopper startstop.Stopper, compression compression.Component, ipc ipc.Component) (*DirectEventMsgSender, error) {
 	useSecRuntimeTrack := pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.use_secruntime_track")
 
 	endpoints, destinationsCtx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
@@ -106,7 +106,7 @@ func NewDirectMsgSender(stopper startstop.Stopper, compression compression.Compo
 		return nil, fmt.Errorf("failed to create direct reporter: %w", err)
 	}
 
-	return &DirectMsgSender{
+	return &DirectEventMsgSender{
 		reporter: reporter,
 	}, nil
 }

--- a/pkg/security/module/opts.go
+++ b/pkg/security/module/opts.go
@@ -13,5 +13,5 @@ import (
 // Opts define module options
 type Opts struct {
 	EventSender events.EventSender
-	MsgSender   MsgSender
+	MsgSender   EventMsgSender
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -686,7 +686,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 
 	if as.msgSender == nil {
 		if cfg.SendEventFromSystemProbe {
-			msgSender, err := NewDirectMsgSender(stopper, compression, ipc)
+			msgSender, err := NewDirectEventMsgSender(stopper, compression, ipc)
 			if err != nil {
 				log.Errorf("failed to setup direct reporter: %v", err)
 			} else {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -173,7 +173,16 @@ func (a *APIServer) GetActivityDumpStream(_ *api.ActivityDumpStreamParams, strea
 }
 
 // SendActivityDump queues an activity dump to the chan of activity dumps
-func (a *APIServer) SendActivityDump(dump *api.ActivityDumpStreamMessage) {
+func (a *APIServer) SendActivityDump(imageName string, imageTag string, header []byte, data []byte) {
+	dump := &api.ActivityDumpStreamMessage{
+		Selector: &api.WorkloadSelectorMessage{
+			Name: imageName,
+			Tag:  imageTag,
+		},
+		Header: header,
+		Data:   data,
+	}
+
 	// send the dump to the channel
 	select {
 	case a.activityDumps <- dump:

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -688,7 +688,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 		if cfg.SendEventFromSystemProbe {
 			msgSender, err := NewDirectEventMsgSender(stopper, compression, ipc)
 			if err != nil {
-				log.Errorf("failed to setup direct reporter: %v", err)
+				log.Errorf("failed to setup direct event sender: %v", err)
 			} else {
 				as.msgSender = msgSender
 			}
@@ -699,7 +699,20 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 		}
 	}
 
-	as.activityDumpSender = NewChanMsgSender(as.activityDumps)
+	if as.activityDumpSender == nil {
+		if cfg.SendEventFromSystemProbe {
+			adSender, err := NewDirectActivityDumpMsgSender()
+			if err != nil {
+				log.Errorf("failed to setup direct activity dump sender: %v", err)
+			} else {
+				as.activityDumpSender = adSender
+			}
+		}
+
+		if as.activityDumpSender == nil {
+			as.activityDumpSender = NewChanMsgSender(as.activityDumps)
+		}
+	}
 
 	return as, nil
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -685,7 +685,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	as.collectOSReleaseData()
 
 	if as.msgSender == nil {
-		if cfg.SendEventFromSystemProbe {
+		if cfg.SendPayloadsFromSystemProbe {
 			msgSender, err := NewDirectEventMsgSender(stopper, compression, ipc)
 			if err != nil {
 				log.Errorf("failed to setup direct event sender: %v", err)
@@ -700,7 +700,7 @@ func NewAPIServer(cfg *config.RuntimeSecurityConfig, probe *sprobe.Probe, msgSen
 	}
 
 	if as.activityDumpSender == nil {
-		if cfg.SendEventFromSystemProbe {
+		if cfg.SendPayloadsFromSystemProbe {
 			adSender, err := NewDirectActivityDumpMsgSender()
 			if err != nil {
 				log.Errorf("failed to setup direct activity dump sender: %v", err)

--- a/pkg/security/resolvers/cgroup/model/types.go
+++ b/pkg/security/resolvers/cgroup/model/types.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux || windows
-
 // Package model holds model related files
 package model
 

--- a/pkg/security/security_profile/storage/backend/forwarder.go
+++ b/pkg/security/security_profile/storage/backend/forwarder.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
-
 // Package backend holds files related to forwarder backends for security profiles
 package backend
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 	spconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
@@ -899,6 +900,8 @@ func (fs *fakeMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.Securit
 
 	fs.msgs[msgStruct.AgentContext.RuleID] = msg
 }
+
+func (fs *fakeMsgSender) SendTelemetry(statsd.ClientInterface) {}
 
 func (fs *fakeMsgSender) getMsg(ruleID eval.RuleID) *api.SecurityEventMessage {
 	fs.Lock()


### PR DESCRIPTION
### What does this PR do?

With the `direct_send_from_system_probe` you can already send regular events directly from the system-probe (skipping the security agent), this PR adds support for activity dumps as well.

To do that, some of the existing direct sender code is extracted and repurposed to support both payload types. 

This feature is disabled by default, and is part of a much broader migration.

### Motivation

### Describe how you validated your changes

### Additional Notes
