### PR TITLE
[macos test] Disable macos test in flake finder

### DIFF
--- a/.gitlab/e2e_install_packages/macos.yml
+++ b/.gitlab/e2e_install_packages/macos.yml
@@ -11,5 +11,6 @@ new-e2e-agent-platform-install-script-macos-x64:
     - !reference [.manual]
   variables:
     TARGETS: ./tests/agent-platform/macos
+    SHOULD_RUN_IN_FLAKES_FINDER: "false"
 
 


### PR DESCRIPTION
### What does this PR do?


Disable MacOS install script test in flake finder.
Flake finder is a pipeline that runs the test several time on nightlies. For cost reasons and limit in the number of macos host we can have we should disable the macos test in that pipeline

### Motivation

Make sure we do not go over the limit of dedicated host we have

### Describe how you validated your changes

### Additional Notes
