### PR TITLE
AGTMETRICS-353 Remove hidden allocation in trackContext

### DIFF
--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.69.2 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.69.2 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.69.2 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -211,7 +211,10 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.0.0-00010101000000-000000000000 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.69.2 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.69.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.0.0-00010101000000-000000000000 // indirect

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -28,7 +28,7 @@ func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 	k := ckey.NewKeyGenerator()
 	tb := tagset.NewHashingTagsAccumulator()
 	taggerComponent := nooptagger.NewComponent()
-	sample.GetTags(tb, tb, taggerComponent.EnrichTags)
+	sample.GetTags(tb, tb, taggerComponent)
 	return k.Generate(sample.GetName(), sample.GetHost(), tb)
 }
 

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -101,7 +101,7 @@ func newContextResolver(tagger tagger.Component, cache *tags.Store, id string) *
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, timestamp int64) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.taggerBuffer, cr.metricBuffer, cr.tagger.EnrichTags) // tags here are not sorted and can contain duplicates
+	metricSampleContext.GetTags(cr.taggerBuffer, cr.metricBuffer, cr.tagger) // tags here are not sorted and can contain duplicates
 	defer cr.taggerBuffer.Reset()
 	defer cr.metricBuffer.Reset()
 

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
@@ -248,7 +249,7 @@ func (s *mockSample) GetHost() string                   { return "noop" }
 func (s *mockSample) GetMetricType() metrics.MetricType { return metrics.GaugeType }
 func (s *mockSample) IsNoIndex() bool                   { return false }
 func (s *mockSample) GetSource() metrics.MetricSource   { return metrics.MetricSourceUnknown }
-func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator, _ metrics.EnrichTagsfn) {
+func (s *mockSample) GetTags(tb, mb tagset.TagsAccumulator, _ tagger.Component) {
 	tb.Append(s.taggerTags...)
 	mb.Append(s.metricTags...)
 }

--- a/pkg/aggregator/no_aggregation_stream_worker.go
+++ b/pkg/aggregator/no_aggregation_stream_worker.go
@@ -204,7 +204,7 @@ func (w *noAggregationStreamWorker) run() {
 							}
 
 							// enrich metric sample tags
-							sample.GetTags(w.taggerBuffer, w.metricBuffer, w.tagger.EnrichTags)
+							sample.GetTags(w.taggerBuffer, w.metricBuffer, w.tagger)
 							w.metricBuffer.AppendHashlessAccumulator(w.taggerBuffer)
 
 							// if the value is a rate, we have to account for the 10s interval

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/pkg/metrics
 go 1.24.0
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
@@ -17,8 +18,13 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/flare/types v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -6,6 +6,7 @@
 package metrics
 
 import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
@@ -36,7 +37,7 @@ func (m *HistogramBucket) GetHost() string {
 }
 
 // GetTags returns the bucket tags.
-func (m *HistogramBucket) GetTags(_, metricBuffer tagset.TagsAccumulator, _ EnrichTagsfn) {
+func (m *HistogramBucket) GetTags(_, metricBuffer tagset.TagsAccumulator, _ tagger.Component) {
 	// Other 'GetTags' methods for metrics support origin detections. Since
 	// HistogramBucket only come, for now, from checks we can simply return
 	// tags.

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -6,6 +6,7 @@
 package metrics
 
 import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
@@ -37,9 +38,6 @@ var (
 		DistributionType: {},
 	}
 )
-
-// EnrichTagsfn can be used to Enrich tags with origin detection tags.
-type EnrichTagsfn func(tb tagset.TagsAccumulator, origin taggertypes.OriginInfo)
 
 // String returns a string representation of MetricType
 func (m MetricType) String() string {
@@ -81,7 +79,7 @@ type MetricSampleContext interface {
 	// Implementations should call `Append` or `AppendHashed` on the provided accumulators.
 	// Tags from origin detection should be appended to taggerBuffer. Client-provided tags
 	// should be appended to the metricBuffer.
-	GetTags(taggerBuffer, metricBuffer tagset.TagsAccumulator, fn EnrichTagsfn)
+	GetTags(taggerBuffer, metricBuffer tagset.TagsAccumulator, tagger tagger.Component)
 
 	// GetMetricType returns the metric type for this metric.  This is used for telemetry.
 	GetMetricType() MetricType
@@ -123,9 +121,9 @@ func (m *MetricSample) GetHost() string {
 }
 
 // GetTags returns the metric sample tags
-func (m *MetricSample) GetTags(taggerBuffer, metricBuffer tagset.TagsAccumulator, fn EnrichTagsfn) {
+func (m *MetricSample) GetTags(taggerBuffer, metricBuffer tagset.TagsAccumulator, tagger tagger.Component) {
 	metricBuffer.Append(m.Tags...)
-	fn(taggerBuffer, m.OriginInfo)
+	tagger.EnrichTags(taggerBuffer, m.OriginInfo)
 }
 
 // GetMetricType implements MetricSampleContext#GetMetricType.

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -34,7 +34,10 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.59.0-rc.6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0 // indirect


### PR DESCRIPTION
### What does this PR do?

Pass an entire component instead of a function.

Passing EnrichTags as a function pointer to GetTags seems to correspond to a call to runtime.newobject:
```
104     in github.com/DataDog/datadog-agent/pkg/aggregator/context_resolver.go
   0x0000000005be6451 <+81>:    mov    0x80(%rax),%rcx
   0x0000000005be6458 <+88>:    mov    %rcx,0x70(%rsp)
   0x0000000005be645d <+93>:    test   %al,(%rcx)
   0x0000000005be645f <+95>:    mov    0x88(%rax),%rcx
   0x0000000005be6466 <+102>:   mov    %rcx,0xa0(%rsp)
   0x0000000005be646e <+110>:   lea    -0x3817a15(%rip),%rax        # 0x23cea60
   0x0000000005be6475 <+117>:   call   0x3dd98a0 <runtime.newobject>
   0x0000000005be647a <+122>:   lea    0x1187f(%rip),%rcx        # 0x5bf7d00 <github.com/DataDog/datadog-agent/comp/core/tagger/def.Component.EnrichTags-fm>
```

### Motivation

Performance improvements

<img width="954" height="340" alt="Screenshot 2025-09-04 at 13 53 42" src="https://github.com/user-attachments/assets/82893a62-52b1-4f93-82cc-a142ec2ffd08" />


### Describe how you validated your changes

### Additional Notes
