### PR TITLE
Remove potential culprits for hanging `bazel` diagnostics on Windows in CI

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -37,19 +37,20 @@
       $PSNativeCommandUseErrorActionPreference = $true
       Set-StrictMode -Version 3.0
       '@
-    - Invoke-Expression $FailFast
+      Invoke-Expression $FailFast
+      $Utf8Script = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding([Console]::OutputEncoding.CodePage).GetBytes($SCRIPT))
+      $EncodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes("$FailFast`n$Utf8Script"))
     - >-
-      (($FailFast, $SCRIPT) -join [Environment]::NewLine) | docker run
+      docker run
       --env=BAZELISK_HOME
       --env=BAZEL_DISK_CACHE
       --env=BAZEL_OUTPUT_USER_ROOT
       --env=BAZEL_REPO_CONTENTS_CACHE
       --env=CI_PROJECT_DIR
       --env=RUNNER_TEMP_PROJECT_DIR
-      --interactive
       --rm
       --volume="${CI_PROJECT_DIR}:$CI_PROJECT_DIR"
       --volume="${RUNNER_TEMP_PROJECT_DIR}:$RUNNER_TEMP_PROJECT_DIR"
       --workdir="$CI_PROJECT_DIR"
       "$WINBUILDIMAGE"
-      powershell -Command -
+      powershell -NonInteractive -NoLogo -NoProfile -OutputFormat Text -EncodedCommand $EncodedCommand

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -1,4 +1,5 @@
-@echo off & setlocal EnableDelayedExpansion
+@echo off
+setlocal EnableDelayedExpansion
 >nul chcp 65001
 
 :: Check `bazelisk` properly bootstraps `bazel` or fail with instructions
@@ -57,12 +58,17 @@ set "bazel_exit=!errorlevel!"
 
 :: Diagnostics: dump logs on failure
 if !bazel_exit! neq 0 (
-  >&2 echo 🟡 Bazel failed, dumping available info:
-  for /d %%d in ("!BAZEL_OUTPUT_USER_ROOT!\*") do (
-    for %%f in ("%%d\java.log.*" "%%d\server\*") do (
-      >&2 echo 🟡 %%f:
-      >&2 type "%%f"
-      >&2 echo.
+  >&2 echo 🟡 Bazel failed [!bazel_exit!], dumping available info in !BAZEL_OUTPUT_USER_ROOT! ^(excluding junctions^):
+  for /f "delims=" %%d in ('dir /a:d-l /b "!BAZEL_OUTPUT_USER_ROOT!"') do (
+    >&2 echo 🟡 [%%d]
+    for %%f in ("!BAZEL_OUTPUT_USER_ROOT!\%%d\java.log.*" "!BAZEL_OUTPUT_USER_ROOT!\%%d\server\*") do (
+      if exist "%%f" (
+        >&2 echo 🟡 %%f:
+        >&2 type "%%f"
+        >&2 echo.
+      ) else (
+        >&2 echo 🟡 %%f doesn't exist
+      )
     )
   )
   exit /b !bazel_exit!


### PR DESCRIPTION
### What does this PR do?
These changes aim at removing potential culprits where jobs would hang with no actionable output after `bazel` fails on Windows in CI.

1. `.gitlab/bazel/defs.yaml`:
- Replace script piped to `docker --interactive powershell -Command -` by leveraging `powershell -EncodedCommand`. This is because a pipe may potentially keep either side stuck waiting for the other to resp. read from and write to its buffer, which might not be well handled by GitLab.
  Also, there was an implicit encoding conversion through the pipe which is now explicit and restores the original script encoding. (GitLab's YAML files are UTF-8 encoded, but the `$SCRIPT` variable expansion is altered by Windows console encoding)
- Add PowerShell flags generally recommended in unattended executions:
    - `-NonInteractive`: prevents prompts, failing fast(er) otherwise. (this might look redundant with removing the pipe, but better safe than sorry)
    - `-NoProfile`: skips user/machine profiles for reproducibility, ("stock" behavior)
    - `-NoLogo`: disables PowerShell banners, (there doesn't seem to be one atm)
    - `-OutputFormat Text`: forces plain-text output for build logs. ([avoids "CLIXML" formatting](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.5#-outputformat---o---of))
2. `tools/bazel.bat`:
- Print some more details: exit code, available directories, etc.
- Exclude junction points (`/a:d-l`) from directory traversal to avoid potential infinite loops.

### Motivation
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1182889552:
<img width="739" height="164" alt="image" src="https://github.com/user-attachments/assets/071169d1-1f49-4623-9e63-4f20eabd4263" />
... <img width="246" height="28" alt="image" src="https://github.com/user-attachments/assets/87fce4f7-9351-4ad9-8cce-9595632c29c8" />

### Describe how you validated your changes
Locally, to the extent of what I could simulate.

### Additional Notes
Without actionable diagnostics, we're still blind wrt what prevents the `bazel` client from contacting its server on Windows in CI.