### PR TITLE
Fix various config tests when running with NodeTreeModel

### DIFF
--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -8,7 +8,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"testing"
 
@@ -294,7 +293,8 @@ func (suite *ConfigTestSuite) TestBadDDConfigFile() {
 	ddFileName := "testdata/doesnotexists.yaml"
 	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
 
-	assert.ErrorIs(t, err, fs.ErrNotExist)
+	expectedError := "no such file or directory"
+	assert.ErrorContains(t, err, expectedError)
 }
 
 func (suite *ConfigTestSuite) TestBadLogLevel() {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -8,6 +8,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
 
@@ -293,8 +294,7 @@ func (suite *ConfigTestSuite) TestBadDDConfigFile() {
 	ddFileName := "testdata/doesnotexists.yaml"
 	_, err := NewConfigComponent(context.Background(), ddFileName, []string{fileName})
 
-	expectedError := "no such file or directory"
-	assert.ErrorContains(t, err, expectedError)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func (suite *ConfigTestSuite) TestBadLogLevel() {

--- a/comp/core/config/setup.go
+++ b/comp/core/config/setup.go
@@ -57,8 +57,7 @@ func setupConfig(config pkgconfigmodel.BuildableConfig, deps configDependencies)
 		warnings, err = pkgconfigsetup.LoadWithoutSecret(config, pkgconfigsetup.SystemProbe().GetEnvVars())
 	}
 
-	var e pkgconfigmodel.ConfigFileNotFoundError
-	if err != nil && (!errors.As(err, &e) || confFilePath != "") {
+	if err != nil && (!errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) || confFilePath != "") {
 		// special-case permission-denied with a clearer error message
 		if errors.Is(err, fs.ErrPermission) {
 			if runtime.GOOS == "windows" {

--- a/comp/core/configsync/configsyncimpl/module_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/module_integration_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestOptionalModule(t *testing.T) {
 	handler := func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte(`{"key1": "value1"}`))
+		w.Write([]byte(`{"api_key": "value1"}`))
 	}
 
 	ipcComp := ipcmock.New(t)
@@ -59,6 +59,6 @@ func TestOptionalModule(t *testing.T) {
 	require.True(t, comp.(configSync).enabled)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		assert.Equal(t, "value1", cfg.Get("key1"))
+		assert.Equal(t, "value1", cfg.Get("api_key"))
 	}, 5*time.Second, 500*time.Millisecond)
 }

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,14 +15,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// ConfigFileNotFoundError wrapper error for when a config file is not found
-type ConfigFileNotFoundError struct {
-	Err error
-}
+// ErrConfigFileNotFound is an error for when the config file is not found
+var ErrConfigFileNotFound = errors.New("Config File Not Found")
 
-// Error returns the error message
-func (e ConfigFileNotFoundError) Error() string {
-	return fmt.Sprintf("Config File Not Found %v", e.Err.Error())
+// NewConfigFileNotFoundError returns a well known error for the config file missing
+func NewConfigFileNotFoundError(err error) error {
+	return fmt.Errorf("%w: %w", ErrConfigFileNotFound, err)
 }
 
 // Source stores what edits a setting as a string

--- a/pkg/config/nodetreemodel/getter.go
+++ b/pkg/config/nodetreemodel/getter.go
@@ -134,7 +134,7 @@ simplyCopy:
 func (c *ntmConfig) getNodeValue(key string) interface{} {
 	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
-		return missingLeaf
+		return ""
 	}
 	c.maybeRebuild()
 

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -83,7 +83,7 @@ func (c *ntmConfig) ReadConfig(in io.Reader) error {
 func (c *ntmConfig) readInConfig(filePath string) error {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return model.ConfigFileNotFoundError{Err: err}
+		return model.NewConfigFileNotFoundError(err) // nolint: forbidigo // constructing proper error
 	}
 	return c.readConfigurationContent(c.file, model.SourceFile, content)
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -275,6 +275,7 @@ func init() {
 	initConfig()
 
 	datadog.(pkgconfigmodel.BuildableConfig).BuildSchema()
+	systemProbe.(pkgconfigmodel.BuildableConfig).BuildSchema()
 }
 
 // initCommonWithServerless initializes configs that are common to all agents, in particular serverless.

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -150,6 +150,15 @@ func unmarshalKeyReflection(cfg model.Reader, key string, target interface{}, op
 	}
 
 	outValue := reflect.ValueOf(target)
+	// Resolve pointers 2 times. This is needed because callers often do this:
+	//
+	// mystruct := &MyStruct{}
+	// err := structure.UnmarshalKey(config, "my_key", &mystruct)
+	//
+	// It would take highly unusual code to have more indirection than this.
+	if outValue.Kind() == reflect.Pointer {
+		outValue = reflect.Indirect(outValue)
+	}
 	if outValue.Kind() == reflect.Pointer {
 		outValue = reflect.Indirect(outValue)
 	}

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -608,12 +608,8 @@ func (c *safeConfig) ReadInConfig() error {
 	defer c.Unlock()
 	// ReadInConfig reset configuration with the main config file
 	err := errors.Join(c.Viper.ReadInConfig(), c.configSources[model.SourceFile].ReadInConfig())
-	var e viper.ConfigFileNotFoundError
 	if err != nil {
-		if errors.As(err, &e) {
-			return model.ConfigFileNotFoundError{Err: err}
-		}
-		return err
+		return model.NewConfigFileNotFoundError(err) // nolint: forbidigo // constructing proper error
 	}
 
 	type extraConf struct {

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -79,8 +79,7 @@ func newSysprobeConfig(configPath string, fleetPoliciesDirPath string) (*types.C
 			return nil, fmt.Errorf("cannot access the system-probe config file (%w); try running the command under the same user as the Datadog Agent", err)
 		}
 
-		var e pkgconfigmodel.ConfigFileNotFoundError
-		if !errors.As(err, &e) && !errors.Is(err, os.ErrNotExist) {
+		if !errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) && !errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("unable to load system-probe config file: %w", err)
 		}
 	}
@@ -206,8 +205,7 @@ func SetupOptionalDatadogConfigWithDir(configDir, configFile string) error {
 	// load the configuration
 	_, err := pkgconfigsetup.LoadDatadogCustom(cfg, "datadog.yaml", option.None[secrets.Component](), pkgconfigsetup.SystemProbe().GetEnvVars())
 	// If `!failOnMissingFile`, do not issue an error if we cannot find the default config file.
-	var e pkgconfigmodel.ConfigFileNotFoundError
-	if err != nil && !errors.As(err, &e) {
+	if err != nil && !errors.Is(err, pkgconfigmodel.ErrConfigFileNotFound) {
 		// special-case permission-denied with a clearer error message
 		if errors.Is(err, fs.ErrPermission) {
 			if runtime.GOOS == "windows" {


### PR DESCRIPTION
### What does this PR do?

When run with `DD_CONF_NODETREEMODEL=enable`, this PR fixes tests for the following packages:

`comp/core/configsync/configsyncimpl/module_integration_test.go`
`cmd/agent/subcommands/run`
`cmd/otel-agent/config/agent_config_test.go`
`comp/networkdeviceconfig/impl/{TestConfig,TestRetrieveConfiguration_Real}`

See individual commits for more details on what is fixed for each of these.

### Motivation

Getting tests to pass with new config model

### Describe how you validated your changes

Tests cover these changes