### PR TITLE
fix(renovate): Update the registry URL

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -99,7 +99,7 @@
     ],
     "customDatasources": {
       "linux-images": {
-        "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-deb_x64/tags",
+        "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-linux/tags",
         "transformTemplates": [
           "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
         ]


### PR DESCRIPTION
### What does this PR do?
Update the registry URL used by renovate for the linux images

### Motivation
We do not publish the `deb_x64` image anymore. Let's replace the URL with the new multi-arch linux image

### Describe how you validated your changes
n/a

### Additional Notes
