### PR TITLE
fix: [fa]warning on key not available in the config

### DIFF
--- a/pkg/diagnose/connectivity/inventoryendpoint.go
+++ b/pkg/diagnose/connectivity/inventoryendpoint.go
@@ -78,9 +78,13 @@ func (e *endpointDescription) buildEndpoints(cfg model.Reader, domains []domain)
 	if e.route != "" {
 		mainDomain := domains[0]
 		route := e.route
-		urlOverrideKey := getURLOverrideKey(e.altURLOverrideKey, false)
-		if overrideRoute := cfg.GetString(urlOverrideKey); overrideRoute != "" {
-			route = overrideRoute
+		if e.altURLOverrideKey != "" {
+			urlOverrideKey := getURLOverrideKey(e.altURLOverrideKey, false)
+			if cfg.IsKnown(urlOverrideKey) {
+				if overrideRoute := cfg.GetString(urlOverrideKey); overrideRoute != "" {
+					route = overrideRoute
+				}
+			}
 		}
 
 		return []resolvedEndpoint{
@@ -117,7 +121,12 @@ func getAPIKey(cfg model.Reader, configPrefix string, defaultAPIKey string, altA
 	if !altAPIKey {
 		return defaultAPIKey
 	}
-	if apiKey := cfg.GetString(joinSuffix(configPrefix, ".") + "api_key"); apiKey != "" {
+
+	configAPIKey := joinSuffix(configPrefix, ".") + "api_key"
+	if !cfg.IsKnown(configAPIKey) {
+		return defaultAPIKey
+	}
+	if apiKey := cfg.GetString(configAPIKey); apiKey != "" {
 		return apiKey
 	}
 	return defaultAPIKey

--- a/pkg/diagnose/connectivity/inventoryendpoint_test.go
+++ b/pkg/diagnose/connectivity/inventoryendpoint_test.go
@@ -93,11 +93,11 @@ func TestBuildRoute(t *testing.T) {
 			}
 			version.AgentVersion = "6.0.0"
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("site", tt.domain.site)
-			mockConfig.SetWithoutSource("multi_region_failover.enabled", tt.domain.isFailover)
-			mockConfig.SetWithoutSource("multi_region_failover.site", tt.domain.site)
+			mockConfig.BindEnvAndSetDefault("site", tt.domain.site)
+			mockConfig.BindEnvAndSetDefault("multi_region_failover.enabled", tt.domain.isFailover)
+			mockConfig.BindEnvAndSetDefault("multi_region_failover.site", tt.domain.site)
 			if tt.urlOverrideKey != "" {
-				mockConfig.SetWithoutSource(tt.urlOverrideKey, "http://myproxy.com")
+				mockConfig.BindEnvAndSetDefault(tt.urlOverrideKey, "http://myproxy.com")
 			}
 			url := endpointDescription.buildRoute(mockConfig, tt.domain)
 			assert.Equal(t, tt.expected, url)
@@ -252,13 +252,13 @@ func TestBuildEndpoints(t *testing.T) {
 			mockConfig := configmock.New(t)
 
 			for key, value := range tt.config {
-				mockConfig.SetWithoutSource(key, value)
+				mockConfig.BindEnvAndSetDefault(key, value)
 			}
 
-			mockConfig.SetWithoutSource("site", tt.domains[0].site)
+			mockConfig.BindEnvAndSetDefault("site", tt.domains[0].site)
 			if len(tt.domains) > 1 {
-				mockConfig.SetWithoutSource("multi_region_failover.enabled", true)
-				mockConfig.SetWithoutSource("multi_region_failover.site", tt.domains[1].site)
+				mockConfig.BindEnvAndSetDefault("multi_region_failover.enabled", true)
+				mockConfig.BindEnvAndSetDefault("multi_region_failover.site", tt.domains[1].site)
 			}
 
 			endpoints := tt.endpointDescription.buildEndpoints(mockConfig, tt.domains)
@@ -348,11 +348,11 @@ func TestGetDomainInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("api_key", tt.apiKey)
-			mockConfig.SetWithoutSource("site", tt.site)
-			mockConfig.SetWithoutSource("multi_region_failover.enabled", tt.multiRegionFailover)
-			mockConfig.SetWithoutSource("multi_region_failover.site", tt.multiRegionFailoverSite)
-			mockConfig.SetWithoutSource("multi_region_failover.api_key", tt.multiRegionFailoverAPIKey)
+			mockConfig.BindEnvAndSetDefault("api_key", tt.apiKey)
+			mockConfig.BindEnvAndSetDefault("site", tt.site)
+			mockConfig.BindEnvAndSetDefault("multi_region_failover.enabled", tt.multiRegionFailover)
+			mockConfig.BindEnvAndSetDefault("multi_region_failover.site", tt.multiRegionFailoverSite)
+			mockConfig.BindEnvAndSetDefault("multi_region_failover.api_key", tt.multiRegionFailoverAPIKey)
 			domains := getDomains(mockConfig)
 			assert.Equal(t, tt.expectedKeys, domains)
 		})
@@ -423,7 +423,7 @@ func TestCheckHeadWithRedirectLimit(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	cfg := configmock.New(t)
-	cfg.SetWithoutSource("api_key", "test-api-key")
+	cfg.BindEnvAndSetDefault("api_key", "test-api-key")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "HEAD" {


### PR DESCRIPTION
### What does this PR do?
In the connectivity check, verify that a key is known before getting it in order to avoid warn messages like :
```
2025-09-02 16:42:24 WIB | CORE | WARN | (pkg/diagnose/connectivity/inventoryendpoint.go:120 in getAPIKey) | config key "service_discovery.forwarder.api_key" is unknown
2025-09-02 16:42:24 WIB | CORE | WARN | (pkg/diagnose/connectivity/inventoryendpoint.go:120 in getAPIKey) | config key "container_image.api_key" is unknown
```

### Motivation
Support question from a concerned customer

### Describe how you validated your changes
Manual QA

### Additional Notes
