### PR TITLE
[CONTP-546] DCA: Fix Language Detection Issues During Leader Election Changes

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -12,13 +12,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -36,9 +40,16 @@ type handlerConfig struct {
 }
 
 type languageDetectionHandler struct {
-	ownersLanguages *OwnersLanguages
-	cfg             handlerConfig
-	wlm             workloadmeta.Component
+	ownersLanguages       *OwnersLanguages
+	cfg                   handlerConfig
+	wlm                   workloadmeta.Component
+	leaderElectionEnabled bool
+
+	// Protected by stateMutex
+	wasLeader          bool
+	followerSyncCancel context.CancelFunc
+	initialized        bool // tracks if we've done initial setup
+	stateMutex         sync.Mutex
 }
 
 func newLanguageDetectionHandler(wlm workloadmeta.Component, cfg config.Component) *languageDetectionHandler {
@@ -48,8 +59,10 @@ func newLanguageDetectionHandler(wlm workloadmeta.Component, cfg config.Componen
 			languageTTL:   cfg.GetDuration("cluster_agent.language_detection.cleanup.language_ttl"),
 			cleanupPeriod: cfg.GetDuration("cluster_agent.language_detection.cleanup.period"),
 		},
-		wlm:             wlm,
-		ownersLanguages: newOwnersLanguages(),
+		wlm:                   wlm,
+		ownersLanguages:       newOwnersLanguages(),
+		leaderElectionEnabled: cfg.GetBool("leader_election"),
+		wasLeader:             false,
 	}
 }
 
@@ -61,7 +74,10 @@ func (handler *languageDetectionHandler) startCleanupInBackground(ctx context.Co
 		for {
 			select {
 			case <-cleanupTicker.C:
-				handler.ownersLanguages.cleanExpiredLanguages(handler.wlm)
+				// Only clean expired languages if we're the leader
+				if handler.isLeader() {
+					handler.ownersLanguages.cleanExpiredLanguages(handler.wlm)
+				}
 			case <-ctx.Done():
 				break
 			}
@@ -70,6 +86,11 @@ func (handler *languageDetectionHandler) startCleanupInBackground(ctx context.Co
 
 	// Remove any owner when its corresponding resource is deleted
 	go handler.ownersLanguages.cleanRemovedOwners(handler.wlm)
+
+	// Monitor leadership changes and sync state for followers
+	if handler.leaderElectionEnabled {
+		go handler.monitorLeadershipChanges(ctx)
+	}
 }
 
 // preHandler is called by both leader and followers and returns true if the request should be forwarded or handled by the leader
@@ -128,4 +149,187 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 
 	ProcessedRequests.Inc(statusSuccess)
 	w.WriteHeader(http.StatusOK)
+}
+
+// isLeader checks if the current instance is the leader
+func (handler *languageDetectionHandler) isLeader() bool {
+	if !handler.leaderElectionEnabled {
+		return true
+	}
+
+	leaderEngine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		log.Errorf("Failed to get leader engine: %v", err)
+		return false
+	}
+
+	return leaderEngine.IsLeader()
+}
+
+// monitorLeadershipChanges monitors leader election changes and manages state accordingly
+// Uses a hybrid approach: subscribes to events but also polls periodically as a fallback
+// This is necessary because the event-based mechanism can miss notifications (see PR #37122)
+func (handler *languageDetectionHandler) monitorLeadershipChanges(ctx context.Context) {
+	// Try to get the leader election engine and subscribe
+	var leadershipChangeChan <-chan struct{}
+	if handler.leaderElectionEnabled {
+		leaderEngine, err := leaderelection.GetLeaderEngine()
+		if err != nil {
+			log.Warnf("Failed to get leader engine for event subscription, will use polling only: %v", err)
+		} else {
+			// Subscribe to events, but don't rely on them exclusively
+			leadershipChangeChan, _ = leaderEngine.Subscribe()
+		}
+	}
+
+	// Use a ticker as a fallback mechanism (or primary mechanism if leader election is disabled)
+	// This ensures we don't miss leadership changes even if events are dropped
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	// Cleanup on exit
+	defer func() {
+		handler.stateMutex.Lock()
+		if handler.followerSyncCancel != nil {
+			handler.followerSyncCancel()
+		}
+		handler.stateMutex.Unlock()
+	}()
+
+	// Process initial state
+	handler.handleLeadershipState(ctx)
+
+	// Monitor for leadership changes using both events and polling
+	for {
+		select {
+		case <-leadershipChangeChan:
+			// Event received, check leadership immediately
+			handler.handleLeadershipState(ctx)
+
+		case <-ticker.C:
+			// Periodic check as fallback
+			handler.handleLeadershipState(ctx)
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// handleLeadershipState checks the current leadership state and handles any necessary transitions
+// It manages starting/stopping follower sync when leadership changes
+func (handler *languageDetectionHandler) handleLeadershipState(ctx context.Context) {
+	isLeader := handler.isLeader()
+
+	handler.stateMutex.Lock()
+	defer handler.stateMutex.Unlock()
+
+	// Handle initial state
+	if !handler.initialized {
+		handler.initialized = true
+		handler.wasLeader = isLeader
+
+		if isLeader {
+			log.Info("Starting as leader")
+			// Leader starts with empty state and will populate it from incoming requests
+		} else {
+			log.Info("Starting as follower, will sync DetectedLangs with InjectableLangs")
+			var syncCtx context.Context
+			syncCtx, handler.followerSyncCancel = context.WithCancel(ctx)
+			go handler.syncFollowerWithInjectableLanguages(syncCtx)
+		}
+		return
+	}
+
+	// No change in leadership state
+	if handler.wasLeader == isLeader {
+		return
+	}
+
+	// Update state
+	handler.wasLeader = isLeader
+
+	if isLeader {
+		// Became leader
+		log.Info("Gained leadership")
+		// Since we were a follower, our DetectedLangs are already in sync with InjectableLangs
+		// No need to initialize - we already have the correct state
+
+		// Stop follower sync if running
+		if handler.followerSyncCancel != nil {
+			handler.followerSyncCancel()
+			handler.followerSyncCancel = nil
+		}
+	} else {
+		// Lost leadership
+		log.Info("Lost leadership, starting to sync DetectedLangs with InjectableLangs")
+		// As a follower, we need to keep DetectedLangs in sync with InjectableLangs
+
+		// Start follower sync
+		if handler.followerSyncCancel != nil {
+			handler.followerSyncCancel() // Cancel any existing sync
+		}
+		var syncCtx context.Context
+		syncCtx, handler.followerSyncCancel = context.WithCancel(ctx)
+		go handler.syncFollowerWithInjectableLanguages(syncCtx)
+	}
+}
+
+// syncFollowerWithInjectableLanguages keeps follower's DetectedLangs in sync with InjectableLangs
+// This runs continuously until the context is cancelled or leadership changes
+func (handler *languageDetectionHandler) syncFollowerWithInjectableLanguages(ctx context.Context) {
+	// Subscribe to deployment changes from kubeapiserver
+	// We're interested in InjectableLanguages changes (which come from annotations)
+	filter := workloadmeta.NewFilterBuilder().
+		SetSource("kubeapiserver").
+		AddKind(workloadmeta.KindKubernetesDeployment).
+		Build()
+
+	evChan := handler.wlm.Subscribe(
+		"language-detection-follower",
+		workloadmeta.NormalPriority,
+		filter,
+	)
+	defer handler.wlm.Unsubscribe(evChan)
+
+	for {
+		select {
+		case evBundle := <-evChan:
+			evBundle.Acknowledge()
+
+			// Process deployment events to sync DetectedLangs with InjectableLangs
+			for _, event := range evBundle.Events {
+				if event.Type != workloadmeta.EventTypeSet {
+					continue
+				}
+				deployment := event.Entity.(*workloadmeta.KubernetesDeployment)
+
+				// Extract deployment name and namespace from entity id
+				deploymentIDs := strings.Split(deployment.ID, "/")
+				if len(deploymentIDs) != 2 {
+					continue
+				}
+				namespace := deploymentIDs[0]
+				deploymentName := deploymentIDs[1]
+
+				owner := langUtil.NewNamespacedOwnerReference(
+					"apps/v1",
+					langUtil.KindDeployment,
+					deploymentName,
+					namespace,
+				)
+
+				// Always sync DetectedLangs to match InjectableLangs (even if empty)
+				handler.ownersLanguages.syncFromInjectableLanguages(handler.wlm, owner, deployment.InjectableLanguages, handler.cfg.languageTTL)
+
+				if len(deployment.InjectableLanguages) > 0 {
+					log.Debugf("Follower synced languages for deployment %s/%s from InjectableLanguages",
+						namespace, deploymentName)
+				}
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -307,6 +307,7 @@ func (handler *languageDetectionHandler) syncFollowerWithInjectableLanguages(ctx
 				// Extract deployment name and namespace from entity id
 				deploymentIDs := strings.Split(deployment.ID, "/")
 				if len(deploymentIDs) != 2 {
+					log.Errorf("Invalid deployment ID format: %s, expected 'namespace/name'", deployment.ID)
 					continue
 				}
 				namespace := deploymentIDs[0]


### PR DESCRIPTION
### What does this PR do?
Fixes two issues with language detection during cluster agent leader election changes:
  1. Prevents followers from patching deployments - Only the leader can modify annotations
  2. Followers sync DetectedLanguages with InjectableLanguages, so state is correct when becoming leader


### Motivation
In multi-instance cluster agent setups with leader election:
  - Issue 1: Follower instances were incorrectly removing language annotations from deployments
  - Issue 2: New leaders started with empty state, temporarily removing all language annotations until re-detection

  This caused production issues with language injection being lost during leader transitions.
  This PR implements
  1. `pkg/clusteragent/languagedetection/patcher.go`
  - Added isLeader() method to check leadership status before patching
  - Modified processOwner() to skip patching when not leader
  - Prevents followers from modifying deployment annotations

  2. `cmd/cluster-agent/api/v1/languagedetection/handler.go`
  - Added follower state synchronization in handleLeadershipState()
  - Followers continuously sync DetectedLanguages with InjectableLanguages
  - Ensures state continuity when follower becomes leader

  3. `cmd/cluster-agent/api/v1/languagedetection/util.go`
  - syncFromInjectableLanguages: updates DetectedLanguages to match InjectableLanguages for followers
  
 Maintains single source of truth
  - Leader: Authoritative for language lifecycle (detection, expiry, patching)
  - Followers: Mirror state from InjectableLanguages, ready to take over

### Describe how you validated your changes
1. Deploy cluster agent with 3 replicas and with enablement of 
Process Collection enabled. 
Language detection enabled.
```
datadog:
  processAgent:
    enabled: true
    processCollection: true
  env:
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
clusterAgent:
  enabled: true
  replicas: 3
  env:
    - name: DD_LOG_LEVEL
      value: "DEBUG"
    - name: DD_LANGUAGE_DETECTION_ENABLED
      value: "true"
    - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
      value: "true"
    - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
      value: "true"
clusterChecksRunner:
  enabled: true
```
2. Verify leader pod
```
  kubectl exec -n datadog-agent-helm <leader-pod> -- env | grep -E "LANGUAGE|PATCHER"
  # Result: 
  # DD_LANGUAGE_DETECTION_ENABLED=true
  # DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED=true
```
3. Deploy Test Applications
```
apiVersion: v1
kind: Namespace
metadata:
  name: workload-java
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-java-app
  namespace: workload-java
  labels:
    app: test-java
  annotations:
    # Language detection annotations
    admission.datadoghq.com/java.injected: "true"
    internal.dd.datadoghq.com/app.detected_langs: "container:app,language:java"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test-java
  template:
    metadata:
      labels:
        app: test-java
    spec:
      containers:
      - name: app
        image: openjdk:11-jre-slim
        command: ["sh", "-c", "while true; do sleep 30; done"]
        resources:
          requests:
            memory: "128Mi"
            cpu: "100m"
          limits:
            memory: "256Mi"
            cpu: "200m"
```
4. Verify annotations exist
```
  kubectl get deployment test-java-app -n workload-java -o jsonpath='{.metadata.annotations}' | jq 'keys'
  # Result: 
[
  "admission.datadoghq.com/java.injected",
  "internal.dd.datadoghq.com/app.detected_langs",
 ....
]
```

5. Test Leadership Transition 
  - kill the leader pod 
  - Check Logs for Our Implementation
 
```
  # New leader logs
  kubectl logs -n datadog-agent-helm <new-leader-pod> | grep -E "api/v1/languagedetection/handler.go"
  # Result:
  # "Starting as follower, will sync DetectedLangs with InjectableLangs"
  # "Gained leadership"

  # Follower logs  
  kubectl logs -n datadog-agent-helm <follower-pod> | grep "Follower synced"
  # Result:
  # "Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages"

  kubectl get deployment test-java-app -n workload-java -o jsonpath='{.metadata.annotations}' | jq 'keys'
  # ["admission.datadoghq.com/java.injected", "internal.dd.datadoghq.com/app.detected_langs", ...]
```

  5. Test Language Deprecation Sync
```
  # Remove Java annotation
  kubectl annotate deployment test-java-app -n workload-java admission.datadoghq.com/java.injected- --overwrite

  # Verify removal
  kubectl get deployment test-java-app -n workload-java -o jsonpath='{.metadata.annotations}' | jq 'keys'
  # ["internal.dd.datadoghq.com/app.detected_langs", ...] 
  # (java.injected is gone)

  # Kill current leader to force another transition and wait for 30s

  # Verify annotation stays removed after new leader
  kubectl get deployment test-java-app -n workload-java -o jsonpath='{.metadata.annotations}' | jq 'keys'
  # ["internal.dd.datadoghq.com/app.detected_langs", ...]

 # log of new leader pod
2025-09-04 15:10:09 UTC | CLUSTER | INFO | (api/v1/languagedetection/handler.go:236 in handleLeadershipState) | Starting as follower, will sync DetectedLangs with InjectableLangs
2025-09-04 18:04:20 UTC | CLUSTER | DEBUG | (api/v1/languagedetection/handler.go:326 in syncFollowerWithInjectableLanguages) | Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages
2025-09-04 19:09:34 UTC | CLUSTER | DEBUG | (api/v1/languagedetection/handler.go:326 in syncFollowerWithInjectableLanguages) | Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages
2025-09-04 19:41:52 UTC | CLUSTER | DEBUG | (api/v1/languagedetection/handler.go:326 in syncFollowerWithInjectableLanguages) | Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages
2025-09-04 19:41:52 UTC | CLUSTER | DEBUG | (api/v1/languagedetection/handler.go:326 in syncFollowerWithInjectableLanguages) | Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages
2025-09-04 20:08:13 UTC | CLUSTER | DEBUG | (api/v1/languagedetection/handler.go:326 in syncFollowerWithInjectableLanguages) | Follower synced languages for deployment workload-java/test-java-app from InjectableLanguages
2025-09-04 20:27:50 UTC | CLUSTER | INFO | (api/v1/languagedetection/handler.go:254 in handleLeadershipState) | Gained leadership

```
 


### Additional Notes
