### PR TITLE
small cleanup of `getIPCAddressPort`/`getIPCServerAddressPort`

### DIFF
--- a/comp/api/api/apiimpl/listener.go
+++ b/comp/api/api/apiimpl/listener.go
@@ -6,7 +6,6 @@
 package apiimpl
 
 import (
-	"fmt"
 	"net"
 	"strconv"
 
@@ -19,7 +18,7 @@ func getIPCAddressPort() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%v:%v", address, pkgconfigsetup.Datadog().GetInt("cmd_port")), nil
+	return net.JoinHostPort(address, pkgconfigsetup.GetIPCPort()), nil
 }
 
 // getListener returns a listening connection

--- a/comp/api/api/apiimpl/server.go
+++ b/comp/api/api/apiimpl/server.go
@@ -12,7 +12,6 @@ import (
 	stdLog "log"
 	"net"
 	"net/http"
-	"strconv"
 
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/observability"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -66,10 +65,7 @@ func (server *apiServer) startServers() error {
 	}
 
 	// start the IPC server
-	if ipcServerPort := server.cfg.GetInt("agent_ipc.port"); ipcServerPort > 0 {
-		ipcServerHost := server.cfg.GetString("agent_ipc.host")
-		ipcServerHostPort := net.JoinHostPort(ipcServerHost, strconv.Itoa(ipcServerPort))
-
+	if _, ipcServerHostPort, enabled := getIPCServerAddressPort(); enabled {
 		if err := server.startIPCServer(ipcServerHostPort, tmf); err != nil {
 			// if we fail to start the IPC server, we should stop the CMD server
 			server.stopServers()


### PR DESCRIPTION
### What does this PR do?

`getIPCServerAddressPort` is currently unused (outside of tests), but it's function is duplicated in the api impl. This PR makes use of it. This PR also simplifies `getIPCAddressPort` to make use of `net.JoinHostPort` and `pkgconfigsetup.GetIPCPort` directly

### Motivation

### Describe how you validated your changes

### Additional Notes
