### PR TITLE
[ACIX-887] Add a diagnose for Kubernetes environment

### DIFF
--- a/test/new-e2e/examples/eks_test.go
+++ b/test/new-e2e/examples/eks_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package examples
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	tifeks "github.com/DataDog/test-infra-definitions/scenarios/aws/eks"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
+
+	// "github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
+	compkube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type myEKSSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func TestMyEKSSuite(t *testing.T) {
+	e2e.Run(t, &myEKSSuite{}, e2e.WithProvisioner(
+		awskubernetes.EKSProvisioner(
+			awskubernetes.WithEKSOptions(
+				tifeks.WithLinuxNodeGroup(),
+				tifeks.WithWindowsNodeGroup(),
+				tifeks.WithBottlerocketNodeGroup(),
+				tifeks.WithLinuxARMNodeGroup(),
+			),
+			awskubernetes.WithWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider) (*compkube.Workload, error) {
+				return nginx.K8sAppDefinition(e, kubeProvider, "nginx", "", false, nil)
+			}),
+		)))
+}
+
+func (v *myEKSSuite) TestClusterAgentInstalled() {
+	res, _ := v.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(context.TODO(), v1.ListOptions{})
+	var clusterAgent corev1.Pod
+	containsClusterAgent := false
+	for _, pod := range res.Items {
+		if strings.Contains(pod.Name, "cluster-agent") {
+			containsClusterAgent = true
+			clusterAgent = pod
+			break
+		}
+	}
+	assert.True(v.T(), containsClusterAgent, "Cluster Agent not found")
+
+	stdout, stderr, err := v.Env().KubernetesCluster.KubernetesClient.
+		PodExec("datadog", clusterAgent.Name, "datadog-cluster-agent", []string{"ls"})
+	require.NoError(v.T(), err)
+	assert.Empty(v.T(), stderr)
+	assert.NotEmpty(v.T(), stdout)
+
+}

--- a/test/new-e2e/pkg/environments/kubernetes.go
+++ b/test/new-e2e/pkg/environments/kubernetes.go
@@ -6,7 +6,18 @@
 package environments
 
 import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 // Kubernetes is an environment that contains a Kubernetes cluster, the Agent and a FakeIntake.
@@ -15,4 +26,112 @@ type Kubernetes struct {
 	KubernetesCluster *components.KubernetesCluster
 	FakeIntake        *components.FakeIntake
 	Agent             *components.KubernetesAgent
+}
+
+var _ common.Diagnosable = (*Kubernetes)(nil)
+
+// Diagnose generates a diagnose for the Kubernetes environment, creating a flare for each agent and cluster-agent pod.
+func (e *Kubernetes) Diagnose(outputDir string) (string, error) {
+	fmt.Println("Kubernetes Diagnose will be written to", outputDir)
+	diagnoseOutput := []string{"==== Kubernetes Diagnose ===="}
+	if e.KubernetesCluster == nil {
+		return "", fmt.Errorf("KubernetesCluster component is not initialized")
+	}
+	if e.Agent == nil {
+		return "", fmt.Errorf("Agent component is not initialized")
+	}
+	if e.KubernetesCluster.KubernetesClient == nil {
+		return "", fmt.Errorf("KubernetesClient component is not initialized")
+	}
+	ctx := context.Background()
+
+	diagnoseOutput = append(diagnoseOutput, "==== Linux pods ====")
+	linuxPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.LinuxNodeAgent.LabelSelectors["app"]).String(),
+	})
+	if err != nil {
+		diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to list linux pods: %s\n", err.Error()))
+	} else {
+		if len(linuxPods.Items) == 0 {
+			diagnoseOutput = append(diagnoseOutput, "No linux pods found")
+			return strings.Join(diagnoseOutput, "\n"), nil
+		}
+
+		for _, pod := range linuxPods.Items {
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Pod %s:\n", pod.Name))
+			flarePath, err := e.generateAndDownloadAgentFlare("agent", pod, "agent", outputDir)
+			if err != nil {
+				diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to generate and download agent flare: %s\n", err.Error()))
+				continue
+			}
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Downloaded flare: %s", flarePath))
+		}
+	}
+
+	diagnoseOutput = append(diagnoseOutput, "==== Windows pods ====")
+	windowsPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.WindowsNodeAgent.LabelSelectors["app"]).String(),
+	})
+	if err != nil {
+		diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to list windows pods: %s\n", err.Error()))
+	} else {
+		if len(windowsPods.Items) == 0 {
+			diagnoseOutput = append(diagnoseOutput, "No windows pods found")
+		}
+
+		for _, pod := range windowsPods.Items {
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Pod %s:\n", pod.Name))
+			flarePath, err := e.generateAndDownloadAgentFlare("agent.exe", pod, "agent", outputDir)
+			if err != nil {
+				diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to generate and download agent flare: %s\n", err.Error()))
+				continue
+			}
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Downloaded flare: %s", flarePath))
+		}
+	}
+
+	diagnoseOutput = append(diagnoseOutput, "==== Cluster Agent pod ====")
+	cluserAgentPods, err := e.KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector("app", e.Agent.LinuxClusterAgent.LabelSelectors["app"]).String(),
+	})
+	if err != nil {
+		diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to list cluster agent pods: %s\n", err.Error()))
+	} else {
+		if len(cluserAgentPods.Items) == 0 {
+			diagnoseOutput = append(diagnoseOutput, "No cluster agent pods found")
+		}
+
+		for _, pod := range cluserAgentPods.Items {
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Pod %s:\n", pod.Name))
+			flarePath, err := e.generateAndDownloadAgentFlare("datadog-cluster-agent", pod, "cluster-agent", outputDir)
+			if err != nil {
+				diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Failed to generate and download cluster agent flare: %s\n", err.Error()))
+				continue
+			}
+			diagnoseOutput = append(diagnoseOutput, fmt.Sprintf("Downloaded flare: %s", flarePath))
+		}
+	}
+
+	return strings.Join(diagnoseOutput, "\n"), nil
+}
+
+func (e *Kubernetes) generateAndDownloadAgentFlare(agentBinary string, pod v1.Pod, container string, outputDir string) (string, error) {
+	stdout, stderr, err := e.KubernetesCluster.KubernetesClient.PodExec(pod.Namespace, pod.Name, container, []string{agentBinary, "flare", "--email", "e2e-tests@datadog-agent", "--send"})
+	flareOutput := strings.Join([]string{stdout, stderr}, "\n")
+	if err != nil {
+		flareOutput = fmt.Sprintf("%s\n%s", flareOutput, err.Error())
+	}
+	// find <path to flare>.zip in flare command output
+	// (?m) is a flag that allows ^ and $ to match the beginning and end of each line
+	re := regexp.MustCompile(`(?m)^(.+\.zip) is going to be uploaded to Datadog$`)
+	matches := re.FindStringSubmatch(flareOutput)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("Failed to find flare path in output: %s", flareOutput)
+	}
+	flarePath := matches[1]
+	err = e.KubernetesCluster.KubernetesClient.DownloadFromPod(pod.Namespace, pod.Name, container, flarePath, strings.Join([]string{outputDir, pod.Name}, "/"))
+	if err != nil {
+		return "", fmt.Errorf("failed to download flare archive: %w", err)
+	}
+	return flarePath, nil
 }

--- a/test/new-e2e/pkg/utils/e2e/client/k8s.go
+++ b/test/new-e2e/pkg/utils/e2e/client/k8s.go
@@ -6,7 +6,11 @@
 package client
 
 import (
+	"archive/tar"
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -72,8 +76,82 @@ func (k *KubernetesClient) PodExec(namespace, pod, container string, cmd []strin
 		Stderr: &stderrSb,
 	})
 	if err != nil {
-		return "", "", err
+		return stdoutSb.String(), suppressGoCoverWarning(stderrSb.String()), err
 	}
 
 	return stdoutSb.String(), suppressGoCoverWarning(stderrSb.String()), nil
+}
+
+// DownloadFromPod downloads a folder from a pod to a local destination
+func (k *KubernetesClient) DownloadFromPod(namespace, podName, container, srcPath, destPath string) error {
+	reader, outStream := io.Pipe()
+	options := &corev1.PodExecOptions{
+		Container: container,
+		Command:   []string{"tar", "cf", "-", srcPath},
+		Stdout:    true,
+		Stderr:    true,
+	}
+
+	req := k.K8sClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	req.VersionedParams(options, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(k.K8sConfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer outStream.Close()
+		err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+			Stdout: outStream,
+			Stderr: os.Stderr,
+			Tty:    false,
+		})
+	}()
+
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return err
+	}
+
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		splittedSrcPath := strings.Split(srcPath, "/")
+		target := filepath.Join(destPath, strings.TrimPrefix(header.Name, splittedSrcPath[len(splittedSrcPath)-1]))
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			dir := filepath.Dir(target)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return err
+			}
+
+			file, err := os.Create(target)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			if _, err := io.Copy(file, tarReader); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Generate a flare of all the pods running in the cluster when a test fails to help debugging the test and understand what happened.
We can see the flare generation is working and downloadable in `e2e-output`: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1113608457


### Motivation

Make it easier to troubleshoot failing tests

### Describe how you validated your changes

### Additional Notes
