### PR TITLE
[CXP-2600] [agent] add process entity wlm logging

### DIFF
--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1628,13 +1628,25 @@ func (p Process) String(verbose bool) string {
 
 	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
 	_, _ = fmt.Fprintln(&sb, "PID:", p.EntityID.ID)
+	_, _ = fmt.Fprintln(&sb, "Name:", p.Name)
+	_, _ = fmt.Fprintln(&sb, "Exe:", p.Exe)
 	_, _ = fmt.Fprintln(&sb, "Namespace PID:", p.NsPid)
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
 	if p.Language != nil {
 		_, _ = fmt.Fprintln(&sb, "Language:", p.Language.Name)
 	}
+
+	if verbose {
+		_, _ = fmt.Fprintln(&sb, "Comm:", p.Comm)
+		_, _ = fmt.Fprintln(&sb, "Cwd:", p.Cwd)
+		_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
+		_, _ = fmt.Fprintln(&sb, "Uids:", p.Uids)
+		_, _ = fmt.Fprintln(&sb, "Gids:", p.Gids)
+	}
+
 	if p.Service != nil {
+		_, _ = fmt.Fprintln(&sb, "----------- Service Discovery -----------")
 		_, _ = fmt.Fprintln(&sb, "Service Generated Name:", p.Service.GeneratedName)
 		if verbose {
 			_, _ = fmt.Fprintln(&sb, "Service Generated Name Source:", p.Service.GeneratedNameSource)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1630,6 +1630,7 @@ func (p Process) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "PID:", p.EntityID.ID)
 	_, _ = fmt.Fprintln(&sb, "Name:", p.Name)
 	_, _ = fmt.Fprintln(&sb, "Exe:", p.Exe)
+	_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
 	_, _ = fmt.Fprintln(&sb, "Namespace PID:", p.NsPid)
 	_, _ = fmt.Fprintln(&sb, "Container ID:", p.ContainerID)
 	_, _ = fmt.Fprintln(&sb, "Creation time:", p.CreationTime)
@@ -1640,7 +1641,6 @@ func (p Process) String(verbose bool) string {
 	if verbose {
 		_, _ = fmt.Fprintln(&sb, "Comm:", p.Comm)
 		_, _ = fmt.Fprintln(&sb, "Cwd:", p.Cwd)
-		_, _ = fmt.Fprintln(&sb, "Cmdline:", sliceToString(p.Cmdline))
 		_, _ = fmt.Fprintln(&sb, "Uids:", p.Uids)
 		_, _ = fmt.Fprintln(&sb, "Gids:", p.Gids)
 	}

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -122,10 +122,11 @@ func TestProcessString(t *testing.T) {
 	tests := []struct {
 		name     string
 		process  Process
+		verbose  bool
 		expected string
 	}{
 		{
-			name: "basic process with minimal fields",
+			name: "basic process with minimal fields non-verbose",
 			process: Process{
 				EntityID: EntityID{
 					Kind: KindProcess,
@@ -140,19 +141,57 @@ func TestProcessString(t *testing.T) {
 				Comm:         "test-process",
 				Cmdline:      []string{"/usr/bin/test-process", "--flag"},
 				Uids:         []int32{1000, 1001},
-				Gids:         []int32{1000, 1001},
+				Gids:         []int32{1002, 1003},
 				ContainerID:  "container-123",
 				CreationTime: creationTime,
 			},
+			verbose: false,
 			expected: `----------- Entity ID -----------
 PID: 12345
+Name: test-process
+Exe: /usr/bin/test-process
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 `,
 		},
 		{
-			name: "process with language and service",
+			name: "basic process with minimal fields verbose",
+			process: Process{
+				EntityID: EntityID{
+					Kind: KindProcess,
+					ID:   "12345",
+				},
+				Pid:          12345,
+				NsPid:        12345,
+				Ppid:         1,
+				Name:         "test-process",
+				Cwd:          "/tmp",
+				Exe:          "/usr/bin/test-process",
+				Comm:         "test-process",
+				Cmdline:      []string{"/usr/bin/test-process", "--flag"},
+				Uids:         []int32{1000, 1001},
+				Gids:         []int32{1002, 1003},
+				ContainerID:  "container-123",
+				CreationTime: creationTime,
+			},
+			verbose: true,
+			expected: `----------- Entity ID -----------
+PID: 12345
+Name: test-process
+Exe: /usr/bin/test-process
+Namespace PID: 12345
+Container ID: container-123
+Creation time: 2023-01-01 12:00:00 +0000 UTC
+Comm: test-process
+Cwd: /tmp
+Cmdline: /usr/bin/test-process --flag
+Uids: [1000 1001]
+Gids: [1002 1003]
+`,
+		},
+		{
+			name: "process with language and service non-verbose",
 			process: Process{
 				EntityID: EntityID{
 					Kind: KindProcess,
@@ -166,8 +205,8 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 				Exe:          "/usr/bin/java",
 				Comm:         "java",
 				Cmdline:      []string{"/usr/bin/java", "-jar", "app.jar"},
-				Uids:         []int32{1000},
-				Gids:         []int32{1000},
+				Uids:         []int32{1000, 2, 3},
+				Gids:         []int32{1001, 4, 5},
 				ContainerID:  "container-999",
 				CreationTime: creationTime,
 				Language: &languagemodels.Language{
@@ -180,8 +219,8 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 					AdditionalGeneratedNames: []string{"java", "app"},
 					TracerMetadata:           []tracermetadata.TracerMetadata{},
 					DDService:                "java-app",
-					TCPPorts:                 []uint16{8080},
-					UDPPorts:                 []uint16{8081},
+					TCPPorts:                 []uint16{8080, 8081},
+					UDPPorts:                 []uint16{8082, 8083},
 					APMInstrumentation:       "enabled",
 					Type:                     "web_service",
 					LogFiles: []string{
@@ -190,19 +229,80 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 					},
 				},
 			},
+			verbose: false,
 			expected: `----------- Entity ID -----------
 PID: 12345
+Name: java-app
+Exe: /usr/bin/java
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Language: java
+----------- Service Discovery -----------
+Service Generated Name: java-app
+`,
+		},
+		{
+			name: "process with language and service verbose",
+			process: Process{
+				EntityID: EntityID{
+					Kind: KindProcess,
+					ID:   "12345",
+				},
+				Pid:          12345,
+				NsPid:        12345,
+				Ppid:         1,
+				Name:         "java-app",
+				Cwd:          "/app",
+				Exe:          "/usr/bin/java",
+				Comm:         "java",
+				Cmdline:      []string{"/usr/bin/java", "-jar", "app.jar"},
+				Uids:         []int32{1000, 2, 3},
+				Gids:         []int32{1001, 4, 5},
+				ContainerID:  "container-999",
+				CreationTime: creationTime,
+				Language: &languagemodels.Language{
+					Name:    languagemodels.Java,
+					Version: "11.0.0",
+				},
+				Service: &Service{
+					GeneratedName:            "java-app",
+					GeneratedNameSource:      "binary_name",
+					AdditionalGeneratedNames: []string{"java", "app"},
+					TracerMetadata:           []tracermetadata.TracerMetadata{},
+					DDService:                "java-app",
+					TCPPorts:                 []uint16{8080, 8081},
+					UDPPorts:                 []uint16{8082, 8083},
+					APMInstrumentation:       "enabled",
+					Type:                     "web_service",
+					LogFiles: []string{
+						"/var/log/app_access.log",
+						"/var/log/app_error.log",
+					},
+				},
+			},
+			verbose: true,
+			expected: `----------- Entity ID -----------
+PID: 12345
+Name: java-app
+Exe: /usr/bin/java
+Namespace PID: 12345
+Container ID: container-999
+Creation time: 2023-01-01 12:00:00 +0000 UTC
+Language: java
+Comm: java
+Cwd: /app
+Cmdline: /usr/bin/java -jar app.jar
+Uids: [1000 2 3]
+Gids: [1001 4 5]
+----------- Service Discovery -----------
 Service Generated Name: java-app
 Service Generated Name Source: binary_name
 Service Additional Generated Names: [java app]
 Service Tracer Metadata: []
 Service DD Service: java-app
-Service TCP Ports: [8080]
-Service UDP Ports: [8081]
+Service TCP Ports: [8080 8081]
+Service UDP Ports: [8082 8083]
 Service APM Instrumentation: enabled
 Service Type: web_service
 ----------- Log Files -----------
@@ -214,7 +314,7 @@ Service Type: web_service
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := test.process.String(true)
+			actual := test.process.String(test.verbose)
 			compareTestOutput(t, test.expected, actual)
 		})
 	}

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -150,6 +150,7 @@ func TestProcessString(t *testing.T) {
 PID: 12345
 Name: test-process
 Exe: /usr/bin/test-process
+Cmdline: /usr/bin/test-process --flag
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
@@ -180,12 +181,12 @@ Creation time: 2023-01-01 12:00:00 +0000 UTC
 PID: 12345
 Name: test-process
 Exe: /usr/bin/test-process
+Cmdline: /usr/bin/test-process --flag
 Namespace PID: 12345
 Container ID: container-123
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Comm: test-process
 Cwd: /tmp
-Cmdline: /usr/bin/test-process --flag
 Uids: [1000 1001]
 Gids: [1002 1003]
 `,
@@ -234,6 +235,7 @@ Gids: [1002 1003]
 PID: 12345
 Name: java-app
 Exe: /usr/bin/java
+Cmdline: /usr/bin/java -jar app.jar
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
@@ -286,13 +288,13 @@ Service Generated Name: java-app
 PID: 12345
 Name: java-app
 Exe: /usr/bin/java
+Cmdline: /usr/bin/java -jar app.jar
 Namespace PID: 12345
 Container ID: container-999
 Creation time: 2023-01-01 12:00:00 +0000 UTC
 Language: java
 Comm: java
 Cwd: /app
-Cmdline: /usr/bin/java -jar app.jar
 Uids: [1000 2 3]
 Gids: [1001 4 5]
 ----------- Service Discovery -----------

--- a/releasenotes/notes/workload-list-logs-2c91e1e88ee56e08.yaml
+++ b/releasenotes/notes/workload-list-logs-2c91e1e88ee56e08.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Adds complete workloadmeta process-entity information to workload-list command logs (datadog-agent workload-list)

--- a/test/new-e2e/tests/language-detection/language_detection_test.go
+++ b/test/new-e2e/tests/language-detection/language_detection_test.go
@@ -112,6 +112,9 @@ func (s *languageDetectionSuite) getLanguageForPid(pid string, source string) (s
 		if line == headerLine {
 			scanner.Scan() // entity line
 			scanner.Scan() // pid
+			scanner.Scan() // name
+			scanner.Scan() // exe
+			scanner.Scan() // cmdline
 			scanner.Scan() // nspid
 			scanner.Scan() // container id
 			scanner.Scan() // creation time


### PR DESCRIPTION
### What does this PR do?
- adds additional process information to be printed in the `datadog-agent workload-list` output command for debugging
- updates e2e test to reflect new `workload-list` output

#### Default logging
- name (derived from `/proc/[pid]/status`, will be the main thread of the process)
- exe (path to executable)  
- cmdline (cmdline can be long so this can potentially move to verbose later)

#### Verbose logging
- comm (similar to `name` but can be taken from any thread of the process)
- cwd (working dir)
- uids (user ids)
- gids (group ids)

### Motivation
- the new process collector utilizes workload meta and logging this extra information can be helpful for debugging

### Describe how you validated your changes
- unit tests

### Additional Notes
