### PR TITLE
AGTMETRICS-353 Gate Tracef calls on trace loglevel being enabled

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -41,8 +41,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 const (


### PR DESCRIPTION
### What does this PR do?

Gate Tracef calls on trace loglevel being enabled.

Calling Tracef causes an allocation, even if trace log level is not enabled. EnrichTags is called a lot, once for each dogstatsd sample, and avoiding allocations here is worthwhile.

### Motivation

Performance improvements

<img width="954" height="340" alt="Screenshot 2025-09-04 at 13 55 40" src="https://github.com/user-attachments/assets/160cd688-ce86-49a9-b441-d729eaa5d450" />

### Describe how you validated your changes

### Additional Notes
