### PR TITLE
Add support to take actions on Argo Rollouts objects in Autoscaling

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -454,10 +454,13 @@ func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscale
 
 	var resourceName string
 	switch owner := podAutoscalerInternal.Spec().TargetRef.Kind; owner {
-	case "Deployment":
+	case kubernetes.DeploymentKind:
 		resourceName = kubernetes.ParseDeploymentForPodName(clusterAgentPodName)
-	case "ReplicaSet":
+	case kubernetes.ReplicaSetKind:
 		resourceName = kubernetes.ParseReplicaSetForPodName(clusterAgentPodName)
+	default:
+		// We don't support other ways to deploy the Cluster Agent
+		return nil
 	}
 
 	clusterAgentNs := common.GetMyNamespace()

--- a/pkg/util/kubernetes/const.go
+++ b/pkg/util/kubernetes/const.go
@@ -96,6 +96,10 @@ const (
 	StorageClassKind = "StorageClass"
 	// VerticalPodAutoscalerKind represents the VerticalPodAutoscaler object kind
 	VerticalPodAutoscalerKind = "VerticalPodAutoscaler"
+	// RolloutAPIVersion represents the Argo Rollout API version
+	RolloutAPIVersion = "argoproj.io/v1alpha1"
+	// RolloutKind represents the Argo Rollout object kind
+	RolloutKind = "Rollout"
 
 	// CriContainerNamespaceLabel is the label set on containers by runtimes with Pod Namespace
 	CriContainerNamespaceLabel = "io.kubernetes.pod.namespace"


### PR DESCRIPTION
### What does this PR do?

Add support to take actions on `Rollout` objects in Autoscaling. There's not a lot of changes as mostly the Cluster Agent supports any object, _except_ for vertical, which what this PR addresses mostly.

### Motivation

Support Argo Rollouts

### Describe how you validated your changes

Currently you need custom code to "fake" feed the Autoscaling by updating the `postProcess` function in `pkg/clusteragent/autoscaling/workload/config_retriever_values.go` to inject fake data for Argo Rollout.
Once the backend has proper support it can be easily validated end-to-end by creating a `DPA` with a target to an Argo Rollout:
```
  kind: DatadogPodAutoscaler
  spec:
    owner: Local
    targetRef:
      apiVersion: argoproj.io/v1alpha1
      kind: Rollout
      name: rollout-canary
```

### Additional Notes

The `StrategicMergePatchType` is not supported for CRs, but for what we are doing (updating a `map`), there's no difference between `StrategicMergePatchType` and `MergePatchType (JSON Merge Patch)`