### PR TITLE
dyninst: reduce memory usage for scraping and symbolicator

### DIFF
--- a/pkg/dyninst/gosym/cli/symbol.go
+++ b/pkg/dyninst/gosym/cli/symbol.go
@@ -77,7 +77,7 @@ var listCmd = &cobra.Command{
 		}
 		defer func() { retErr = errors.Join(retErr, closeFn()) }()
 		for fn := range symtab.Functions() {
-			fmt.Printf("%s %#x-%#x\n", fn.Name, fn.Entry, fn.End)
+			fmt.Printf("%s %#x-%#x\n", fn.Name(), fn.Entry, fn.End)
 		}
 		return nil
 	},

--- a/pkg/dyninst/gosym/cli/symbol.go
+++ b/pkg/dyninst/gosym/cli/symbol.go
@@ -11,32 +11,120 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
+
+	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gosym"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 )
 
-func run(binary string, pc uint64) error {
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Short: "PC symbolication utilities",
+}
+
+func init() {
+	rootCmd.AddCommand(addr2lineCmd)
+	rootCmd.AddCommand(listCmd)
+}
+
+var addr2lineCmd = &cobra.Command{
+	Use:   "addr2line <binary> <pc>",
+	Short: "Resolve a PC to function@file:line",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+		pc, err := strconv.ParseUint(args[1], 0, 64)
+		if err != nil {
+			return fmt.Errorf("invalid pc: %w", err)
+		}
+		binary := args[0]
+		cmd.SilenceUsage = true
+		symtab, closeFn, err := openGoSymbolTable(binary)
+		if err != nil {
+			return err
+		}
+		defer func() { retErr = errors.Join(retErr, closeFn()) }()
+		locations := symtab.LocatePC(pc)
+		if len(locations) == 0 {
+			return fmt.Errorf("no location found for pc 0x%x", pc)
+		}
+		for _, location := range locations {
+			fmt.Printf("%s@%s:%d\n", location.Function, location.File, location.Line)
+		}
+		return nil
+	},
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list <binary>",
+	Short: "List all functions in a Go binary",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+		binary := args[0]
+		cmd.SilenceUsage = true
+
+		symtab, closeFn, err := openGoSymbolTable(binary)
+		if err != nil {
+			return err
+		}
+		defer func() { retErr = errors.Join(retErr, closeFn()) }()
+		for fn := range symtab.Functions() {
+			fmt.Printf("%s %#x-%#x\n", fn.Name, fn.Entry, fn.End)
+		}
+		return nil
+	},
+}
+
+// openGoSymbolTable opens the binary and constructs the Go symbol table.
+// The returned close function must be called to release resources.
+func openGoSymbolTable(binary string) (
+	_ *gosym.GoSymbolTable, _ func() error, retErr error,
+) {
+	var closers []io.Closer
+	cleanupFn := func() error {
+		var err error
+		for _, closer := range closers {
+			err = errors.Join(err, closer.Close())
+		}
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, cleanupFn())
+		}
+	}()
+
 	mef, err := object.OpenMMappingElfFile(binary)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer func() { err = errors.Join(err, mef.Close()) }()
+	closers = append(closers, mef)
+
 	moduledata, err := object.ParseModuleData(mef)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
+
 	goDebugSections, err := moduledata.GoDebugSections(mef)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	defer func() { err = errors.Join(err, goDebugSections.Close()) }()
+	closers = append(closers, goDebugSections)
+
 	goVersion, err := object.ReadGoVersion(mef)
 	if err != nil {
-		return err
+		_ = errors.Join(goDebugSections.Close(), mef.Close())
+		return nil, nil, err
 	}
+
 	symtab, err := gosym.ParseGoSymbolTable(
 		goDebugSections.PcLnTab.Data(),
 		goDebugSections.GoFunc.Data(),
@@ -47,31 +135,8 @@ func run(binary string, pc uint64) error {
 		goVersion,
 	)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	locations := symtab.LocatePC(pc)
-	if len(locations) == 0 {
-		return fmt.Errorf("no location found for pc 0x%x", pc)
-	}
-	for _, location := range locations {
-		fmt.Printf("%s@%s:%d\n", location.Function, location.File, location.Line)
-	}
-	return nil
-}
 
-func main() {
-	if len(os.Args) != 3 {
-		fmt.Println("Usage: symbol <binary> <pc>")
-		os.Exit(1)
-	}
-	pc, err := strconv.ParseUint(os.Args[2], 16, 64)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	err = run(os.Args[1], pc)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	return symtab, cleanupFn, nil
 }

--- a/pkg/dyninst/gosym/cli/symbol.go
+++ b/pkg/dyninst/gosym/cli/symbol.go
@@ -119,12 +119,6 @@ func openGoSymbolTable(binary string) (
 	}
 	closers = append(closers, goDebugSections)
 
-	goVersion, err := object.ReadGoVersion(mef)
-	if err != nil {
-		_ = errors.Join(goDebugSections.Close(), mef.Close())
-		return nil, nil, err
-	}
-
 	symtab, err := gosym.ParseGoSymbolTable(
 		goDebugSections.PcLnTab.Data(),
 		goDebugSections.GoFunc.Data(),
@@ -132,7 +126,6 @@ func openGoSymbolTable(binary string) (
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/dyninst/gosym/symtab_benchmark_test.go
+++ b/pkg/dyninst/gosym/symtab_benchmark_test.go
@@ -45,11 +45,6 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	goVersion, err := object.ReadGoVersion(mef)
-	if err != nil {
-		b.Fatal(err)
-	}
-
 	goDebugSections, err := moduledata.GoDebugSections(mef)
 	if err != nil {
 		b.Fatal(err)
@@ -65,7 +60,6 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 				moduledata.EText,
 				moduledata.MinPC,
 				moduledata.MaxPC,
-				goVersion,
 			)
 			if err != nil {
 				b.Fatal(err)
@@ -80,7 +74,6 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	if err != nil {
 		b.Fatal(err)

--- a/pkg/dyninst/gosym/symtab_benchmark_test.go
+++ b/pkg/dyninst/gosym/symtab_benchmark_test.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package gosym
+package gosym_test
 
 import (
 	"math/rand"
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gosym"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
@@ -22,38 +23,28 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		GOARCH:      "arm64",
 		GOTOOLCHAIN: "go1.24.3",
 	})
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	mef, err := object.OpenMMappingElfFile(binPath)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	defer mef.Close()
 
 	b.Run("ParseModuleData", func(b *testing.B) {
 		for b.Loop() {
 			_, err := object.ParseModuleData(mef)
-			if err != nil {
-				b.Fatal(err)
-			}
+			require.NoError(b, err)
 		}
 	})
 
 	moduledata, err := object.ParseModuleData(mef)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 
 	goDebugSections, err := moduledata.GoDebugSections(mef)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	defer func() { require.NoError(b, goDebugSections.Close()) }()
 
 	b.Run("ParseGoSymbolTable", func(b *testing.B) {
 		for b.Loop() {
-			_, err := ParseGoSymbolTable(
+			_, err := gosym.ParseGoSymbolTable(
 				goDebugSections.PcLnTab.Data(),
 				goDebugSections.GoFunc.Data(),
 				moduledata.Text,
@@ -67,7 +58,7 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		}
 	})
 
-	symtab, err := ParseGoSymbolTable(
+	symtab, err := gosym.ParseGoSymbolTable(
 		goDebugSections.PcLnTab.Data(),
 		goDebugSections.GoFunc.Data(),
 		moduledata.Text,
@@ -75,9 +66,7 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 		moduledata.MinPC,
 		moduledata.MaxPC,
 	)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 
 	b.Run("ListFunctions", func(b *testing.B) {
 		for b.Loop() {

--- a/pkg/dyninst/gosym/symtab_benchmark_test.go
+++ b/pkg/dyninst/gosym/symtab_benchmark_test.go
@@ -88,12 +88,12 @@ func BenchmarkParseGoSymbolTable(b *testing.B) {
 
 	b.Run("ListFunctions", func(b *testing.B) {
 		for b.Loop() {
-			symtab.Functions()
+			symtab.CollectFunctions()
 		}
 	})
 
 	var pcs []uint64
-	for _, f := range symtab.Functions() {
+	for f := range symtab.Functions() {
 		pcs = append(pcs, (f.Entry+f.End)/2)
 	}
 

--- a/pkg/dyninst/gosym/symtab_test.go
+++ b/pkg/dyninst/gosym/symtab_test.go
@@ -65,9 +65,6 @@ func runTest(
 	moduledata, err := object.ParseModuleData(obj)
 	require.NoError(t, err)
 
-	goVersion, err := object.ReadGoVersion(obj)
-	require.NoError(t, err)
-
 	goDebugSections, err := moduledata.GoDebugSections(obj)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, goDebugSections.Close()) }()
@@ -79,7 +76,6 @@ func runTest(
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	require.NoError(t, err)
 

--- a/pkg/dyninst/gosym/symtab_test.go
+++ b/pkg/dyninst/gosym/symtab_test.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package gosym
+package gosym_test
 
 import (
 	"bytes"
@@ -62,22 +62,9 @@ func runTest(
 	require.NoError(t, err)
 	require.Empty(t, iro.Issues)
 
-	moduledata, err := object.ParseModuleData(obj)
+	symtab, err := object.OpenGoSymbolTable(binPath)
 	require.NoError(t, err)
-
-	goDebugSections, err := moduledata.GoDebugSections(obj)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, goDebugSections.Close()) }()
-
-	symtab, err := ParseGoSymbolTable(
-		goDebugSections.PcLnTab.Data(),
-		goDebugSections.GoFunc.Data(),
-		moduledata.Text,
-		moduledata.EText,
-		moduledata.MinPC,
-		moduledata.MaxPC,
-	)
-	require.NoError(t, err)
+	defer func() { require.NoError(t, symtab.Close()) }()
 
 	var out bytes.Buffer
 	var inlinedSp *ir.Subprogram

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -241,9 +241,6 @@ func testDyninst(
 	moduledata, err := object.ParseModuleData(obj)
 	require.NoError(t, err)
 
-	goVersion, err := object.ReadGoVersion(obj)
-	require.NoError(t, err)
-
 	goDebugSections, err := moduledata.GoDebugSections(obj)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, goDebugSections.Close()) }()
@@ -255,7 +252,6 @@ func testDyninst(
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	require.NoError(t, err)
 	symbolicator := symbol.NewGoSymbolicator(symbolTable)

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/gosym"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
@@ -238,23 +237,11 @@ func testDyninst(
 	require.NoError(t, err)
 	defer func() { require.NoError(t, obj.Close()) }()
 
-	moduledata, err := object.ParseModuleData(obj)
+	symbolTable, err := object.ParseGoSymbolTable(obj)
 	require.NoError(t, err)
-
-	goDebugSections, err := moduledata.GoDebugSections(obj)
+	defer func() { require.NoError(t, symbolTable.Close()) }()
 	require.NoError(t, err)
-	defer func() { require.NoError(t, goDebugSections.Close()) }()
-
-	symbolTable, err := gosym.ParseGoSymbolTable(
-		goDebugSections.PcLnTab.Data(),
-		goDebugSections.GoFunc.Data(),
-		moduledata.Text,
-		moduledata.EText,
-		moduledata.MinPC,
-		moduledata.MaxPC,
-	)
-	require.NoError(t, err)
-	symbolicator := symbol.NewGoSymbolicator(symbolTable)
+	symbolicator := symbol.NewGoSymbolicator(&symbolTable.GoSymbolTable)
 	require.NotNil(t, symbolicator)
 
 	cachingSymbolicator, err := symbol.NewCachingSymbolicator(symbolicator, 10000)

--- a/pkg/dyninst/module/symbol.go
+++ b/pkg/dyninst/module/symbol.go
@@ -58,11 +58,6 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ i
 		return nil, nil, fmt.Errorf("error parsing module data: %w", err)
 	}
 
-	goVersion, err := object.ReadGoVersion(mef)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing go version: %w", err)
-	}
-
 	goDebugSections, err := moduledata.GoDebugSections(mef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting go debug sections: %w", err)
@@ -75,7 +70,6 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ i
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing go symbol table: %w", err)

--- a/pkg/dyninst/module/symbol.go
+++ b/pkg/dyninst/module/symbol.go
@@ -8,7 +8,6 @@
 package module
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -38,43 +37,18 @@ func (n noopSymbolicator) Symbolicate(_ []uint64, _ uint64) ([]symbol.StackFrame
 
 var _ symbol.Symbolicator = noopSymbolicator{}
 
-func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ io.Closer, retErr error) {
-	var closer multiCloser
+func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, c io.Closer, retErr error) {
 	defer func() {
-		if retErr != nil {
-			_ = closer.Close()
+		if retErr != nil && c != nil {
+			_ = c.Close()
 		}
 	}()
-	mef, err := object.OpenMMappingElfFile(executable.Path)
+	symbolTable, err := object.OpenGoSymbolTable(executable.Path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating mmapping elf file: %w", err)
+		return nil, nil, fmt.Errorf("error opening go symbol table: %w", err)
 	}
-	closer.closers = append(closer.closers, mef)
-	// Do not close mef here, it must be kept open for the symbolicator to work.
-	// It will be closed when the symbolicator is closed.
-
-	moduledata, err := object.ParseModuleData(mef)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing module data: %w", err)
-	}
-
-	goDebugSections, err := moduledata.GoDebugSections(mef)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting go debug sections: %w", err)
-	}
-	closer.closers = append(closer.closers, goDebugSections)
-	symbolTable, err := gosym.ParseGoSymbolTable(
-		goDebugSections.PcLnTab.Data(),
-		goDebugSections.GoFunc.Data(),
-		moduledata.Text,
-		moduledata.EText,
-		moduledata.MinPC,
-		moduledata.MaxPC,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error parsing go symbol table: %w", err)
-	}
-	symbolicator := symbol.NewGoSymbolicator(symbolTable)
+	c = symbolTable
+	symbolicator := symbol.NewGoSymbolicator(&symbolTable.GoSymbolTable)
 	if symbolicator == nil {
 		return nil, nil, fmt.Errorf("error creating go symbolicator")
 	}
@@ -84,19 +58,5 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, _ i
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating caching symbolicator: %w", err)
 	}
-	return cachingSymbolicator, &closer, nil
-}
-
-type multiCloser struct {
-	closers []io.Closer
-}
-
-func (m *multiCloser) Close() error {
-	var errs []error
-	for _, closer := range m.closers {
-		if err := closer.Close(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+	return cachingSymbolicator, symbolTable, nil
 }

--- a/pkg/dyninst/object/gomoduledata.go
+++ b/pkg/dyninst/object/gomoduledata.go
@@ -17,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
-// TODO: MMap accessed sections. Requires threading through original file along the elf.File object
-
 // Module data offsets
 const (
 	ModuledataMinPCOffset       = 160

--- a/pkg/dyninst/object/gosym.go
+++ b/pkg/dyninst/object/gosym.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package object
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/gosym"
+)
+
+// GoSymbolTable is a wrapper around the Go symbol table.
+//
+// Note that it is not safe to use the SymbolTable field after calling Close.
+type GoSymbolTable struct {
+	gosym.GoSymbolTable
+	GoDebugSections
+	ModuleData *ModuleData
+
+	// The GoDebugSections and GoDebugSections are both part of the struct
+	// so that by holding any references to the GoSymbolTable alive will
+	// prevent the GoDebugSections from being garbage collected, and thus
+	// will prevent the finalizers from running. This is all just a
+	// precaution to help prevent misuse, but it is not enforced by the type
+	// system.
+	_ struct{}
+}
+
+// OpenGoSymbolTable opens the Go symbol table from an object file.
+func OpenGoSymbolTable(path string) (_ *GoSymbolTable, retErr error) {
+	mef, err := OpenMMappingElfFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		closeErr := mef.Close()
+		if retErr == nil {
+			retErr = closeErr
+		} else if closeErr != nil {
+			retErr = errors.Join(retErr, closeErr)
+		}
+	}()
+	return ParseGoSymbolTable(mef)
+}
+
+// ParseGoSymbolTable parses the Go symbol table from an object file.
+func ParseGoSymbolTable(mef File) (_ *GoSymbolTable, retErr error) {
+	moduledata, err := ParseModuleData(mef)
+	if err != nil {
+		return nil, err
+	}
+
+	goDebugSections, err := moduledata.GoDebugSections(mef)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if err := goDebugSections.Close(); err != nil {
+			retErr = errors.Join(retErr, err)
+		}
+	}()
+
+	symbolTable, err := gosym.ParseGoSymbolTable(
+		goDebugSections.PcLnTab.Data(),
+		goDebugSections.GoFunc.Data(),
+		moduledata.Text,
+		moduledata.EText,
+		moduledata.MinPC,
+		moduledata.MaxPC,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoSymbolTable{
+		GoSymbolTable:   *symbolTable,
+		GoDebugSections: *goDebugSections,
+		ModuleData:      moduledata,
+	}, nil
+}

--- a/pkg/dyninst/object/goversion.go
+++ b/pkg/dyninst/object/goversion.go
@@ -29,7 +29,7 @@ type GoVersion struct {
 	PatchOrRC PatchOrReleaseCandidate
 }
 
-// ReadGoVersion extracts the Go version from an object file
+// ReadGoVersion extracts the Go version from an object file.
 func ReadGoVersion(mef File) (*GoVersion, error) {
 	// Find the runtime.buildVersion symbol
 	symbols, err := mef.Symbols()

--- a/pkg/dyninst/object/goversion.go
+++ b/pkg/dyninst/object/goversion.go
@@ -72,7 +72,7 @@ func ReadGoVersion(mef File) (*GoVersion, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to parse version: %s", versionStr)
 	}
-	return &version, nil
+	return version, nil
 }
 
 func readString(mef SectionLoader, section *safeelf.SectionHeader, address, size uint64) (string, error) {
@@ -139,38 +139,38 @@ func readString(mef SectionLoader, section *safeelf.SectionHeader, address, size
 var goVersionRegex = regexp.MustCompile(`^go(\d+)\.(\d+)(\.(\d+)|rc(\d+))`)
 
 // ParseGoVersion parses a Go version string into a GoVersion struct.
-func ParseGoVersion(version string) (GoVersion, bool) {
+func ParseGoVersion(version string) (*GoVersion, bool) {
 	matches := goVersionRegex.FindStringSubmatch(version)
 	if matches == nil {
-		return GoVersion{}, false
+		return nil, false
 	}
 
 	major, err := strconv.ParseUint(matches[1], 10, 16)
 	if err != nil {
-		return GoVersion{}, false
+		return nil, false
 	}
 
 	minor, err := strconv.ParseUint(matches[2], 10, 16)
 	if err != nil {
-		return GoVersion{}, false
+		return nil, false
 	}
 
 	var patchOrRC PatchOrReleaseCandidate
 	if matches[4] != "" { // patch version
 		patch, err := strconv.ParseUint(matches[4], 10, 16)
 		if err != nil {
-			return GoVersion{}, false
+			return nil, false
 		}
 		patchOrRC = PatchOrReleaseCandidate{IsPatch: true, Version: uint16(patch)}
 	} else if matches[5] != "" { // release candidate
 		rc, err := strconv.ParseUint(matches[5], 10, 16)
 		if err != nil {
-			return GoVersion{}, false
+			return nil, false
 		}
 		patchOrRC = PatchOrReleaseCandidate{IsPatch: false, Version: uint16(rc)}
 	}
 
-	return GoVersion{
+	return &GoVersion{
 		Major:     uint16(major),
 		Minor:     uint16(minor),
 		PatchOrRC: patchOrRC,

--- a/pkg/dyninst/rcscrape/ir_generator_test.go
+++ b/pkg/dyninst/rcscrape/ir_generator_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package rcscrape
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+)
+
+func BenchmarkGenerateIR(b *testing.B) {
+	cfgs := testprogs.MustGetCommonConfigs(b)
+	binary := testprogs.MustGetBinary(b, "sample", cfgs[0])
+	gen := irGenerator{}
+
+	for b.Loop() {
+		_, err := gen.GenerateIR(1, binary, []ir.ProbeDefinition{
+			probeDefinitionV1{},
+			probeDefinitionV2{},
+			symdbProbeDefinition{},
+		})
+		require.NoError(b, err)
+	}
+}

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -725,10 +725,6 @@ func openBinary(binaryPath string, opt ExtractOptions) (binaryInfo, error) {
 	if err != nil {
 		return binaryInfo{}, err
 	}
-	goVersion, err := object.ReadGoVersion(obj)
-	if err != nil {
-		return binaryInfo{}, err
-	}
 
 	goDebugSections, err := moduledata.GoDebugSections(obj)
 	if err != nil {
@@ -745,7 +741,6 @@ func openBinary(binaryPath string, opt ExtractOptions) (binaryInfo, error) {
 		moduledata.EText,
 		moduledata.MinPC,
 		moduledata.MaxPC,
-		goVersion,
 	)
 	if err != nil {
 		return binaryInfo{}, err

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -721,27 +721,7 @@ func openBinary(binaryPath string, opt ExtractOptions) (binaryInfo, error) {
 	}
 	mainModule := binfo.Main.Path
 
-	moduledata, err := object.ParseModuleData(obj)
-	if err != nil {
-		return binaryInfo{}, err
-	}
-
-	goDebugSections, err := moduledata.GoDebugSections(obj)
-	if err != nil {
-		return binaryInfo{}, err
-	}
-
-	// goDebugSections cannot be Close()'ed while symTable is in use. Ownership of
-	// goDebugSections is transferred to the SymDBBuilder.
-
-	symTable, err := gosym.ParseGoSymbolTable(
-		goDebugSections.PcLnTab.Data(),
-		goDebugSections.GoFunc.Data(),
-		moduledata.Text,
-		moduledata.EText,
-		moduledata.MinPC,
-		moduledata.MaxPC,
-	)
+	symTable, err := object.ParseGoSymbolTable(obj)
 	if err != nil {
 		return binaryInfo{}, err
 	}
@@ -771,8 +751,8 @@ func openBinary(binaryPath string, opt ExtractOptions) (binaryInfo, error) {
 	return binaryInfo{
 		obj:                 obj,
 		mainModule:          mainModule,
-		goDebugSections:     goDebugSections,
-		symTable:            symTable,
+		goDebugSections:     &symTable.GoDebugSections,
+		symTable:            &symTable.GoSymbolTable,
 		firstPartyPkgPrefix: firstPartyPkgPrefix,
 		filesFilter:         filesFilter,
 	}, nil


### PR DESCRIPTION
This is fallout from #incident-42623. Along the way, we remove the need to parse the elf symbol table in order to load the gosym table. We also add some other optimizations to make it more efficient to search the gosym table by name. See individual commits.

#### dyninst/rcscrape: use gosym instead of elf symbols

```
name           old time/op    new time/op    delta
GenerateIR-14    4.07ms ±11%    1.95ms ± 7%  -52.00%  (p=0.000 n=10+10)

name           old alloc/op   new alloc/op   delta
GenerateIR-14    7.37MB ± 0%    0.01MB ± 0%  -99.82%  (p=0.000 n=8+8)

name           old allocs/op  new allocs/op  delta
GenerateIR-14     32.6k ± 0%      0.2k ± 0%  -99.40%  (p=0.000 n=10+10)
```


#### dyninst/rcscrape: add a benchmark for ir generation


#### dyninst/object: add gosym parsing utilities

This code was getting repeated too much.

#### dyninst/gosym: remove dependency on GoVersion

Fixes https://datadoghq.atlassian.net/browse/DEBUG-4442.


#### dyninst/gosym: lazily resolve function names


#### dyninst/object: remove stale TODO


#### dyninst/gosym/cli: adopt cobra, add list command

I wanted to look at the functions, this made it easier to do that.


#### dyninst/gosym: provide streaming iteration, fewer ptrs

It's nice to be able to iterate the functions without keeping
them all in RAM at the same time.

Along the way, I removed some allocations:

```
name                                      old time/op    new time/op    delta
ParseGoSymbolTable/ListFunctions-14          213µs ± 2%     141µs ± 2%  -34.00%  (p=0.000 n=10+10)
ParseGoSymbolTable/LocatePC-14               873ns ± 4%     763ns ± 3%  -12.66%  (p=0.000 n=9+10)

name                                      old alloc/op   new alloc/op   delta
ParseGoSymbolTable/ListFunctions-14          261kB ± 0%     203kB ± 0%  -22.22%  (p=0.002 n=8+10)
ParseGoSymbolTable/LocatePC-14                522B ± 0%      362B ± 0%  -30.70%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op  delta
ParseGoSymbolTable/ListFunctions-14          5.91k ± 0%     1.97k ± 0%  -66.72%  (p=0.000 n=10+10)
ParseGoSymbolTable/LocatePC-14                11.0 ± 0%       6.0 ± 0%  -45.45%  (p=0.000 n=10+10)
```
