### PR TITLE
ci(timeout): Sets a timeout to docker_build_windows jobs

### DIFF
--- a/.gitlab/container_build/docker_windows.yml
+++ b/.gitlab/container_build/docker_windows.yml
@@ -48,6 +48,7 @@
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - docker rmi ${TARGET_TAG}
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
+  timeout: 27m
 
 .docker_build_agent7_windows_common:
   extends:


### PR DESCRIPTION
### What does this PR do?
Defines a timeout for the `docker_build_windows` jobs

### Motivation
Prevent long-duration pipelines when such a job [times out and is retried](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1113004262)

### Describe how you validated your changes

### Additional Notes
Set the threshold to 27 min because the [p99 duration is 25.9 for these jobs on the last 6 months](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3Adocker_build_%2Awindows%2A&agg_m=%40duration&agg_m_source=base&agg_t=avg&fromUser=false&index=cipipeline&tab=overview&viz=distribution&start=1741443406297&end=1756995406297&paused=false)
