### PR TITLE
Introduce config-sync to deliver resolved secrets to system-probe

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	configsyncimpl "github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	healthprobefx "github.com/DataDog/datadog-agent/comp/core/healthprobe/fx"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
@@ -151,6 +152,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 				}),
 				settingsimpl.Module(),
+				configsyncimpl.Module(configsyncimpl.NewDefaultParams()),
 				logscompressionfx.Module(),
 				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
 					return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))
@@ -334,6 +336,7 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 			}
 		}),
 		settingsimpl.Module(),
+		configsyncimpl.Module(configsyncimpl.NewDefaultParams()),
 		logscompressionfx.Module(),
 		fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
 			return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))


### PR DESCRIPTION
### What does this PR do?
Introduce config-sync in System Probe, to allow for resolved secrets in `datadog.yaml` to be resolved and delivered to SP.

### Motivation
When we'll introduce direct communication from SP to our BE, resolving secrets using the secret_backend_command could be a security concern. Hence we are relying on config-sync mechanism already in place, but never introduced in SP.

### Describe how you validated your changes
Manual Testing

### Additional Notes
