### PR TITLE
[CWS] Add eBPFLess support for prctl

### DIFF
--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -52,7 +52,8 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "bind.") &&
 				!strings.HasPrefix(field, "connect.") &&
 				!strings.HasPrefix(field, "setrlimit.") &&
-				!strings.HasPrefix(field, "setsockopt.") {
+				!strings.HasPrefix(field, "setsockopt.") &&
+				!strings.HasPrefix(field, "prctl.") {
 				return rules.ErrEventTypeNotEnabled
 			}
 			return nil

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -359,6 +359,10 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 			pce = model.NewPlaceholderProcessCacheEntry(event.Setrlimit.TargetPid, event.Setrlimit.TargetPid, false)
 		}
 		event.Setrlimit.Target = &pce.ProcessContext
+	case ebpfless.SyscallTypePrctl:
+		event.Type = uint32(model.PrCtlEventType)
+		event.PrCtl.Option = syscallMsg.Prctl.Option
+		event.PrCtl.NewName = syscallMsg.Prctl.NewName
 	}
 
 	// container context

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -101,6 +101,8 @@ const (
 	SyscallTypeSetsockopt
 	// SyscallTypeSetrlimit setrlimit type
 	SyscallTypeSetrlimit
+	// SyscallTypePrctl prctl type
+	SyscallTypePrctl
 )
 
 // ContainerContext defines a container context
@@ -359,6 +361,13 @@ type SetrlimitSyscallMsg struct {
 	Pid      uint32
 }
 
+// PrctlSyscallMsg defines a prctl message
+type PrctlSyscallMsg struct {
+	Option  int
+	Arg2    uint64
+	NewName string
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type         SyscallType
@@ -395,6 +404,7 @@ type SyscallMsg struct {
 	Accept       *AcceptSyscallMsg       `json:",omitempty"`
 	Setsockopt   *SetsockoptSyscallMsg   `json:",omitempty"`
 	Setrlimit    *SetrlimitSyscallMsg    `json:",omitempty"`
+	Prctl        *PrctlSyscallMsg        `json:",omitempty"`
 
 	// internals
 	Dup    *DupSyscallFakeMsg    `json:",omitempty"`

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -84,6 +84,7 @@ const (
 	SetsockoptNr     = unix.SYS_SETSOCKOPT        // SetsockoptNr defines the syscall ID for amd64
 	SetrlimitNr      = unix.SYS_SETRLIMIT         // SetrlimitNr defines the syscall ID for arm64
 	Prlimit64Nr      = unix.SYS_PRLIMIT64         // Prlimit64Nr defines the syscall ID for arm64
+	PrctlNr          = unix.SYS_PRCTL             // PrctlNr defines the syscall ID for amd64
 )
 
 // https://github.com/torvalds/linux/blob/v5.0/arch/x86/entry/entry_64.S#L126

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -66,6 +66,7 @@ const (
 	SetsockoptNr     = unix.SYS_SETSOCKOPT        // SetsockoptNr defines the syscall ID for arm64
 	SetrlimitNr      = unix.SYS_SETRLIMIT         // SetrlimitNr defines the syscall ID for arm64
 	Prlimit64Nr      = unix.SYS_PRLIMIT64         // Prlimit64Nr defines the syscall ID for arm64
+	PrctlNr          = unix.SYS_PRCTL             // PrctlNr defines the syscall ID for arm64
 
 	OpenNr      = -1  // OpenNr not available on arm64
 	ForkNr      = -2  // ForkNr not available on arm64

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -81,6 +81,7 @@ func SkipIfNotAvailable(t *testing.T) {
 			"TestMountPropagated",
 			"~TestSetSockOpt",
 			"~TestSetrlimitEvent",
+			"TestPrCtl",
 		}
 
 		exclude := []string{

--- a/pkg/security/tests/prctl_test.go
+++ b/pkg/security/tests/prctl_test.go
@@ -29,10 +29,6 @@ func TestPrCtl(t *testing.T) {
 			Expression: `prctl.option == PR_SET_NAME && prctl.new_name == "my_thread"`,
 		},
 		{
-			ID:         "test_rule_prctl_truncated",
-			Expression: `prctl.option == PR_SET_NAME && prctl.is_name_truncated == true`,
-		},
-		{
 			ID:         "test_rule_prctl_get_dumpable",
 			Expression: `prctl.option == PR_GET_DUMPABLE`,
 		},
@@ -64,6 +60,39 @@ func TestPrCtl(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_prctl")
 		})
 	})
+	t.Run("prctl-get-dumpable", func(t *testing.T) {
+		test.WaitSignal(t, func() error {
+			_, _, errno := syscall.Syscall6(
+				syscall.SYS_PRCTL,
+				uintptr(syscall.PR_GET_DUMPABLE),
+				0, 0, 0, 0, 0,
+			)
+			if errno != 0 {
+				return fmt.Errorf("prctl(PR_GET_DUMPABLE) failed: %v", errno)
+			}
+			return nil
+		}, func(_ *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_prctl_get_dumpable")
+		})
+	})
+}
+
+func TestPrCtlTruncated(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_rule_prctl_truncated",
+			Expression: `prctl.option == PR_SET_NAME && prctl.is_name_truncated == true`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer test.Close()
 	t.Run("prctl-set-name-truncated", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			bs, err := syscall.BytePtrFromString("my_thread_is_waaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaay_too_long")
@@ -89,20 +118,5 @@ func TestPrCtl(t *testing.T) {
 		assert.NotEmpty(t, test.statsdClient.Get(key))
 		assert.NotZero(t, test.statsdClient.Get(key))
 
-	})
-	t.Run("prctl-get-dumpable", func(t *testing.T) {
-		test.WaitSignal(t, func() error {
-			_, _, errno := syscall.Syscall6(
-				syscall.SYS_PRCTL,
-				uintptr(syscall.PR_GET_DUMPABLE),
-				0, 0, 0, 0, 0,
-			)
-			if errno != 0 {
-				return fmt.Errorf("prctl(PR_GET_DUMPABLE) failed: %v", errno)
-			}
-			return nil
-		}, func(_ *model.Event, rule *rules.Rule) {
-			assertTriggeredRule(t, rule, "test_rule_prctl_get_dumpable")
-		})
 	})
 }


### PR DESCRIPTION
### What does this PR do?
Add eBPFLess support for prctl syscall.
Retrieve all the same info defined in this other PR for eBPF: https://github.com/DataDog/datadog-agent/pull/40340

### Motivation

### Describe how you validated your changes

### Additional Notes
