### PR TITLE
dyninst/symdb: use disk-based uncompression of binaries

### DIFF
--- a/pkg/dyninst/decoder_error_handling_test.go
+++ b/pkg/dyninst/decoder_error_handling_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symbol"
@@ -81,6 +82,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 		uploader.NewLogsUploaderFactory(uploader.WithURL(logsURL)),
 		uploader.NewDiagnosticsUploader(uploader.WithURL(diagURL)),
 		symdbURL,
+		object.NewInMemoryLoader(),
 		scraper,
 		&failOnceDecoderFactory{
 			underlying: module.DefaultDecoderFactory{},

--- a/pkg/dyninst/irgen/config.go
+++ b/pkg/dyninst/irgen/config.go
@@ -9,15 +9,10 @@ package irgen
 
 import "github.com/DataDog/datadog-agent/pkg/dyninst/object"
 
-// ObjectLoader is an interface that abstracts the loading of object files.
-type ObjectLoader interface {
-	Load(path string) (object.FileWithDwarf, error)
-}
-
 type config struct {
 	maxDynamicTypeSize uint32
 	maxHashBucketsSize uint32
-	objectLoader       ObjectLoader
+	objectLoader       object.Loader
 }
 
 var defaultConfig = config{
@@ -57,7 +52,7 @@ func WithMaxDynamicDataSize(size int) Option {
 }
 
 // WithObjectLoader sets the object loader to use for loading object files.
-func WithObjectLoader(loader ObjectLoader) Option {
+func WithObjectLoader(loader object.Loader) Option {
 	return optionFunc(func(c *config) { c.objectLoader = loader })
 }
 

--- a/pkg/dyninst/module/controller.go
+++ b/pkg/dyninst/module/controller.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -59,6 +60,7 @@ func NewController[AT ActuatorTenant, LU LogsUploader](
 	logUploader LogsUploaderFactory[LU],
 	diagUploader DiagnosticsUploader,
 	symdbUploaderURL *url.URL,
+	objectLoader object.Loader,
 	rcScraper Scraper,
 	decoderFactory DecoderFactory,
 	irGenerator actuator.IRGenerator,
@@ -70,7 +72,7 @@ func NewController[AT ActuatorTenant, LU LogsUploader](
 		rcScraper:      rcScraper,
 		store:          store,
 		diagnostics:    newDiagnosticsManager(diagUploader),
-		symdb:          newSymdbManager(symdbUploaderURL),
+		symdb:          newSymdbManager(symdbUploaderURL, objectLoader),
 		decoderFactory: decoderFactory,
 	}
 	c.actuator = a.NewTenant(

--- a/pkg/dyninst/module/controller_test.go
+++ b/pkg/dyninst/module/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcjson"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/rcscrape"
@@ -203,7 +204,8 @@ func TestController_HappyPathEndToEnd(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -250,7 +252,8 @@ func TestController_ProgramLifecycleFlow(t *testing.T) {
 	scraper.updates = []rcscrape.ProcessUpdate{processUpdate}
 
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory,
 		irgen.NewGenerator(),
 	)
 	require.NotNil(t, controller)
@@ -300,7 +303,8 @@ func TestController_IRGenerationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 	require.NotNil(t, controller)
 	require.NotNil(t, a.tenant)
@@ -341,7 +345,8 @@ func TestController_AttachmentFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -385,7 +390,8 @@ func TestController_LoadingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -428,7 +434,8 @@ func TestController_DecoderCreationFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 	controller.CheckForUpdates()
 
@@ -457,7 +464,8 @@ func TestController_EventDecodingSuccess(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -511,7 +519,8 @@ func TestController_EventDecodingFailure(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -551,7 +560,8 @@ func TestController_ProcessRemoval(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 	at := a.tenant
 
@@ -607,7 +617,8 @@ func TestController_MultipleProcesses(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		actuator, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		actuator, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -656,7 +667,8 @@ func TestController_ProbeIssueReporting(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()
@@ -702,7 +714,8 @@ func TestController_NoSuccessfulProbesError(t *testing.T) {
 
 	irGenerator := irgen.NewGenerator()
 	controller := module.NewController(
-		a, logUploaderFactory, diagUploader, symdbURL, scraper, decoderFactory, irGenerator,
+		a, logUploaderFactory, diagUploader, symdbURL,
+		object.NewInMemoryLoader(), scraper, decoderFactory, irGenerator,
 	)
 
 	controller.CheckForUpdates()

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -80,7 +80,7 @@ func NewModule(
 	if err != nil {
 		return nil, fmt.Errorf("error creating loader: %w", err)
 	}
-	var objectLoader irgen.ObjectLoader
+	var objectLoader object.Loader
 	if config.DiskCacheEnabled {
 		objectLoader, err = object.NewDiskCache(config.DiskCacheConfig)
 		if err != nil {
@@ -94,7 +94,7 @@ func NewModule(
 	rcScraper := rcscrape.NewScraper(actuator)
 	irGenerator := irgen.NewGenerator(irgen.WithObjectLoader(objectLoader))
 	controller := NewController(
-		actuator, logUploader, diagsUploader, symdbUploaderURL, rcScraper, DefaultDecoderFactory{}, irGenerator,
+		actuator, logUploader, diagsUploader, symdbUploaderURL, objectLoader, rcScraper, DefaultDecoderFactory{}, irGenerator,
 	)
 	procMon := procmon.NewProcessMonitor(&processHandler{
 		scraperHandler: rcScraper.AsProcMonHandler(),

--- a/pkg/dyninst/module/symdb.go
+++ b/pkg/dyninst/module/symdb.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/uploader"
@@ -23,10 +24,11 @@ import (
 // symdbManager deals with uploading symbols to the SymDB backend.
 type symdbManager struct {
 	// If enabled is false, we never upload anything.
-	enabled   bool
-	uploadURL *url.URL
-	cfg       symdbManagerConfig
-	mu        struct {
+	enabled      bool
+	uploadURL    *url.URL
+	objectLoader object.Loader
+	cfg          symdbManagerConfig
+	mu           struct {
 		sync.Mutex
 		queuedUploads []uploadRequest
 		cond          *sync.Cond
@@ -65,7 +67,11 @@ type uploadRequest struct {
 // newSymdbManager creates a new symdbManager and starts the upload worker.
 //
 // If uploadURL is nil, the manager is disabled and no uploads are performed.
-func newSymdbManager(uploadURL *url.URL, opts ...option) *symdbManager {
+func newSymdbManager(
+	uploadURL *url.URL,
+	objectLoader object.Loader,
+	opts ...option,
+) *symdbManager {
 	cfg := symdbManagerConfig{
 		maxBufferFuncs: 10000,
 	}
@@ -77,6 +83,7 @@ func newSymdbManager(uploadURL *url.URL, opts ...option) *symdbManager {
 	m := &symdbManager{
 		enabled:      uploadURL != nil,
 		uploadURL:    uploadURL,
+		objectLoader: objectLoader,
 		cfg:          cfg,
 		workerCancel: cancel,
 	}
@@ -300,7 +307,9 @@ func (m *symdbManager) worker(ctx context.Context) {
 func (m *symdbManager) performUpload(ctx context.Context, procID processKey, runtimeID string, executablePath string) error {
 	log.Infof("SymDB: uploading symbols for process %v (service: %s, version: %s, executable: %s)",
 		procID.pid, procID.service, procID.version, executablePath)
-	it, err := symdb.PackagesIterator(executablePath,
+	it, err := symdb.PackagesIterator(
+		executablePath,
+		m.objectLoader,
 		symdb.ExtractOptions{
 			Scope:                   symdb.ExtractScopeModulesFromSameOrg,
 			IncludeInlinedFunctions: false,

--- a/pkg/dyninst/module/symdb_test.go
+++ b/pkg/dyninst/module/symdb_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/procmon"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
 )
@@ -57,7 +58,7 @@ func TestSymdbManagerUpload(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create process store and symdb manager
-	manager := newSymdbManager(symdbURL)
+	manager := newSymdbManager(symdbURL, object.NewInMemoryLoader())
 
 	// Create runtime ID for testing
 	runtimeID := procRuntimeID{
@@ -127,7 +128,9 @@ func testSymdbManagerCancellation(t *testing.T, useStop bool) {
 	symdbURL, err := url.Parse(symdbServer.URL)
 	require.NoError(t, err)
 
-	manager := newSymdbManager(symdbURL,
+	manager := newSymdbManager(
+		symdbURL,
+		object.NewInMemoryLoader(),
 		// Use a small buffer (which will force a flush after every package)
 		// in order to have an opportunity to cancel the uploads in between
 		// flushes.

--- a/pkg/dyninst/object/disk_cache.go
+++ b/pkg/dyninst/object/disk_cache.go
@@ -26,6 +26,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// Loader abstracts the loading of object files.
+type Loader interface {
+	Load(path string) (FileWithDwarf, error)
+}
+
 // DiskCacheConfig is the configuration for a DiskCache.
 type DiskCacheConfig struct {
 	// DirPath is the directory to store cached sections.

--- a/pkg/dyninst/object/elf_file_with_dwarf.go
+++ b/pkg/dyninst/object/elf_file_with_dwarf.go
@@ -115,12 +115,6 @@ func (e *ElfFileWithDwarf) Close() error {
 	return e.decompressingMMappingElfFile.Close()
 }
 
-// PointerSize returns the size of the pointer on the architecture of the object
-// file.
-func (e *ElfFileWithDwarf) PointerSize() uint8 {
-	return uint8(e.Architecture().PointerSize())
-}
-
 type dwarfData struct {
 	debugSections DebugSections
 	reader        loclist.Reader

--- a/pkg/dyninst/symdb/cli/main.go
+++ b/pkg/dyninst/symdb/cli/main.go
@@ -17,6 +17,7 @@ import (
 	"runtime/trace"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/symdbutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -97,12 +98,12 @@ func run(binaryPath string) error {
 	}
 	if !*stream {
 		var err error
-		symbols, err = symdb.ExtractSymbols(binaryPath, opt)
+		symbols, err = symdb.ExtractSymbols(binaryPath, object.NewInMemoryLoader(), opt)
 		if err != nil {
 			return err
 		}
 	} else {
-		it, err := symdb.PackagesIterator(binaryPath, opt)
+		it, err := symdb.PackagesIterator(binaryPath, object.NewInMemoryLoader(), opt)
 		if err != nil {
 			return err
 		}

--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -40,12 +40,12 @@ var loclistErrorLogLimiter = rate.NewLimiter(rate.Every(1*time.Minute), 1)
 // ExtractOptions.IncludeInlinedFunctions=false (i.e. if we're ignoring inlined
 // functions), since inlined functions can appear in different compile units
 // than their package.
-func PackagesIterator(binaryPath string, opt ExtractOptions) (iter.Seq2[Package, error], error) {
+func PackagesIterator(binaryPath string, loader object.Loader, opt ExtractOptions) (iter.Seq2[Package, error], error) {
 	if opt.IncludeInlinedFunctions {
 		return nil, fmt.Errorf("cannot overate over packages when IncludeInlinedFunctions is set")
 	}
 
-	bin, err := openBinary(binaryPath, opt)
+	bin, err := openBinary(binaryPath, loader, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +56,8 @@ func PackagesIterator(binaryPath string, opt ExtractOptions) (iter.Seq2[Package,
 
 // ExtractSymbols walks the DWARF data and accumulates the symbols to send to
 // SymDB.
-func ExtractSymbols(binaryPath string, opt ExtractOptions) (Symbols, error) {
-	bin, err := openBinary(binaryPath, opt)
+func ExtractSymbols(binaryPath string, loader object.Loader, opt ExtractOptions) (Symbols, error) {
+	bin, err := openBinary(binaryPath, loader, opt)
 	if err != nil {
 		return Symbols{}, err
 	}
@@ -680,7 +680,7 @@ func newPackagesIterator(bin binaryInfo, opt ExtractOptions) *packagesIterator {
 		dwarfData:           bin.obj.DwarfData(),
 		sym:                 bin.symTable,
 		loclistReader:       bin.obj.LoclistReader(),
-		pointerSize:         int(bin.obj.PointerSize()),
+		pointerSize:         int(bin.obj.Architecture().PointerSize()),
 		options:             opt,
 		mainModule:          bin.mainModule,
 		firstPartyPkgPrefix: bin.firstPartyPkgPrefix,
@@ -700,7 +700,7 @@ func newPackagesIterator(bin binaryInfo, opt ExtractOptions) *packagesIterator {
 }
 
 type binaryInfo struct {
-	obj                 *object.ElfFileWithDwarf
+	obj                 object.FileWithDwarf
 	mainModule          string
 	goDebugSections     *object.GoDebugSections
 	symTable            *gosym.GoSymbolTable
@@ -708,8 +708,8 @@ type binaryInfo struct {
 	filesFilter         []string
 }
 
-func openBinary(binaryPath string, opt ExtractOptions) (binaryInfo, error) {
-	obj, err := object.OpenElfFileWithDwarf(binaryPath)
+func openBinary(binaryPath string, loader object.Loader, opt ExtractOptions) (binaryInfo, error) {
+	obj, err := loader.Load(binaryPath)
 	if err != nil {
 		return binaryInfo{}, fmt.Errorf("failed to open file: %w", err)
 	}

--- a/pkg/dyninst/symdb/symdb_test.go
+++ b/pkg/dyninst/symdb/symdb_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/symdb/symdbutil"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
@@ -33,7 +34,9 @@ func TestSymDB(t *testing.T) {
 			binaryPath, err := testprogs.GetBinary("simple", cfg)
 			require.NoError(t, err)
 			t.Logf("exploring binary: %s", binaryPath)
-			symbols, err := symdb.ExtractSymbols(binaryPath,
+			symbols, err := symdb.ExtractSymbols(
+				binaryPath,
+				object.NewInMemoryLoader(),
 				symdb.ExtractOptions{
 					Scope:                   symdb.ExtractScopeAllSymbols,
 					IncludeInlinedFunctions: true,
@@ -81,10 +84,13 @@ func TestSymDBSnapshot(t *testing.T) {
 							defer sem.Acquire()()
 							binaryPath := testprogs.MustGetBinary(t, prog, cfg)
 							t.Logf("exploring binary: %s", binaryPath)
-							symbols, err := symdb.ExtractSymbols(binaryPath, symdb.ExtractOptions{
-								Scope:                   symdb.ExtractScopeMainModuleOnly,
-								IncludeInlinedFunctions: !streaming,
-							})
+							symbols, err := symdb.ExtractSymbols(
+								binaryPath,
+								object.NewInMemoryLoader(),
+								symdb.ExtractOptions{
+									Scope:                   symdb.ExtractScopeMainModuleOnly,
+									IncludeInlinedFunctions: !streaming,
+								})
 							require.NoError(t, err, "failed to extract symbols from %s", binaryPath)
 							require.NotEmpty(t, symbols.Packages)
 


### PR DESCRIPTION
Before this patch, we were uncompressing files in memory for the SymDB upload. Switch to uncompressing them in the disk cache, to save on memory use.
