### PR TITLE
[SLES-2438] Add a log file descriptor for AAS instance logging

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -27,7 +27,7 @@ import (
 const (
 	defaultFlushTimeout   = 5 * time.Second
 	defaultTailingPath    = "/home/LogFiles/*$COMPUTERNAME*.log"
-	modifiableTailingPath = "/home/LogFiles/*$COMPUTERNAME*.%s.log"
+	modifiableTailingPath = "/home/LogFiles/*$COMPUTERNAME*_%s.log"
 	logEnabledEnvVar      = "DD_LOGS_ENABLED"
 	envVarTailFilePath    = "DD_SERVERLESS_LOG_PATH"
 	aasInstanceTailing    = "DD_AAS_INSTANCE_LOGGING_ENABLED"

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -27,11 +27,11 @@ import (
 const (
 	defaultFlushTimeout   = 5 * time.Second
 	defaultTailingPath    = "/home/LogFiles/*$COMPUTERNAME*.log"
-	modifiableTailingPath = "/home/LogFiles/*$COMPUTERNAME*_%s.log"
+	modifiableTailingPath = "/home/LogFiles/*$COMPUTERNAME*%s.log"
 	logEnabledEnvVar      = "DD_LOGS_ENABLED"
 	envVarTailFilePath    = "DD_SERVERLESS_LOG_PATH"
 	aasInstanceTailing    = "DD_AAS_INSTANCE_LOGGING_ENABLED"
-	aasLoggingSuffix      = "DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX"
+	aasLoggingDescriptor  = "DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR"
 	sourceEnvVar          = "DD_SOURCE"
 	sourceName            = "Datadog Agent"
 )
@@ -109,7 +109,7 @@ func isInstanceTailingEnabled() bool {
 }
 
 func setAasInstanceTailingPath() string {
-	customPath, set := os.LookupEnv(aasLoggingSuffix)
+	customPath, set := os.LookupEnv(aasLoggingDescriptor)
 	if set && customPath != "" {
 		return os.ExpandEnv(fmt.Sprintf(modifiableTailingPath, customPath))
 	}

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -9,6 +9,7 @@
 package log
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -24,12 +25,15 @@ import (
 )
 
 const (
-	defaultFlushTimeout = 5 * time.Second
-	logEnabledEnvVar    = "DD_LOGS_ENABLED"
-	envVarTailFilePath  = "DD_SERVERLESS_LOG_PATH"
-	aasInstanceTailing  = "DD_AAS_INSTANCE_LOGGING_ENABLED"
-	sourceEnvVar        = "DD_SOURCE"
-	sourceName          = "Datadog Agent"
+	defaultFlushTimeout   = 5 * time.Second
+	defaultTailingPath    = "/home/LogFiles/*$COMPUTERNAME*.log"
+	modifiableTailingPath = "/home/LogFiles/*$COMPUTERNAME*.%s.log"
+	logEnabledEnvVar      = "DD_LOGS_ENABLED"
+	envVarTailFilePath    = "DD_SERVERLESS_LOG_PATH"
+	aasInstanceTailing    = "DD_AAS_INSTANCE_LOGGING_ENABLED"
+	aasLoggingSuffix      = "DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX"
+	sourceEnvVar          = "DD_SOURCE"
+	sourceName            = "Datadog Agent"
 )
 
 // Config holds the log configuration
@@ -76,7 +80,7 @@ func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags
 	if appServiceDefaultLoggingEnabled {
 		src := sources.NewLogSource("aas-instance-file-tail", &logConfig.LogsConfig{
 			Type:    logConfig.FileType,
-			Path:    os.ExpandEnv("/home/LogFiles/*$COMPUTERNAME*.log"),
+			Path:    setAasInstanceTailingPath(),
 			Service: os.Getenv("DD_SERVICE"),
 			Tags:    tags,
 			Source:  source,
@@ -102,4 +106,12 @@ func isEnabled(envValue string) bool {
 func isInstanceTailingEnabled() bool {
 	val := strings.ToLower(os.Getenv(aasInstanceTailing))
 	return val == "true" || val == "1"
+}
+
+func setAasInstanceTailingPath() string {
+	customPath, set := os.LookupEnv(aasLoggingSuffix)
+	if set && customPath != "" {
+		return os.ExpandEnv(fmt.Sprintf(modifiableTailingPath, customPath))
+	}
+	return os.ExpandEnv(defaultTailingPath)
 }

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -59,5 +59,5 @@ func TestSetAasInstanceTailingPath(t *testing.T) {
 
 	// Custom path
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX", "customsuffix")
-	assert.Equal(t, "/home/LogFiles/*testInstance*.customsuffix.log", setAasInstanceTailingPath())
+	assert.Equal(t, "/home/LogFiles/*testInstance*_customsuffix.log", setAasInstanceTailingPath())
 }

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -54,10 +54,10 @@ func TestSetAasInstanceTailingPath(t *testing.T) {
 	t.Setenv("COMPUTERNAME", "testInstance")
 	// Default path
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "true")
-	t.Setenv("DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX", "")
+	t.Setenv("DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR", "")
 	assert.Equal(t, "/home/LogFiles/*testInstance*.log", setAasInstanceTailingPath())
 
 	// Custom path
-	t.Setenv("DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX", "customsuffix")
-	assert.Equal(t, "/home/LogFiles/*testInstance*_customsuffix.log", setAasInstanceTailingPath())
+	t.Setenv("DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR", "_custominfix")
+	assert.Equal(t, "/home/LogFiles/*testInstance*_custominfix.log", setAasInstanceTailingPath())
 }

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -49,3 +49,15 @@ func TestIsInstanceTailingEnabled(t *testing.T) {
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "")
 	assert.False(t, isInstanceTailingEnabled())
 }
+
+func TestSetAasInstanceTailingPath(t *testing.T) {
+	t.Setenv("COMPUTERNAME", "testInstance")
+	// Default path
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "true")
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX", "")
+	assert.Equal(t, "/home/LogFiles/*testInstance*.log", setAasInstanceTailingPath())
+
+	// Custom path
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_PATH_SUFFIX", "customsuffix")
+	assert.Equal(t, "/home/LogFiles/*testInstance*.customsuffix.log", setAasInstanceTailingPath())
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds a new environment variable `DD_AAS_INSTANCE_LOG_FILE_DESCRIPTOR` to narrow down the amount of tailed files when using the AAS sidecar with instance logging enabled.

### Motivation

When instance logging is enabled we tail all the files in path. This led to many open files in high load environments, which caused undesirable behavior. By adding the descriptor option we can allow users to focus on the files they care about most and limit issues with Azure's log rotation. Additionally, this is ideal for users who only want to tail the default application log `filename_default_docker.log` used by Azure App Services for application logging.

### Describe how you validated your changes
Unit Test and in an application

### Additional Notes
