### PR TITLE
smp: publish agent images to multiple regions

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -141,14 +141,18 @@ docker_build_agent7:
     TAG_SUFFIX: -7
     BUILD_ARG: --build-arg DD_AGENT_ARTIFACT=datadog-agent-7*-amd64.tar.xz
 
-# TODO: Move this job to .gitlab/deploy_containers/deploy_containers_a7.yml.
-# This cannot be done now because of the following reasons:
+# TODO: Move these single-machine-performance jobs to
+# .gitlab/deploy_containers/deploy_containers_a7.yml.
+#
+# This move cannot be done now because of the following reasons:
 #   #### From deploy_containers_a7.yml ####
-#   Notes: this defines a child pipline of the datadog-agent repository. Therefore:
+#   Notes: this defines a child pipline of the datadog-agent repository.
+#   Therefore:
 #   - Only blocks defined in this file or the included files below can be used.
 #   - In particular, blocks defined in the main .gitlab-ci.yml are unavailable.
-#   - Dependencies / needs on jobs not defined in this file or the included files cannot be made.
-single_machine_performance-full-amd64-a7:
+#   - Dependencies / needs on jobs not defined in this file or the included
+#     files cannot be made.
+.publish_to_single_machine_performance-full-amd64-a7:
   extends: .docker_publish_job_definition
   stage: container_build
   rules:
@@ -157,9 +161,23 @@ single_machine_performance-full-amd64-a7:
   needs:
     - docker_build_agent7_full
   variables:
-    IMG_REGISTRIES: internal-aws-smp
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64
     IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-full-amd64
+
+single_machine_performance-full-amd64-a7-us-east-1:
+  extends: .publish_to_single_machine_performance-full-amd64-a7
+  variables:
+    IMG_REGISTRIES: internal-aws-smp-us-east-1
+
+single_machine_performance-full-amd64-a7-us-east-2:
+  extends: .publish_to_single_machine_performance-full-amd64-a7
+  variables:
+    IMG_REGISTRIES: internal-aws-smp-us-east-2
+
+single_machine_performance-full-amd64-a7-us-west-2:
+  extends: .publish_to_single_machine_performance-full-amd64-a7
+  variables:
+    IMG_REGISTRIES: internal-aws-smp-us-west-2
 
 docker_build_agent7_arm64:
   extends: [.docker_build_arm64, .docker_build_agent7]

--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -152,7 +152,7 @@ docker_build_agent7:
 #   - In particular, blocks defined in the main .gitlab-ci.yml are unavailable.
 #   - Dependencies / needs on jobs not defined in this file or the included
 #     files cannot be made.
-.publish_to_single_machine_performance-full-amd64-a7:
+single_machine_performance-full-amd64-a7:
   extends: .docker_publish_job_definition
   stage: container_build
   rules:
@@ -161,23 +161,9 @@ docker_build_agent7:
   needs:
     - docker_build_agent7_full
   variables:
+    IMG_REGISTRIES: smp
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64
     IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-full-amd64
-
-single_machine_performance-full-amd64-a7-us-east-1:
-  extends: .publish_to_single_machine_performance-full-amd64-a7
-  variables:
-    IMG_REGISTRIES: internal-aws-smp-us-east-1
-
-single_machine_performance-full-amd64-a7-us-east-2:
-  extends: .publish_to_single_machine_performance-full-amd64-a7
-  variables:
-    IMG_REGISTRIES: internal-aws-smp-us-east-2
-
-single_machine_performance-full-amd64-a7-us-west-2:
-  extends: .publish_to_single_machine_performance-full-amd64-a7
-  variables:
-    IMG_REGISTRIES: internal-aws-smp-us-west-2
 
 docker_build_agent7_arm64:
   extends: [.docker_build_arm64, .docker_build_agent7]

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -78,7 +78,7 @@ single-machine-performance-regression_detector:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
-    - job: single_machine_performance-full-amd64-a7
+    - job: single_machine_performance-full-amd64-a7-us-west-2
       artifacts: false
     - job: single_machine_performance-regression_detector-merge_base_check
       artifacts: true

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -78,7 +78,7 @@ single-machine-performance-regression_detector:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   needs:
-    - job: single_machine_performance-full-amd64-a7-us-west-2
+    - job: single_machine_performance-full-amd64-a7
       artifacts: false
     - job: single_machine_performance-regression_detector-merge_base_check
       artifacts: true


### PR DESCRIPTION
### What does this PR do?

This pull request should not be merged into `main` until https://github.com/DataDog/public-images/pull/88 (or something similar) is merged, otherwise it will break SMP's CI jobs.

To support running Single Machine Performance (SMP) jobs (e.g., the Regression Detector, Performance Quality Gates) in multiple regions, this pull request modifies the existing `single_machine_performance-full-amd64-a7` job so that it pushes images to `us-east-1` and `us-east-2` in addition to `us-west-2` (which the current job already does). The purpose of manually pushing images to all three regions is to enable SMP to use compute from all three regions during periods of high demand (e.g., many PRs being submitted before a merge freeze). We do not use AWS' automatic image replication because it would introduce a delay in adding Agent container images to ECR in `us-east-1` and `us-east-2` of possibly up to 30 minutes.

This pull request does *not* do a merge-base check in any region other than `us-west-2`, nor does it submit SMP jobs to any region other than `us-west-2`. Extending those operations to multiple regions is deferred to another pull request in order to make this pull request easier to review.

### Motivation

Improve stability of Agent Performance Quality Gates via running jobs in multiple regions.

### Describe how you validated your changes

To be determined, because it depends on merging the changes in  https://github.com/DataDog/public-images/pull/88.

### Additional Notes

cc: @DataDog/agent-delivery as a heads up. 
