### PR TITLE
CXP-2600 [agent] update wlm process entity logs

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1545,6 +1545,7 @@ func (p Process) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "PID:", p.EntityID.ID)
 	_, _ = fmt.Fprintln(&sb, "Name:", p.Name)
 	_, _ = fmt.Fprintln(&sb, "Exe:", p.Exe)
+	_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
 	_, _ = fmt.Fprintln(&sb, "Namespace PID:", p.NsPid)
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
@@ -1555,7 +1556,6 @@ func (p Process) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Comm:", p.Comm)
 		_, _ = fmt.Fprintln(&sb, "Cwd:", p.Cwd)
-		_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
 		_, _ = fmt.Fprintln(&sb, "Uids:", p.Uids)
 		_, _ = fmt.Fprintln(&sb, "Gids:", p.Gids)
 	}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1543,13 +1543,25 @@ func (p Process) String(verbose bool) string {
 
 	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
 	_, _ = fmt.Fprintln(&sb, "PID:", p.EntityID.ID)
+	_, _ = fmt.Fprintln(&sb, "Name:", p.Name)
+	_, _ = fmt.Fprintln(&sb, "Exe:", p.Exe)
 	_, _ = fmt.Fprintln(&sb, "Namespace PID:", p.NsPid)
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
 	if p.Language != nil {
 		_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
 	}
+
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "Comm:", p.Comm)
+		_, _ = fmt.Fprintln(&sb, "Cwd:", p.Cwd)
+		_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
+		_, _ = fmt.Fprintln(&sb, "Uids:", p.Uids)
+		_, _ = fmt.Fprintln(&sb, "Gids:", p.Gids)
+	}
+
 	if p.Service != nil {
+		_, _ = fmt.Fprintln(&sb, "----------- Service Discovery -----------")
 		_, _ = fmt.Fprintln(&sb, "Service Generated Name:", p.Service.GeneratedName)
 		if verbose {
 			_, _ = fmt.Fprintln(&sb, "Service Generated Name Source:", p.Service.GeneratedNameSource)

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -149,6 +149,7 @@ func TestProcessString(t *testing.T) {
 PID: 12345
 Name: test-process
 Exe: /usr/bin/test-process
+Cmdline: /usr/bin/test-process --flag
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
@@ -179,12 +180,12 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 PID: 12345
 Name: test-process
 Exe: /usr/bin/test-process
+Cmdline: /usr/bin/test-process --flag
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Comm: test-process
 Cwd: /tmp
-Cmdline: /usr/bin/test-process --flag
 Uids: [1000 1001]
 Gids: [1002 1003]
 `,
@@ -233,6 +234,7 @@ Gids: [1002 1003]
 PID: 12345
 Name: java-app
 Exe: /usr/bin/java
+Cmdline: /usr/bin/java -jar app.jar
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
@@ -285,13 +287,13 @@ Service Generated Name: java-app
 PID: 12345
 Name: java-app
 Exe: /usr/bin/java
+Cmdline: /usr/bin/java -jar app.jar
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Language: java
 Comm: java
 Cwd: /app
-Cmdline: /usr/bin/java -jar app.jar
 Uids: [1000 2 3]
 Gids: [1001 4 5]
 ----------- Service Discovery -----------

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -121,10 +121,11 @@ func TestProcessString(t *testing.T) {
 	tests := []struct {
 		name     string
 		process  Process
+		verbose  bool
 		expected string
 	}{
 		{
-			name: "basic process with minimal fields",
+			name: "basic process with minimal fields non-verbose",
 			process: Process{
 				EntityID: EntityID{
 					Kind: KindProcess,
@@ -139,19 +140,57 @@ func TestProcessString(t *testing.T) {
 				Comm:         "test-process",
 				Cmdline:      []string{"/usr/bin/test-process", "--flag"},
 				Uids:         []int32{1000, 1001},
-				Gids:         []int32{1000, 1001},
+				Gids:         []int32{1002, 1003},
 				ContainerID:  "container-123",
 				CreationTime: creationTime,
 			},
+			verbose: false,
 			expected: `----------- Entity ID -----------
 PID: 12345
+Name: test-process
+Exe: /usr/bin/test-process
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 `,
 		},
 		{
-			name: "process with language and service",
+			name: "basic process with minimal fields verbose",
+			process: Process{
+				EntityID: EntityID{
+					Kind: KindProcess,
+					ID:   "12345",
+				},
+				Pid:          12345,
+				NsPid:        12345,
+				Ppid:         1,
+				Name:         "test-process",
+				Cwd:          "/tmp",
+				Exe:          "/usr/bin/test-process",
+				Comm:         "test-process",
+				Cmdline:      []string{"/usr/bin/test-process", "--flag"},
+				Uids:         []int32{1000, 1001},
+				Gids:         []int32{1002, 1003},
+				ContainerID:  "container-123",
+				CreationTime: creationTime,
+			},
+			verbose: true,
+			expected: `----------- Entity ID -----------
+PID: 12345
+Name: test-process
+Exe: /usr/bin/test-process
+Namespace PID: 12345
+Container ID: container-123
+Creation time: 2023-01-01 12:00:00 +0000 UTC
+Comm: test-process
+Cwd: /tmp
+Cmdline: /usr/bin/test-process --flag
+Uids: [1000 1001]
+Gids: [1002 1003]
+`,
+		},
+		{
+			name: "process with language and service non-verbose",
 			process: Process{
 				EntityID: EntityID{
 					Kind: KindProcess,
@@ -165,8 +204,8 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 				Exe:          "/usr/bin/java",
 				Comm:         "java",
 				Cmdline:      []string{"/usr/bin/java", "-jar", "app.jar"},
-				Uids:         []int32{1000},
-				Gids:         []int32{1000},
+				Uids:         []int32{1000, 2, 3},
+				Gids:         []int32{1001, 4, 5},
 				ContainerID:  "container-999",
 				CreationTime: creationTime,
 				Language: &languagemodels.Language{
@@ -179,8 +218,8 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 					AdditionalGeneratedNames: []string{"java", "app"},
 					TracerMetadata:           []tracermetadata.TracerMetadata{},
 					DDService:                "java-app",
-					TCPPorts:                 []uint16{8080},
-					UDPPorts:                 []uint16{8081},
+					TCPPorts:                 []uint16{8080, 8081},
+					UDPPorts:                 []uint16{8082, 8083},
 					APMInstrumentation:       "enabled",
 					Type:                     "web_service",
 					LogFiles: []string{
@@ -189,19 +228,80 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 					},
 				},
 			},
+			verbose: false,
 			expected: `----------- Entity ID -----------
 PID: 12345
+Name: java-app
+Exe: /usr/bin/java
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Language: java
+----------- Service Discovery -----------
+Service Generated Name: java-app
+`,
+		},
+		{
+			name: "process with language and service verbose",
+			process: Process{
+				EntityID: EntityID{
+					Kind: KindProcess,
+					ID:   "12345",
+				},
+				Pid:          12345,
+				NsPid:        12345,
+				Ppid:         1,
+				Name:         "java-app",
+				Cwd:          "/app",
+				Exe:          "/usr/bin/java",
+				Comm:         "java",
+				Cmdline:      []string{"/usr/bin/java", "-jar", "app.jar"},
+				Uids:         []int32{1000, 2, 3},
+				Gids:         []int32{1001, 4, 5},
+				ContainerID:  "container-999",
+				CreationTime: creationTime,
+				Language: &languagemodels.Language{
+					Name:    languagemodels.Java,
+					Version: "11.0.0",
+				},
+				Service: &Service{
+					GeneratedName:            "java-app",
+					GeneratedNameSource:      "binary_name",
+					AdditionalGeneratedNames: []string{"java", "app"},
+					TracerMetadata:           []tracermetadata.TracerMetadata{},
+					DDService:                "java-app",
+					TCPPorts:                 []uint16{8080, 8081},
+					UDPPorts:                 []uint16{8082, 8083},
+					APMInstrumentation:       "enabled",
+					Type:                     "web_service",
+					LogFiles: []string{
+						"/var/log/app_access.log",
+						"/var/log/app_error.log",
+					},
+				},
+			},
+			verbose: true,
+			expected: `----------- Entity ID -----------
+PID: 12345
+Name: java-app
+Exe: /usr/bin/java
+Namespace PID: 12345
+Container ID: container-999
+Creation time: 2023-01-01 12:00:00 +0000 UTC
+Language: java
+Comm: java
+Cwd: /app
+Cmdline: /usr/bin/java -jar app.jar
+Uids: [1000 2 3]
+Gids: [1001 4 5]
+----------- Service Discovery -----------
 Service Generated Name: java-app
 Service Generated Name Source: binary_name
 Service Additional Generated Names: [java app]
 Service Tracer Metadata: []
 Service DD Service: java-app
-Service TCP Ports: [8080]
-Service UDP Ports: [8081]
+Service TCP Ports: [8080 8081]
+Service UDP Ports: [8082 8083]
 Service APM Instrumentation: enabled
 Service Type: web_service
 ----------- Log Files -----------
@@ -213,7 +313,7 @@ Service Type: web_service
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.process.String(true)
+			actual := test.process.String(test.verbose)
 			compareTestOutput(t, test.expected, actual)
 		})
 	}

--- a/releasenotes/notes/workload-list-logs-2c91e1e88ee56e08.yaml
+++ b/releasenotes/notes/workload-list-logs-2c91e1e88ee56e08.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Adds complete workloadmeta process-entity information to workload-list command logs (datadog-agent workload-list)


### PR DESCRIPTION
### What does this PR do?
- adds additional process information to be printed in the `datadog-agent workload-list` output command for debugging

#### Default logging
- name (derived from `/proc/[pid]/status`, will be the main thread of the process)
- exe (path to executable)  

#### Verbose logging
- comm (similar to `name` but can be taken from any thread of the process)
- cwd (working dir)
- cmdline (cmdline can be long so this was initially designated to be verbose but since it's useful I can see the argument to put in default logging)
- uids (user ids)
- gids (group ids)

### Motivation
- the new process collector utilizes workload meta and logging this extra information can be helpful for debugging

### Describe how you validated your changes
- unit tests

### Additional Notes
