### PR TITLE
[USMON-1484] USM Kafka: Add NO_PREALLOC flags to hash maps

### DIFF
--- a/pkg/config/setup/system_probe_usm.go
+++ b/pkg/config/setup/system_probe_usm.go
@@ -29,6 +29,7 @@ func initUSMSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// Each event has a fixed size of approximately 4KB (sizeof(batch_data_t)).
 	// By setting this value to 100, the channel will buffer up to ~400KB of data in the Go heap memory.
 	cfg.BindEnvAndSetDefault(join(smNS, "data_channel_size"), 100)
+	cfg.BindEnvAndSetDefault(join(smNS, "disable_map_preallocation"), true)
 
 	// ========================================
 	// HTTP Protocol Configuration

--- a/pkg/network/config/usm_config.go
+++ b/pkg/network/config/usm_config.go
@@ -49,6 +49,10 @@ type USMConfig struct {
 	// USMDataChannelSize specifies the size of the data channel for USM
 	USMDataChannelSize int
 
+	// DisableMapPreallocation controls whether eBPF maps should disable preallocation (BPF_F_NO_PREALLOC flag).
+	// When true, maps allocate entries on-demand instead of preallocating the full map size, improving memory efficiency.
+	DisableMapPreallocation bool
+
 	// ========================================
 	// HTTP Protocol Configuration
 	// ========================================
@@ -172,6 +176,7 @@ func NewUSMConfig(cfg model.Config) *USMConfig {
 		EnableUSMEventStream:      cfg.GetBool(sysconfig.FullKeyPath(smNS, "enable_event_stream")),
 		USMKernelBufferPages:      cfg.GetInt(sysconfig.FullKeyPath(smNS, "kernel_buffer_pages")),
 		USMDataChannelSize:        cfg.GetInt(sysconfig.FullKeyPath(smNS, "data_channel_size")),
+		DisableMapPreallocation:   cfg.GetBool(sysconfig.FullKeyPath(smNS, "disable_map_preallocation")),
 
 		// HTTP Protocol Configuration
 		EnableHTTPMonitoring:      cfg.GetBool(sysconfig.FullKeyPath(smNS, "enable_http_monitoring")),

--- a/pkg/network/config/usm_config_test.go
+++ b/pkg/network/config/usm_config_test.go
@@ -109,6 +109,31 @@ func TestUSMDataChannelSize(t *testing.T) {
 	})
 }
 
+func TestDisableMapPreallocation(t *testing.T) {
+	t.Run("via yaml", func(t *testing.T) {
+		mockSystemProbe := mock.NewSystemProbe(t)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.disable_map_preallocation", false)
+		cfg := New()
+
+		assert.False(t, cfg.DisableMapPreallocation)
+	})
+
+	t.Run("via ENV variable", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_DISABLE_MAP_PREALLOCATION", "false")
+		cfg := New()
+
+		assert.False(t, cfg.DisableMapPreallocation)
+	})
+
+	t.Run("default value", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+
+		assert.True(t, cfg.DisableMapPreallocation)
+	})
+}
+
 func TestMaxUSMConcurrentRequests(t *testing.T) {
 	t.Run("default value", func(t *testing.T) {
 		mock.NewSystemProbe(t)

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -266,15 +266,22 @@ func (p *protocol) Name() string {
 // Configuring the kafka event stream with the manager and its options, and enabling the kafka_monitoring_enabled eBPF
 // option.
 func (p *protocol) ConfigureOptions(opts *manager.Options) {
+	var mapFlags uint32
+	editorFlag := manager.EditMaxEntries
+	if p.cfg.DisableMapPreallocation {
+		mapFlags = unix.BPF_F_NO_PREALLOC
+		editorFlag |= manager.EditFlags
+	}
+
 	opts.MapSpecEditors[inFlightMap] = manager.MapSpecEditor{
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
-		Flags:      unix.BPF_F_NO_PREALLOC,
-		EditorFlag: manager.EditMaxEntries | manager.EditFlags,
+		Flags:      mapFlags,
+		EditorFlag: editorFlag,
 	}
 	opts.MapSpecEditors[responseMap] = manager.MapSpecEditor{
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
-		Flags:      unix.BPF_F_NO_PREALLOC,
-		EditorFlag: manager.EditMaxEntries | manager.EditFlags,
+		Flags:      mapFlags,
+		EditorFlag: editorFlag,
 	}
 	netifProbeID := manager.ProbeIdentificationPair{
 		EBPFFuncName: netifProbe,

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -15,6 +15,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
+	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -267,11 +268,13 @@ func (p *protocol) Name() string {
 func (p *protocol) ConfigureOptions(opts *manager.Options) {
 	opts.MapSpecEditors[inFlightMap] = manager.MapSpecEditor{
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
-		EditorFlag: manager.EditMaxEntries,
+		Flags:      unix.BPF_F_NO_PREALLOC,
+		EditorFlag: manager.EditMaxEntries | manager.EditFlags,
 	}
 	opts.MapSpecEditors[responseMap] = manager.MapSpecEditor{
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
-		EditorFlag: manager.EditMaxEntries,
+		Flags:      unix.BPF_F_NO_PREALLOC,
+		EditorFlag: manager.EditMaxEntries | manager.EditFlags,
 	}
 	netifProbeID := manager.ProbeIdentificationPair{
 		EBPFFuncName: netifProbe,


### PR DESCRIPTION
### What does this PR do?

Enables `BPF_F_NO_PREALLOC` flag for Kafka hash maps (`kafka_in_flight` and `kafka_response`) to improve memory efficiency by allocating entries on-demand instead of preallocating the full map size.

### Motivation

Kafka hash maps currently preallocate memory for the full `MaxUSMConcurrentRequests` size even when actual Kafka traffic is low or non-existent. This wastes memory on systems with little Kafka activity. The `NO_PREALLOC` flag enables dynamic allocation, reducing memory footprint.

### Describe how you validated your changes

- **Implementation**: Used `MapSpecEditor` with `unix.BPF_F_NO_PREALLOC` constant for clean, reversible approach
- **Maps affected**: Both `kafka_in_flight` and `kafka_response` hash maps
- **Editor flags**: Combined `manager.EditMaxEntries | manager.EditFlags` to edit both size and flags
- **No eBPF changes**: Implementation done entirely in Go userspace code

### Additional Notes

- **Memory optimization**: Maps will only consume memory for active Kafka connections/transactions
- **Backward compatible**: No functional changes to Kafka monitoring behavior  
- **Clean implementation**: Uses proper `unix.BPF_F_NO_PREALLOC` constant instead of magic numbers
- **Reversible**: No eBPF header file modifications, all changes in Go code

🤖 Generated with [Claude Code](https://claude.ai/code)