### PR TITLE
Update `quality_gate_metrics_logs` dogstatsd load

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
@@ -43,7 +43,7 @@ generator:
       # `bytes_per_second` is understood to be a high-end use case,
       # however Agent's internal telemetry differs from lading's units: UDS
       # packets per second versus bytes per second.
-      bytes_per_second: "100 MiB"
+      bytes_per_second: "20 MiB"
       maximum_prebuild_cache_size_bytes: "500 MiB"
 
   # Log rotation file system for logs collection (following quality_gate_logs pattern)


### PR DESCRIPTION
### What does this PR do?

This applies a load of 6k dogstatsd messages per second in the `quality_gate_metrics_logs` experiment.

### Motivation

### Describe how you validated your changes

### Additional Notes
