### PR TITLE
[AGNTLOG-208] Increase Logs Agent default max message size

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1115,13 +1115,13 @@ api_key:
   #
   # file_wildcard_selection_mode: by_name
 
-  ## @param max_message_size_bytes - integer - optional - default: 256000
-  ## @env DD_LOGS_CONFIG_MAX_MESSAGE_SIZE_BYTES - integer - optional - default : 256000
+  ## @param max_message_size_bytes - integer - optional - default: 900000
+  ## @env DD_LOGS_CONFIG_MAX_MESSAGE_SIZE_BYTES - integer - optional - default : 900000
   ## The maximum size of single log message in bytes. If maxMessageSizeBytes exceeds
   ## the documented API limit of 1MB - any payloads larger than 1MB will be dropped by the intake.
   # https://docs.datadoghq.com/api/latest/logs/
   #
-  # max_message_size_bytes: 256000
+  # max_message_size_bytes: 900000
 
   ## @param integrations_logs_files_max_size - integer - optional - default: 10
   ## @env DD_LOGS_CONFIG_INTEGRATIONS_LOGS_FILES_MAX_SIZE - integer - optional - default: 10

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1887,7 +1887,7 @@ func podman(config pkgconfigmodel.Setup) {
 }
 
 // LoadProxyFromEnv overrides the proxy settings with environment variables
-func LoadProxyFromEnv(config pkgconfigmodel.Config) {
+func LoadProxyFromEnv(config pkgconfigmodel.ReaderWriter) {
 	// Viper doesn't handle mixing nested variables from files and set
 	// manually.  If we manually set one of the sub value for "proxy" all
 	// other values from the conf file will be shadowed when using

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -133,7 +133,7 @@ const (
 
 	// DefaultMaxMessageSizeBytes is the default value for max_message_size_bytes
 	// If a log message is larger than this byte limit, the overflow bytes will be truncated.
-	DefaultMaxMessageSizeBytes = 256 * 1000
+	DefaultMaxMessageSizeBytes = 900 * 1000
 
 	// DefaultNetworkPathTimeout defines the default timeout for a network path test
 	DefaultNetworkPathTimeout = 1000
@@ -1887,7 +1887,7 @@ func podman(config pkgconfigmodel.Setup) {
 }
 
 // LoadProxyFromEnv overrides the proxy settings with environment variables
-func LoadProxyFromEnv(config pkgconfigmodel.ReaderWriter) {
+func LoadProxyFromEnv(config pkgconfigmodel.Config) {
 	// Viper doesn't handle mixing nested variables from files and set
 	// manually.  If we manually set one of the sub value for "proxy" all
 	// other values from the conf file will be shadowed when using

--- a/pkg/logs/internal/framer/docker_stream_test.go
+++ b/pkg/logs/internal/framer/docker_stream_test.go
@@ -40,7 +40,7 @@ func TestDetectDockerHeader(t *testing.T) {
 		gotLens = append(gotLens, rawDataLen)
 	}
 
-	fr := NewFramer(outputFn, DockerStream, 256000)
+	fr := NewFramer(outputFn, DockerStream, 900000)
 
 	for i := 4; i < 8; i++ {
 		input := []byte("hello\n")
@@ -70,7 +70,7 @@ func TestDetectMultipleDockerHeader(t *testing.T) {
 		gotLens = append(gotLens, rawDataLen)
 	}
 
-	fr := NewFramer(outputFn, DockerStream, 256000)
+	fr := NewFramer(outputFn, DockerStream, 900000)
 
 	var input []byte
 	for i := 0; i < 100; i++ {
@@ -95,7 +95,7 @@ func TestDetectMultipleDockerHeaderOnAChunkedLine(t *testing.T) {
 		gotLens = append(gotLens, rawDataLen)
 	}
 
-	fr := NewFramer(outputFn, DockerStream, 256000)
+	fr := NewFramer(outputFn, DockerStream, 900000)
 
 	var input []byte
 	longestChunk := strings.Repeat("A", 16384)
@@ -132,7 +132,7 @@ func TestDecoderNoNewLineBeforeDockerHeader(t *testing.T) {
 		gotLens = append(gotLens, rawDataLen)
 	}
 
-	fr := NewFramer(outputFn, DockerStream, 256000)
+	fr := NewFramer(outputFn, DockerStream, 900000)
 
 	for i := 4; i < 8; i++ {
 		input := []byte("hello")

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
-const contentLenLimit = 256000
+const contentLenLimit = 900000
 
 // brokenLine represents a decoded line and the raw length
 type brokenLine struct {

--- a/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
+++ b/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
@@ -6,7 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-fixes:
+enhancements:
   - |
     Increase the Logs Agent default max message payload size from 256 KB to 900 KB.
-

--- a/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
+++ b/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Increase the logs agent default max messsage payload size from 256 kb to 900 kb.
+    Increase the Logs Agent default max message payload size from 256 KB to 900 KB.
 

--- a/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
+++ b/releasenotes/notes/increase-default-max-payload-3147e552384a6fb8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Increase the logs agent default max messsage payload size from 256 kb to 900 kb.
+


### PR DESCRIPTION
### What does this PR do?
Increase Logs Agent default max log message size from 256KB to 900KB. 

### Motivation
https://datadoghq.atlassian.net/browse/AGNTLOG-208

### Describe how you validated your changes
Unit Tests

<details><summary>Manual Testing</summary>
<p>
Locally, generate logs with a known quantity of messages > 900KB (need to be truncated). Manually validate the updated default max log message size is enforced and the expected quantity are truncated. 

```shell
#!/bin/bash

# Counters
log_count=0
max_logs=100

echo "Starting mixed log generation - will create $max_logs logs total"

while [ $log_count -lt $max_logs ]; do
    level_arr=("INFO" "WARNING" "ERROR")
    level=${level_arr[$RANDOM % ${#level_arr[@]}]}

    # Every 3rd log will be oversized (> 900KB limit)
    if [ $((log_count % 3)) -eq 0 ]; then
        # Create oversized message (1MB+ > 900KB limit)
        long_message="$(date) - $level - OVERSIZED Log message $RANDOM - "
        long_message+="$(printf 'A%.0s' {1..1000000})"  # Add 1MB of 'A' characters
        echo "$long_message" | tee -a /var/log/myapp.log
        echo "Created OVERSIZED log #$((log_count + 1)) (1MB+)"
    else
        # Create normal message (< 900KB limit)
        normal_message="$(date) - $level - Log message $RANDOM"
        echo "$normal_message" | tee -a /var/log/myapp.log
        echo "Created normal log #$((log_count + 1))"
    fi

    log_count=$((log_count + 1))
    sleep 1
done

echo "Finished!! Created $max_logs logs total"
echo "There should be $(log_count / 3) oversized logs and $((log_count - log_count / 3)) normal logs"
``` 
</p>
</details> 

### Additional Notes
