### PR TITLE
Fix timeout option being ignored when using settings http helpers

### DIFF
--- a/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
+++ b/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fix potential deadlock when querying sub-processes configuration. When other processes are in a failed state the
-    Agent HTTPS timeout would not be taken into account causing to wait forever. This would block the creation of the status
+    Fix potential deadlock when querying sub-processes configuration. When other processes are in a failed state, the
+    Agent HTTPS timeout would not be taken into account, causing it to wait forever. This would block the creation of the status
     page and cause missing information in flares.

--- a/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
+++ b/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix potential deadlock when queryiung sub-processes configuration. When other processes are in a failed stated the
+    Agent HTTPS timeout would not be taken into account causing to wait forever. This would block the creation of the status
+    page and cause missing information in flares.

--- a/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
+++ b/releasenotes/notes/fix-deadlock-in-metadata-e4c72281d54ac090.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Fix potential deadlock when queryiung sub-processes configuration. When other processes are in a failed stated the
+    Fix potential deadlock when querying sub-processes configuration. When other processes are in a failed state the
     Agent HTTPS timeout would not be taken into account causing to wait forever. This would block the creation of the status
     page and cause missing information in flares.


### PR DESCRIPTION
### What does this PR do?

The timeout was ignored following #37247 which introduce the IPC module. This cause unresponsive HTTP call to deadlock the metadata module and prevent flare and status from being generated.

### Describe how you validated your changes

Run the agent with process-agent installed and make sure the status page can be created and flares contain `metadata/inventory/agent.json` file.

### Additional Notes
