### PR TITLE
Fix nil pointer dereference panic in image resolver

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go
@@ -10,6 +10,7 @@ package autoinstrumentation
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -256,9 +257,9 @@ type ResolvedImage struct {
 // NewImageResolver creates the appropriate ImageResolver based on whether
 // a remote config client is available.
 func NewImageResolver(rcClient RemoteConfigClient) ImageResolver {
-	if rcClient != nil {
-		return newRemoteConfigImageResolver(rcClient)
+	if rcClient == nil || reflect.ValueOf(rcClient).IsNil() {
+		log.Debugf("No remote config client available")
+		return newNoOpImageResolver()
 	}
-	log.Debugf("No remote config client available")
-	return newNoOpImageResolver()
+	return newRemoteConfigImageResolver(rcClient)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver_test.go
@@ -17,10 +17,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // mockRCClient is a lightweight mock that implements RemoteConfigClient
@@ -106,7 +107,14 @@ func TestNewImageResolver(t *testing.T) {
 		assert.True(t, ok, "Should return remoteConfigImageResolver when rcClient is not nil")
 	})
 
-	t.Run("without_remote_config_client", func(t *testing.T) {
+	t.Run("without_remote_config_client__typed_nil", func(t *testing.T) {
+		resolver := NewImageResolver((*mockRCClient)(nil))
+
+		_, ok := resolver.(*noOpImageResolver)
+		assert.True(t, ok, "Should return noOpImageResolver when rcClient is nil")
+	})
+
+	t.Run("without_remote_config_client__untyped_nil", func(t *testing.T) {
 		resolver := NewImageResolver(nil)
 
 		_, ok := resolver.(*noOpImageResolver)


### PR DESCRIPTION
### What does this PR do?

Fix nil pointer dereference causing panic in NewImageResolver.

This happens when we compare typed nil with untyped nil. The fix is to also check if the value of the type is nil.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x47bdc64]

goroutine 1 [running]:
github.com/DataDog/datadog-agent/pkg/config/remote/client.(*Client).SubscribeAll(0x0, {0x56d7385, 0x10}, {0x5c5f130, 0x4001125440})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/config/remote/client/client.go:323 +0x34
github.com/DataDog/datadog-agent/pkg/config/remote/client.(*Client).Subscribe(0x0, {0x56d7385, 0x10}, 0x4000d43560)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/config/remote/client/client.go:337 +0x64
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation.newRemoteConfigImageResolverWithRetryConfig({0x5c3f1c0, 0x0}, 0x5, 0x3b9aca00)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go:79 +0x1a0
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation.newRemoteConfigImageResolver({0x5c3f1c0, 0x0})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go:66 +0x3c
github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation.NewImageResolver({0x5c3f1c0, 0x0})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go:260 +0x3c
github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.start({0x5c994c0, _}, {_, _}, {_, _}, {_, _}, {_, _}, ...)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:513 +0x28cc
reflect.Value.call({0x53f3880, 0x592b550, 0x13}, {0x56b1d2c, 0x4}, {0x400071a200, 0x15, 0x15})
        /home/datadog/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.linux-arm64/src/reflect/value.go:584 +0xa00
reflect.Value.Call({0x53f3880, 0x592b550, 0x13}, {0x400071a200, 0x15, 0x15})
        /home/datadog/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.linux-arm64/src/reflect/value.go:368 +0x74
github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0x400024b3c0)
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/args.go:72 +0x94
github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot({0x53f3880, 0x592b550}, {0x4000b87b88, 0x28, 0x2b})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/oneshot.go:54 +0x430
github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.Commands.func1(0x40003e4908, {0x0, 0x0, 0x0})
        /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:141 +0x1e64
github.com/spf13/cobra.(*Command).execute(0x40003e4908, {0x8161b20, 0x0, 0x0})
        /home/datadog/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xbc0
github.com/spf13/cobra.(*Command).ExecuteC(0x40003e4608)
        /home/datadog/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x7dc
github.com/spf13/cobra.(*Command).Execute(0x40003e4608)
        /home/datadog/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071 +0x30
main.main()
        /home/datadog/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/main.go:30 +0x48
```

### Describe how you validated your changes

updated unit tests.

### Additional Notes
