### PR TITLE
[USMON-1483] USM Redis: Migrate configuration to tree structure

### DIFF
--- a/cmd/system-probe/modules/usm_endpoints_linux.go
+++ b/cmd/system-probe/modules/usm_endpoints_linux.go
@@ -60,7 +60,7 @@ func registerUSMEndpoints(nt *networkTracer, httpMux *module.Router) {
 	})
 
 	httpMux.HandleFunc("/debug/redis_monitoring", func(w http.ResponseWriter, req *http.Request) {
-		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.enable_redis_monitoring") {
+		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.redis.enabled") {
 			writeDisabledProtocolMessage("redis", w)
 			return
 		}

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -327,7 +327,7 @@ func (ia *inventoryagent) fetchSystemProbeMetadata() {
 	ia.data["feature_usm_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enabled")
 	ia.data["feature_usm_kafka_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_kafka_monitoring")
 	ia.data["feature_usm_postgres_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_postgres_monitoring")
-	ia.data["feature_usm_redis_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_redis_monitoring")
+	ia.data["feature_usm_redis_enabled"] = sysProbeConf.GetBool("service_monitoring_config.redis.enabled")
 	ia.data["feature_usm_http2_enabled"] = sysProbeConf.GetBool("service_monitoring_config.enable_http2_monitoring")
 	ia.data["feature_usm_istio_enabled"] = sysProbeConf.GetBool("service_monitoring_config.tls.istio.enabled")
 	ia.data["feature_usm_go_tls_enabled"] = sysProbeConf.GetBool("service_monitoring_config.tls.go.enabled")

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -126,7 +126,7 @@ func TestInitData(t *testing.T) {
 		"service_monitoring_config.enable_http2_monitoring":    true,
 		"service_monitoring_config.enable_kafka_monitoring":    true,
 		"service_monitoring_config.enable_postgres_monitoring": true,
-		"service_monitoring_config.enable_redis_monitoring":    true,
+		"service_monitoring_config.redis.enabled":              true,
 		"service_monitoring_config.tls.istio.enabled":          true,
 		"service_monitoring_config.tls.go.enabled":             true,
 		"discovery.enabled":                                    true,
@@ -618,7 +618,8 @@ service_monitoring_config:
   enabled: true
   enable_kafka_monitoring: true
   enable_postgres_monitoring: true
-  enable_redis_monitoring: true
+  redis:
+    enabled: true
   enable_http2_monitoring: true
   enable_http_stats_by_status_code: true
 

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -279,7 +279,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(smNS, "max_kafka_stats_buffered"), 100000)
 	cfg.BindEnv(join(smNS, "max_postgres_stats_buffered"))
 	cfg.BindEnvAndSetDefault(join(smNS, "max_postgres_telemetry_buffer"), 160)
-	cfg.BindEnv(join(smNS, "max_redis_stats_buffered"))
+	cfg.BindEnv(join(smNS, "redis", "max_stats_buffered"))
 	cfg.BindEnv(join(smNS, "max_concurrent_requests"))
 	cfg.BindEnv(join(smNS, "enable_quantization"))
 	cfg.BindEnv(join(smNS, "enable_connection_rollup"))

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -266,7 +266,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_http2_monitoring"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "enable_kafka_monitoring"), false)
 	cfg.BindEnv(join(smNS, "enable_postgres_monitoring"))
-	cfg.BindEnv(join(smNS, "enable_redis_monitoring"))
+	cfg.BindEnvAndSetDefault(join(smNS, "redis", "enabled"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "redis", "track_resources"), false)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "enabled"), true)
 	cfg.BindEnvAndSetDefault(join(smNS, "tls", "istio", "envoy_path"), defaultEnvoyPath)

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -196,7 +196,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		MaxPostgresTelemetryBuffer: cfg.GetInt(sysconfig.FullKeyPath(smNS, "max_postgres_telemetry_buffer")),
 
 		// Redis Protocol Configuration
-		EnableRedisMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "enable_redis_monitoring")),
+		EnableRedisMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "enabled")),
 		RedisTrackResources:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "track_resources")),
 		MaxRedisStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "max_redis_stats_buffered")),
 

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -198,7 +198,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		// Redis Protocol Configuration
 		EnableRedisMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "enabled")),
 		RedisTrackResources:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "redis", "track_resources")),
-		MaxRedisStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "max_redis_stats_buffered")),
+		MaxRedisStatsBuffered: cfg.GetInt(sysconfig.FullKeyPath(smNS, "redis", "max_stats_buffered")),
 
 		// TLS Configuration
 		EnableNativeTLSMonitoring: cfg.GetBool(sysconfig.FullKeyPath(smNS, "tls", "native", "enabled")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1080,7 +1080,7 @@ func TestMaxPostgresStatsBuffered(t *testing.T) {
 func TestEnableRedisMonitoring(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_redis_monitoring", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.redis.enabled", true)
 		cfg := New()
 
 		assert.True(t, cfg.EnableRedisMonitoring)
@@ -1088,7 +1088,7 @@ func TestEnableRedisMonitoring(t *testing.T) {
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_REDIS_MONITORING", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_REDIS_ENABLED", "true")
 		cfg := New()
 
 		_, err := sysconfig.New("", "")

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -1133,7 +1133,7 @@ func TestRedisTrackResources(t *testing.T) {
 func TestMaxRedisStatsBuffered(t *testing.T) {
 	t.Run("value set through env var", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_MAX_REDIS_STATS_BUFFERED", "50000")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_REDIS_MAX_STATS_BUFFERED", "50000")
 		cfg := New()
 
 		assert.Equal(t, 50000, cfg.MaxRedisStatsBuffered)
@@ -1141,7 +1141,7 @@ func TestMaxRedisStatsBuffered(t *testing.T) {
 
 	t.Run("value set through yaml", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("service_monitoring_config.max_redis_stats_buffered", 30000)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.redis.max_stats_buffered", 30000)
 		cfg := New()
 
 		assert.Equal(t, 30000, cfg.MaxRedisStatsBuffered)

--- a/pkg/system-probe/config/adjust_usm.go
+++ b/pkg/system-probe/config/adjust_usm.go
@@ -71,7 +71,7 @@ func adjustUSM(cfg model.Config) {
 	applyDefault(cfg, spNS("process_service_inference", "use_windows_service_name"), true)
 	applyDefault(cfg, smNS("enable_ring_buffers"), true)
 	applyDefault(cfg, smNS("max_postgres_stats_buffered"), 100000)
-	applyDefault(cfg, smNS("max_redis_stats_buffered"), 100000)
+	applyDefault(cfg, smNS("redis", "max_stats_buffered"), 100000)
 
 	// kernel_buffer_pages determines the number of pages allocated *per CPU*
 	// for buffering kernel data, whether using a perf buffer or a ring buffer.


### PR DESCRIPTION
### What does this PR do?

Migrates Redis monitoring configuration from flat structure to nested tree structure, changing `service_monitoring_config.enable_redis_monitoring` to `service_monitoring_config.redis.enabled`.

### Motivation

This is the first change in the effort to migrate protocol configurations into a tree structure, following the pattern established with the TLS tree migration (PR #19515). The nested structure improves organization and provides a namespace for protocol-specific configurations like `redis.track_resources`.

### Describe how you validated your changes

- **Configuration binding**: Updated `pkg/config/setup/system_probe.go` to use `BindEnvAndSetDefault` with nested path
- **Config usage**: Updated `pkg/network/config/config.go` to read from nested path  
- **Tests**: Updated existing `TestEnableRedisMonitoring` to use new configuration paths
- **Default value**: Maintains `false` default for Redis monitoring

### Additional Notes

- **No breaking change**: Redis monitoring was never released, so no backward compatibility needed
- **Tree structure**: Creates foundation for future protocol config migrations (HTTP, HTTP2, Kafka, Postgres)
- **Configuration paths**:
  - Old: `service_monitoring_config.enable_redis_monitoring`
  - New: `service_monitoring_config.redis.enabled`
- **Environment variables**:
  - Old: `DD_SERVICE_MONITORING_CONFIG_ENABLE_REDIS_MONITORING`
  - New: `DD_SERVICE_MONITORING_CONFIG_REDIS_ENABLED`

🤖 Generated with [Claude Code](https://claude.ai/code)