### PR TITLE
Update ddflare key

### DIFF
--- a/comp/otelcol/ddflareextension/README.md
+++ b/comp/otelcol/ddflareextension/README.md
@@ -13,7 +13,7 @@ The datadogextension will be added automatically by the [converter component](..
 *Collector config:*
 ```
 extensions:
- datadog:
+ ddflare:
    port: 7777
 ```
 


### PR DESCRIPTION
### What does this PR do?
Update readme, the datadog extension was renamed from datadog to ddflare: https://github.com/DataDog/datadog-agent/blob/test/otel/v0.69.0-rc.4/comp/otelcol/ddflareextension/impl/internal/metadata/metadata.go#L14.

### Motivation

### Describe how you validated your changes

### Additional Notes
