### PR TITLE
Start agent on configure from systray

### DIFF
--- a/comp/systray/systray/systrayimpl/doconfigure.go
+++ b/comp/systray/systray/systrayimpl/doconfigure.go
@@ -7,10 +7,16 @@
 package systrayimpl
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"time"
 
+	"golang.org/x/sys/windows/svc"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 func onConfigure(s *systrayImpl) {
@@ -23,6 +29,16 @@ func onConfigure(s *systrayImpl) {
 }
 
 func doConfigure(s *systrayImpl) error {
+	// Start the agent service if it's not running
+	onStart(s)
+
+	// If the agent service was not already running, wait for it to be running
+	ctx, cancel := context.WithTimeout(context.Background(), winutil.DefaultServiceCommandTimeout*time.Second)
+	defer cancel()
+
+	if err := winutil.WaitForState(ctx, common.ServiceName, svc.Running); err != nil {
+		return fmt.Errorf("agent service failed to start within timeout: %v", err)
+	}
 
 	guiPort := s.config.GetString("GUI_port")
 	if guiPort == "-1" {

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	// DefaultServiceCommandTimeout is the default timeout for a service commands
 	DefaultServiceCommandTimeout = 30
 )
 

--- a/pkg/util/winutil/service.go
+++ b/pkg/util/winutil/service.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultServiceCommandTimeout = 30
+	DefaultServiceCommandTimeout = 30
 )
 
 // to support edge case/rase condition testing
@@ -109,7 +109,7 @@ func doStartService(service *mgr.Service, serviceArgs ...string) error {
 	// Are we in SERVICE_STOP_PENDING state?
 	if status.State == svc.StopPending {
 		// Lets wait for its completion before preceding
-		ctx, cancel := context.WithTimeout(context.Background(), defaultServiceCommandTimeout*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultServiceCommandTimeout*time.Second)
 		defer cancel()
 
 		status.State, err = waitForPendingStateChange(ctx, service, status.State)
@@ -256,7 +256,7 @@ func doStopServiceWithDependencies(manager *mgr.Mgr, service *mgr.Service,
 	}
 
 	// extend deadline to account for all services we are trying to stop
-	totalTimeout := time.Duration(len(depServices)+1) * defaultServiceCommandTimeout * time.Second
+	totalTimeout := time.Duration(len(depServices)+1) * DefaultServiceCommandTimeout * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
 	defer cancel()
 

--- a/releasenotes/notes/start-agent-on-configure-595265595536fd46.yaml
+++ b/releasenotes/notes/start-agent-on-configure-595265595536fd46.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Start the agent service on configure if it is not running
+    Start the Agent service when "Configure" is clicked from the systray, if it is not running

--- a/releasenotes/notes/start-agent-on-configure-595265595536fd46.yaml
+++ b/releasenotes/notes/start-agent-on-configure-595265595536fd46.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Start the agent service on configure if it is not running


### PR DESCRIPTION
### What does this PR do?
If agent is not running and `configure` is clicked from the systray, start the agent and open the GUI.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1523

### Describe how you validated your changes
Manually on VM (built the systray and copied over to VM):
Test 1
1. Clicked `Configure` from systray when agent is stopped
2. Verified the GUI is opened and agent is running

Test 2
1. Clicked `Configure` when the agent is running
2. Verified the GUI still opens

### Additional Notes
