### PR TITLE
[ACIX-1047] Diagnose for Docker environment

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -661,12 +661,14 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 			// run environment diagnose if the test failed
 			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
 				// at least one test failed, diagnose the environment
+				bs.T().Logf("========= Some tests failed, diagnosing environment ==========")
 				diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
 				if diagnoseErr != nil {
 					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
 				} else {
 					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
 				}
+				bs.T().Logf("========= Environment diagnosed ==========")
 			}
 		}
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/docker.go
+++ b/test/new-e2e/pkg/utils/e2e/client/docker.go
@@ -6,9 +6,13 @@
 package client
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -147,4 +151,45 @@ func (docker *Docker) getContainerIDsByName() (map[string]string, error) {
 		}
 	}
 	return containersMap, nil
+}
+
+// DownloadFile downloads a file from the container to the local filesystem.
+func (docker *Docker) DownloadFile(containerName, containerPath, localPath string) error {
+	docker.t.Logf("Downloading file from container %s:%s to local path %s", containerName, containerPath, localPath)
+
+	ctx := context.Background()
+	reader, _, err := docker.client.CopyFromContainer(ctx, containerName, containerPath)
+	if err != nil {
+		return fmt.Errorf("failed to copy from container %s:%s: %w", containerName, containerPath, err)
+	}
+	defer reader.Close()
+
+	tarReader := tar.NewReader(reader)
+	header, err := tarReader.Next()
+	if err != nil {
+		return fmt.Errorf("failed to read tar header: %w", err)
+	}
+
+	if header.Typeflag == tar.TypeDir {
+		return fmt.Errorf("container path %s is a directory, not a file", containerPath)
+	}
+
+	localDir := filepath.Dir(localPath)
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		return fmt.Errorf("failed to create local directory %s: %w", localDir, err)
+	}
+
+	outFile, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to create local file %s: %w", localPath, err)
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, tarReader)
+	if err != nil {
+		return fmt.Errorf("failed to write file contents: %w", err)
+	}
+
+	docker.t.Logf("Successfully downloaded file to %s", localPath)
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Add a flare for the agent on failing docker environment tests. The goal is to help debugging these failing tests.
We can see that the flare is generated properly on failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1114041140

### Motivation

Ease debugging of tests

### Describe how you validated your changes

### Additional Notes
