### PR TITLE
Document using libraries for execinfo in rtloader

### DIFF
--- a/rtloader/README.md
+++ b/rtloader/README.md
@@ -43,7 +43,7 @@ Most of the code used to extend the embedded interpreter is there.
 RTLoader can optionally show stack traces when a segfault happens, using `execinfo`, which is provided out of the box by the glibc.
 When building with other libc, you can install the shared libraries `libexecinfo` or `libbacktrace` instead.
 CMake should automatically pick it up so that you don't need to configure anything.
-If it doesn't, you can explicitely tell it where to find those by setting `Backtrace_LIBRARY` and `Backtrace_INCLUDE_DIR` options, eg. `-DBacktrace_LIBRARY=/usr/lib/libexecinfo.so -DBacktrace_INCLUDE_DIR=/usr/include`.
+If it doesn't, you can explicitly tell it where to find those by setting `Backtrace_LIBRARY` and `Backtrace_INCLUDE_DIR` options, eg. `-DBacktrace_LIBRARY=/usr/lib/libexecinfo.so -DBacktrace_INCLUDE_DIR=/usr/include`.
 
 ## Build
 

--- a/rtloader/README.md
+++ b/rtloader/README.md
@@ -36,6 +36,15 @@ Most of the code used to extend the embedded interpreter is there.
 * Cmake version 3.15 or above
 * Go compiler with `cgo` capabilities to run the tests
 
+### Optional Requirements
+
+* libexecinfo
+
+RTLoader can optionally show stack traces when a segfault happens, using `execinfo`, which is provided out of the box by the glibc.
+When building with other libc, you can install the shared library `libexecinfo` and its headers.
+CMake should automatically pick it up so that you don't need to configure anything.
+If it doesn't, you can explicitely tell it where to find those by setting `Backtrace_LIBRARY` and `Backtrace_INCLUDE_DIR` options, eg. `-DBacktrace_LIBRARY=/usr/lib/libexecinfo.so -DBacktrace_INCLUDE_DIR=/usr/include`.
+
 ## Build
 
 RtLoader can be built using CMake. Run the configurator/generator first:

--- a/rtloader/README.md
+++ b/rtloader/README.md
@@ -38,10 +38,10 @@ Most of the code used to extend the embedded interpreter is there.
 
 ### Optional Requirements
 
-* libexecinfo
+* [libexecinfo](https://github.com/fam007e/libexecinfo) or [libbacktrace](https://github.com/ianlancetaylor/libbacktrace)
 
 RTLoader can optionally show stack traces when a segfault happens, using `execinfo`, which is provided out of the box by the glibc.
-When building with other libc, you can install the shared library `libexecinfo` and its headers.
+When building with other libc, you can install the shared libraries `libexecinfo` or `libbacktrace` instead.
 CMake should automatically pick it up so that you don't need to configure anything.
 If it doesn't, you can explicitely tell it where to find those by setting `Backtrace_LIBRARY` and `Backtrace_INCLUDE_DIR` options, eg. `-DBacktrace_LIBRARY=/usr/lib/libexecinfo.so -DBacktrace_INCLUDE_DIR=/usr/include`.
 


### PR DESCRIPTION
### What does this PR do?
Document using `libexecinfo` or `libbacktrace` in rtloader.

### Motivation
Have documentation for non-official builds which might require it.

### Describe how you validated your changes
N/A

### Additional Notes
Follow-up of https://github.com/DataDog/datadog-agent/pull/40418
