### PR TITLE
Re-disable `bazel` remote cache by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,10 +9,10 @@ build:linux --strategy=sandboxed
 build:macos --strategy=sandboxed
 build:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
 
-# Caching
-common --remote_instance_name=remote-caching
-common --remote_cache=grpc://bazel-buildbarn-frontend.ddbuild.io:443
-common --remote_timeout=60
-common --remote_retries=1
+# Remote cache: opt in by adding `common --config=cache` to either `user.bazelrc` (workspace) or `~/.bazelrc` (home)
+common:cache --remote_instance_name=remote-caching
+common:cache --remote_cache=grpc://bazel-buildbarn-frontend.ddbuild.io:443
+common:cache --remote_timeout=60
+common:cache --remote_retries=1
 
 try-import %workspace%/user.bazelrc

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -1,0 +1,40 @@
+As you may have noticed, we've been transitioning to the `bazel` build system.
+
+Although most elements are still under development, here are a few notes that could "help us help you."
+
+### Single requirement: `bazelisk`
+
+If your OS or dev container does not already provide it, you will need to install the `bazelisk` tool, which will
+automatically switch to the version of `bazel` specified in the branch you wish to contribute to.
+
+We recommend using `brew` because the package also installs a symbolic link named `bazel`:
+(which is very useful on a daily basis, such as matching examples in the literature)
+
+```sh
+brew install bazelisk
+```
+
+Otherwise, please choose the `bazelisk` installation method that suits you best; you can find some of them here:
+
+- [Installation](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#installation)
+- [Requirements](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#requirements)
+
+In that case, please consider adding a link to `bazelisk` named `bazel` in your PATH.
+
+### Autocorrection of `bazel` files: `buildifier`
+
+To help us maintain good `bazel` file hygiene, please preferably run the version of `buildifier` specified in the branch
+you wish to work in:
+
+```sh
+bazel run //bazel/buildifier
+```
+
+### Remote cache (internal to Datadog)
+
+If you are on the Datadog internal network and want to take advantage of the remote cache, simply add the following line
+to a `user.bazelrc` file located at the root of the workspace, or to a `.bazelrc` file located in your home directory:
+
+```
+common --config=cache
+```

--- a/tools/bazel
+++ b/tools/bazel
@@ -26,6 +26,7 @@ fi
 # Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 cat >"$CI_PROJECT_DIR/user.bazelrc" <<EOF
 startup --output_user_root=$BAZEL_OUTPUT_USER_ROOT
+common --config=cache
 common --repo_contents_cache=$ext_repo_contents_cache
 build --disk_cache=$BAZEL_DISK_CACHE
 EOF

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -42,6 +42,7 @@ if exist "!BAZEL_REPO_CONTENTS_CACHE!" (
 rem Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 (
   echo startup --output_user_root=!BAZEL_OUTPUT_USER_ROOT!
+  echo common --config=cache
   echo common --repo_contents_cache=!ext_repo_contents_cache!
   echo build --disk_cache=!BAZEL_DISK_CACHE!
 ) >"!CI_PROJECT_DIR!\user.bazelrc"


### PR DESCRIPTION
### What does this PR do?
This reverts commit fd983366bbe4729a69d1900da164f9253ace303b: "Reenable `bazel` remote cache (#40322)".

### Motivation
I did overlook that:
> RE should be disabled by default, because, for instance, external contributors are unable to access it
> if users wanted to enable it explicitly they could've used `user.bazelrc`

Thanks to @JSGette for reminding me!

Here's the right fix, then, that is by opting in in CI - thus exercising the documented configuration.

### Additional Notes
The change also provides with an initial `README.md` file aiming at versioning some user-facing `bazel` knowledge base together with the code.