### PR TITLE
feat(issues): Add an auto-closure of stale issues/pull-requests

### DIFF
--- a/.github/chainguard/self.stale.manage-stale.yaml
+++ b/.github/chainguard/self.stale.manage-stale.yaml
@@ -1,0 +1,15 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:environment:main
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/stale\.yml@refs/heads/main
+
+permissions:
+  actions: write
+  issues: write
+  pull_requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -52,13 +52,13 @@ jobs:
             Thanks!
 
           stale-issue-label: 'stale'
-
+          close-issue-label: 'auto-closed'
           # Pull request configuration
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had activity in the past 15 days.
 
 
-            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, adding a comment or pushing new commits will keep it open. Also, you can always reopen the pull request if you missed the window.
+            It will be closed in 30 days if no further activity occurs. If this pull request is still relevant, adding a comment or pushing new commits will keep it open. Also, you can always reopen the pull request if you missed the window.
 
 
             Thank you for your contributions!
@@ -73,10 +73,8 @@ jobs:
             Thanks!
 
           stale-pr-label: 'stale'
+          close-pr-label: 'auto-closed'
 
           # Exemptions
           exempt-issue-labels: 'kind/bug,kind/feature,kind/security,category/bugfix,category/feature,category/security,pending'
           exempt-pr-labels: 'do-not-merge/WIP,do-not-merge/hold'
-
-          # Additional configuration
-          operations-per-run: 50

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -69,7 +69,7 @@ jobs:
           stale-pr-label: 'stale'
 
           # Exemptions
-          exempt-issue-labels: 'kind/bug,kind/feature,kind/security,category/bugfix,category/feature,category/security'
+          exempt-issue-labels: 'kind/bug,kind/feature,kind/security,category/bugfix,category/feature,category/security,pending'
           exempt-pr-labels: 'do-not-merge/WIP,do-not-merge/hold'
 
           # Additional configuration

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,22 +29,23 @@ jobs:
           repo-token: ${{ steps.octo-sts.outputs.token }}
 
           # Stale configuration
-          days-before-stale: 60
-          days-before-close: 7
+          days-before-stale: 15
+          days-before-close: 15
 
           # Issue configuration
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had recent activity.
 
-            It will be closed in 7 days if no further activity occurs. If this issue is still relevant, please:
+
+            It will be closed in 15 days if no further activity occurs. If this issue is still relevant, please:
             - Add a comment to keep it open
-            - Add the `pinned` label to prevent it from being marked as stale
             - Contact the maintainers if you believe this was marked in error
 
             Thank you for your contributions!
 
           close-issue-message: |
-            This issue was closed because it has been stale for 7 days with no activity.
+            This issue was closed because it has been stale for 15 days with no activity.
+
 
             If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
 
@@ -54,24 +55,24 @@ jobs:
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had recent activity.
 
-            It will be closed in 7 days if no further activity occurs. If this pull request is still relevant, please:
+
+            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, please:
             - Add a comment or push new commits to keep it open
-            - Add the `pinned` label to prevent it from being marked as stale
             - Contact the maintainers if you believe this was marked in error
 
             Thank you for your contributions!
 
           close-pr-message: |
-            This pull request was closed because it has been stale for 7 days with no activity.
+            This pull request was closed because it has been stale for 15 days with no activity.
+
 
             If you believe this pull request is still relevant, please reopen it or create a new pull request with updated information.
 
           stale-pr-label: 'stale'
 
           # Exemptions
-          exempt-issue-labels: 'pinned,bug,feature-request,security,needs-investigation'
-          exempt-pr-labels: 'pinned,work-in-progress,blocked,needs-review'
-          exempt-draft-pr: true
+          exempt-issue-labels: 'kind/bug,kind/feature,kind/security,category/bugfix,category/feature,category/security'
+          exempt-pr-labels: 'do-not-merge/WIP,do-not-merge/hold'
 
           # Additional configuration
           operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,9 +37,8 @@ jobs:
             This issue has been automatically marked as stale because it has not had recent activity.
 
 
-            It will be closed in 15 days if no further activity occurs. If this issue is still relevant, please:
-            - Add a comment to keep it open
-            - Contact the maintainers if you believe this was marked in error
+            It will be closed in 15 days if no further activity occurs. If this issue is still relevant, please add a comment to keep it open.
+
 
             Thank you for your contributions!
 
@@ -56,9 +55,8 @@ jobs:
             This pull request has been automatically marked as stale because it has not had recent activity.
 
 
-            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, please:
-            - Add a comment or push new commits to keep it open
-            - Contact the maintainers if you believe this was marked in error
+            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, please add a comment or push new commits to keep it open.
+
 
             Thank you for your contributions!
 
@@ -75,4 +73,4 @@ jobs:
           exempt-pr-labels: 'do-not-merge/WIP,do-not-merge/hold'
 
           # Additional configuration
-          operations-per-run: 100
+          operations-per-run: 50

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,41 +30,47 @@ jobs:
 
           # Stale configuration
           days-before-stale: 15
-          days-before-close: 15
+          days-before-close: 30
 
           # Issue configuration
           stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had recent activity.
+            This issue has been automatically marked as stale because it has not had activity in the past 15 days.
 
 
-            It will be closed in 15 days if no further activity occurs. If this issue is still relevant, please add a comment to keep it open.
+            It will be closed in 30 days if no further activity occurs. If this issue is still relevant, adding a comment will keep it open. Also, you can always reopen the issue if you missed the window.
 
 
             Thank you for your contributions!
 
           close-issue-message: |
-            This issue was closed because it has been stale for 15 days with no activity.
+            This issue was automatically closed because it has been stale for 30 days with no activity.
 
 
-            If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
+            If this issue is still relevant, please reopen it or create a new issue with updated information.
+
+
+            Thanks!
 
           stale-issue-label: 'stale'
 
           # Pull request configuration
           stale-pr-message: |
-            This pull request has been automatically marked as stale because it has not had recent activity.
+            This pull request has been automatically marked as stale because it has not had activity in the past 15 days.
 
 
-            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, please add a comment or push new commits to keep it open.
+            It will be closed in 15 days if no further activity occurs. If this pull request is still relevant, adding a comment or pushing new commits will keep it open. Also, you can always reopen the pull request if you missed the window.
 
 
             Thank you for your contributions!
 
           close-pr-message: |
-            This pull request was closed because it has been stale for 15 days with no activity.
+            This pull request was automatically closed because it has been stale for 15 days with no activity.
 
 
-            If you believe this pull request is still relevant, please reopen it or create a new pull request with updated information.
+            If this pull request is still relevant, please reopen it or create a new pull request with updated information.
+
+
+            Thanks!
 
           stale-pr-label: 'stale'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,77 @@
+---
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    # Every day at noon CEST (10:00 UTC in summer, 11:00 UTC in winter)
+    # Using 10:00 UTC as CEST is UTC+2 (summer time)
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    environment:
+      name: main
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
+    steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-agent
+          policy: self.stale.manage-stale
+
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+        with:
+          repo-token: ${{ steps.octo-sts.outputs.token }}
+
+          # Stale configuration
+          days-before-stale: 60
+          days-before-close: 7
+
+          # Issue configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity.
+
+            It will be closed in 7 days if no further activity occurs. If this issue is still relevant, please:
+            - Add a comment to keep it open
+            - Add the `pinned` label to prevent it from being marked as stale
+            - Contact the maintainers if you believe this was marked in error
+
+            Thank you for your contributions!
+
+          close-issue-message: |
+            This issue was closed because it has been stale for 7 days with no activity.
+
+            If you believe this issue is still relevant, please reopen it or create a new issue with updated information.
+
+          stale-issue-label: 'stale'
+
+          # Pull request configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had recent activity.
+
+            It will be closed in 7 days if no further activity occurs. If this pull request is still relevant, please:
+            - Add a comment or push new commits to keep it open
+            - Add the `pinned` label to prevent it from being marked as stale
+            - Contact the maintainers if you believe this was marked in error
+
+            Thank you for your contributions!
+
+          close-pr-message: |
+            This pull request was closed because it has been stale for 7 days with no activity.
+
+            If you believe this pull request is still relevant, please reopen it or create a new pull request with updated information.
+
+          stale-pr-label: 'stale'
+
+          # Exemptions
+          exempt-issue-labels: 'pinned,bug,feature-request,security,needs-investigation'
+          exempt-pr-labels: 'pinned,work-in-progress,blocked,needs-review'
+          exempt-draft-pr: true
+
+          # Additional configuration
+          operations-per-run: 100


### PR DESCRIPTION
### What does this PR do?
Adds an auto-closure for stale issues/PR

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-1028

### Describe how you validated your changes
I'm not sure we need to test the stale action itself. The only risk is on the chainguard configuration. It would just make the workflow fail and would give the correct JWT for the setting.

### Additional Notes
Relates to 
> [!NOTE]
> The dates (30/15) were discussed and approved by the open-source team.
